### PR TITLE
fix: input output service type imported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1402,10 +1402,17 @@ function createMessage(
  * @param {descriptor.MethodDescriptorProto} methodDescriptor 
  */
 function getRPCOutputType(rootDescriptor, methodDescriptor) {
-  return normalizeTypeName(
+  const name = normalizeTypeName(
     methodDescriptor.output_type,
     rootDescriptor.package
-  );
+  )
+
+  const path = symbolMap.get('.' + name);
+
+  if (!path || !dependencyMap.has(path)) {
+    return ts.factory.createIdentifier(name)
+  }
+  return ts.factory.createPropertyAccessExpression(dependencyMap.get(path), name);
 }
 
 /**
@@ -1413,10 +1420,17 @@ function getRPCOutputType(rootDescriptor, methodDescriptor) {
  * @param {descriptor.MethodDescriptorProto} methodDescriptor 
  */
 function getRPCInputType(rootDescriptor, methodDescriptor) {
-  return normalizeTypeName(
+  const name = normalizeTypeName(
     methodDescriptor.input_type,
     rootDescriptor.package
   );
+
+  const path = symbolMap.get('.' + name);
+
+  if (!path || !dependencyMap.has(path)) {
+    return ts.factory.createIdentifier(name)
+  }
+  return ts.factory.createPropertyAccessExpression(dependencyMap.get(path), name);
 }
 
 /**
@@ -1459,8 +1473,8 @@ function createServiceInterface(rootDescriptor, serviceDescriptor, grpcIdentifie
       ts.factory.createTypeReferenceNode(
         ts.factory.createQualifiedName(grpcIdentifier, ts.factory.createIdentifier("MethodDefinition")),
         [
-          ts.factory.createIdentifier(getRPCInputType(rootDescriptor, methodDescriptor)),
-          ts.factory.createIdentifier(getRPCOutputType(rootDescriptor, methodDescriptor))
+          getRPCInputType(rootDescriptor, methodDescriptor),
+          getRPCOutputType(rootDescriptor, methodDescriptor)
         ]
       )
     ))
@@ -1502,8 +1516,8 @@ function createServerInterface(rootDescriptor, serviceDescriptor, grpcIdentifier
         ts.factory.createTypeReferenceNode(
           ts.factory.createQualifiedName(grpcIdentifier, ts.factory.createIdentifier("handleUnaryCall")),
           [
-            ts.factory.createIdentifier(getRPCInputType(rootDescriptor, methodDescriptor)),
-            ts.factory.createIdentifier(getRPCOutputType(rootDescriptor, methodDescriptor))
+            getRPCInputType(rootDescriptor, methodDescriptor),
+            getRPCOutputType(rootDescriptor, methodDescriptor)
           ]
         )
       )
@@ -1579,9 +1593,7 @@ function createService(rootDescriptor, serviceDescriptor) {
                             "message",
                             undefined,
                             ts.factory.createTypeReferenceNode(
-                              ts.factory.createIdentifier(
-                                getRPCInputType(rootDescriptor, methodDescriptor)
-                              ),
+                              getRPCInputType(rootDescriptor, methodDescriptor),
                               undefined
                             )
                           ),
@@ -1629,9 +1641,7 @@ function createService(rootDescriptor, serviceDescriptor) {
                         ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
                         ts.factory.createCallExpression(
                           ts.factory.createPropertyAccessExpression(
-                            ts.factory.createIdentifier(
-                              getRPCInputType(rootDescriptor, methodDescriptor)
-                            ),
+                            getRPCInputType(rootDescriptor, methodDescriptor),
                             "deserialize"
                           ),
                           undefined,
@@ -1658,9 +1668,7 @@ function createService(rootDescriptor, serviceDescriptor) {
                             "message",
                             undefined,
                             ts.factory.createTypeReferenceNode(
-                              ts.factory.createIdentifier(
-                                getRPCOutputType(rootDescriptor, methodDescriptor)
-                              ),
+                              getRPCOutputType(rootDescriptor, methodDescriptor),
                               undefined
                             )
                           ),
@@ -1708,9 +1716,7 @@ function createService(rootDescriptor, serviceDescriptor) {
                         ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
                         ts.factory.createCallExpression(
                           ts.factory.createPropertyAccessExpression(
-                            ts.factory.createIdentifier(
-                              getRPCOutputType(rootDescriptor, methodDescriptor)
-                            ),
+                            getRPCOutputType(rootDescriptor, methodDescriptor),
                             "deserialize"
                           ),
                           undefined,

--- a/test/importdirective.proto
+++ b/test/importdirective.proto
@@ -4,6 +4,10 @@ package importdirective.a;
 
 import "test/imported.proto";
 
+service ImportedService {
+    rpc ImportedServiceTest(b.Imported) returns (b.Imported.SubMessage);
+}
+
 message Message {
     b.Imported importedField = 1;
     b.Imported.SubMessage submessageField = 2;


### PR DESCRIPTION
Hello,

For protobuf service, input and ouput type is incorrectly generated. It's missing import.
I modify an existing test `test/importdirective.proto` to reproduce this issue.
I hope my commit is ok. I'm not sure about:
```javascript
symbolMap.get('.' + name);
``` 
---
I'm not comfortable with bazel, I failed to add logs or to debug. I almost gave up my wish to find a fix because of that.
So i find this trick:

1. switch node with inspect in `bin/protoc-gen-ts`
```javascript
#!/usr/bin/node --inspect
require('../src/index')
```
2. add this launch conf in vscode 
```jsonc
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "type": "node",
            "runtimeExecutable": "/usr/bin/protoc",
            "request": "launch",
            "name": "Launch Program",
            "skipFiles": [
                "<node_internals>/**"
            ],
            "program": "--plugin=protoc-gen-ts=./bin/protoc-gen-ts",
            "autoAttachChildProcesses": true,
            "outputCapture": "std",
            "args": ["--ts_out=${workspaceFolder}/test", "./test/import*.proto"],
            "cwd": "${workspaceFolder}",
            "outFiles": [
                "${workspaceFolder}/**/*.js"
            ]
        }
    ]
}
```
Now i can debug and run without bazel.
Maybe it can be useful for others.

Thanks for your work

