### PR TITLE
Update src/descriptor.js

### DIFF
--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -1394,9 +1394,14 @@ function createDeserialize(
                                 ),
                                 ts.factory.createCallExpression(
                                     ts.factory.createPropertyAccessExpression(
-                                        ts.factory.createPropertyAccessExpression(
-                                            pbIdentifier,
-                                            "Map"
+                                        ts.factory.createParenthesizedExpression(
+                                            ts.factory.createAsExpression(
+                                                ts.factory.createPropertyAccessExpression(
+                                                    pbIdentifier,
+                                                    "Map"
+                                                ),
+                                                ts.factory.createToken(ts.SyntaxKind.AnyKeyword)
+                                            ),
                                         ),
                                         "deserializeBinary"
                                     ),


### PR DESCRIPTION
Fixes [#76](https://github.com/thesayyn/protoc-gen-ts/issues/76) as long as `static Map.deserializeBinary(...)` is not part of `@types/google-protobuf`