### PR TITLE
Improved map-to-any casts based on fixed typings of google-protobuf

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@bazel/jasmine": "next",
     "@bazel/typescript": "next",
     "@grpc/grpc-js": "^1.3.4",
-    "@types/google-protobuf": "^3.15.2",
+    "@types/google-protobuf": "^3.15.4",
     "@types/jasmine": "^3.7.7",
     "@types/node": "^15.12.5",
     "google-protobuf": "^3.17.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@bazel/jasmine": "next",
     "@bazel/typescript": "next",
     "@grpc/grpc-js": "^1.3.4",
-    "@types/google-protobuf": "^3.15.4",
+    "@types/google-protobuf": "^3.15.5",
     "@types/jasmine": "^3.7.7",
     "@types/node": "^15.12.5",
     "google-protobuf": "^3.17.3",

--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -1403,14 +1403,12 @@ function createDeserialize(
 
                                     undefined,
                                     [
-                                        ts.factory.createParenthesizedExpression(
-                                            ts.factory.createAsExpression(
-                                                ts.factory.createPropertyAccessExpression(
-                                                    ts.factory.createIdentifier("message"),
-                                                    fieldDescriptor.name
-                                                ),
-                                                ts.factory.createToken(ts.SyntaxKind.AnyKeyword)
+                                        ts.factory.createAsExpression(
+                                            ts.factory.createPropertyAccessExpression(
+                                                ts.factory.createIdentifier("message"),
+                                                fieldDescriptor.name
                                             ),
+                                            ts.factory.createToken(ts.SyntaxKind.AnyKeyword)
                                         ),
                                         ts.factory.createIdentifier("reader"),
                                         keyCall,

--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -1394,9 +1394,14 @@ function createDeserialize(
                                 ),
                                 ts.factory.createCallExpression(
                                     ts.factory.createPropertyAccessExpression(
-                                        ts.factory.createPropertyAccessExpression(
-                                            pbIdentifier,
-                                            "Map"
+                                        ts.factory.createParenthesizedExpression(
+                                            ts.factory.createAsExpression(
+                                                ts.factory.createPropertyAccessExpression(
+                                                    pbIdentifier,
+                                                    "Map"
+                                                ),
+                                                ts.factory.createToken(ts.SyntaxKind.AnyKeyword)
+                                            ),
                                         ),
                                         "deserializeBinary"
                                     ),

--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -1394,30 +1394,29 @@ function createDeserialize(
                                 ),
                                 ts.factory.createCallExpression(
                                     ts.factory.createPropertyAccessExpression(
-                                        ts.factory.createParenthesizedExpression(
-                                            ts.factory.createAsExpression(
-                                                ts.factory.createPropertyAccessExpression(
-                                                    pbIdentifier,
-                                                    "Map"
-                                                ),
-                                                ts.factory.createToken(ts.SyntaxKind.AnyKeyword)
-                                            ),
+                                        ts.factory.createPropertyAccessExpression(
+                                            pbIdentifier,
+                                            "Map"
                                         ),
                                         "deserializeBinary"
                                     ),
 
                                     undefined,
                                     [
-                                        ts.factory.createPropertyAccessExpression(
-                                            ts.factory.createIdentifier("message"),
-                                            fieldDescriptor.name
+                                        ts.factory.createParenthesizedExpression(
+                                            ts.factory.createAsExpression(
+                                                ts.factory.createPropertyAccessExpression(
+                                                    ts.factory.createIdentifier("message"),
+                                                    fieldDescriptor.name
+                                                ),
+                                                ts.factory.createToken(ts.SyntaxKind.AnyKeyword)
+                                            ),
                                         ),
                                         ts.factory.createIdentifier("reader"),
                                         keyCall,
                                         valueCall
                                     ]
                                 )
-
                             ),
                         ]
                     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,10 +95,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@types/google-protobuf@^3.15.4":
-  version "3.15.4"
+"@types/google-protobuf@^3.15.5":
+  version "3.15.5"
   resolved "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.4.tgz"
-  integrity sha512-RtevCF/hulWHsczV9R31vKUMHjSLpI74tuPbcpsYyqJWqSvmj8qLSZ1bikKQOtzprNMUw3SiExGTGaqpi4nzaA==
+  integrity sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw==
 
 "@types/is-windows@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,10 +95,10 @@
   resolved "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@types/google-protobuf@^3.15.2":
-  version "3.15.2"
-  resolved "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.2.tgz"
-  integrity sha512-ubeqvw7sl6CdgeiIilsXB2jIFoD/D0F+/LIEp7xEBEXRNtDJcf05FRINybsJtL7GlkWOUVn6gJs2W9OF+xI6lg==
+"@types/google-protobuf@^3.15.4":
+  version "3.15.4"
+  resolved "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.4.tgz"
+  integrity sha512-RtevCF/hulWHsczV9R31vKUMHjSLpI74tuPbcpsYyqJWqSvmj8qLSZ1bikKQOtzprNMUw3SiExGTGaqpi4nzaA==
 
 "@types/is-windows@^1.0.0":
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,7 +97,7 @@
 
 "@types/google-protobuf@^3.15.5":
   version "3.15.5"
-  resolved "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.4.tgz"
+  resolved "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.5.tgz"
   integrity sha512-6bgv24B+A2bo9AfzReeg5StdiijKzwwnRflA8RLd1V4Yv995LeTmo0z69/MPbBDFSiZWdZHQygLo/ccXhMEDgw==
 
 "@types/is-windows@^1.0.0":


### PR DESCRIPTION
I'm not sure if it's worth but this PR changes the map-to-any casts in the generated code from

```typescript
(pb_1.Map as any).deserializeBinary(message.map_field, reader, ...)
```
to

```typescript
pb_1.Map.deserializeBinary(message.map_field as any, reader, ...)
```

because `static Map.deserializeBinary(...)` is finally available in `@types/google-protobuf`. Nevertheless, another cast for the first argument is still required because a `protobuf Map` is expected but an `ES6 Map` is passed. 