### PR TITLE
implemented interfaces to type service implementations

### DIFF
--- a/test/integration/rpcs.spec.ts
+++ b/test/integration/rpcs.spec.ts
@@ -1,11 +1,11 @@
 import * as grpc from "@grpc/grpc-js";
-import { Request, Response, Srv, SrvClient } from "../protos/rpcs";
+import { Request, Response, Srv, SrvClient, ISrvServer } from "../protos/rpcs";
 import * as util from "util";
 
 describe("RPCs", () => {
   let server: grpc.Server;
 
-  let serviceImplSpy: jasmine.SpyObj<unknown>;
+  let serviceImplSpy: jasmine.SpyObj<ISrvServer>;
 
   let client: SrvClient;
 


### PR DESCRIPTION
With this change interfaces are defined for the ServiceDefinition and the ServerImplementation. For example below are the interfaces generated for complex.proto. `IQueueService` is used to provide a type for the service definition. `IQueueServer` can be used by code that implements the Server so that can guarantee all methods are defined with their proper request and response messages.

```
export interface IQueueService extends grpc_1.ServiceDefinition<grpc_1.UntypedServiceImplementation> {
    pop: grpc_1.MethodDefinition<Pop, Event>;
    complete: grpc_1.MethodDefinition<Complete, Complete.Result>;
}
export interface IQueueServer extends grpc_1.UntypedServiceImplementation {
    pop: grpc_1.handleUnaryCall<Pop, Event>;
    complete: grpc_1.handleUnaryCall<Complete, Complete.Result>;
}
export var Queue: IQueueService = {
    pop: {
        path: "/event.Queue/pop",
        requestStream: false,
        responseStream: false,
        requestSerialize: (message: Pop) => Buffer.from(message.serialize()),
        requestDeserialize: (bytes: Buffer) => Pop.deserialize(new Uint8Array(bytes)),
        responseSerialize: (message: Event) => Buffer.from(message.serialize()),
        responseDeserialize: (bytes: Buffer) => Event.deserialize(new Uint8Array(bytes))
    },
    complete: {
        path: "/event.Queue/complete",
        requestStream: false,
        responseStream: false,
        requestSerialize: (message: Complete) => Buffer.from(message.serialize()),
        requestDeserialize: (bytes: Buffer) => Complete.deserialize(new Uint8Array(bytes)),
        responseSerialize: (message: Complete.Result) => Buffer.from(message.serialize()),
        responseDeserialize: (bytes: Buffer) => Complete.Result.deserialize(new Uint8Array(bytes))
    }
};
```