### PR TITLE
fix: added batch script for windows

### DIFF
--- a/bin/protoc-gen-ts.cmd
+++ b/bin/protoc-gen-ts.cmd
@@ -1,0 +1,14 @@
+@echo off
+
+@REM check if package is installed locally.
+for /f %%i in ('npm root') do set install_path=%%i
+
+@REM if not installed locally, set install path to global one
+setlocal enabledelayedexpansion
+if not exist !install_path!\protoc-gen-ts\  (
+    for /f %%i in ('npm root -g') do set install_path=%%i
+)
+endlocal & set install_path=%install_path%
+
+@REM invoke the index.js 
+node %install_path%\protoc-gen-ts\src\index


### PR DESCRIPTION
Closes #51 

Added batch script for windows which can be passed as a input to `--plugin` argument when running `protoc`.