### PR TITLE
change snake_case to camelCase fields name

### DIFF
--- a/src/descriptor.js
+++ b/src/descriptor.js
@@ -1933,6 +1933,15 @@ function createMessage(
     pbIdentifier
 ) {
     const members = [];
+    messageDescriptor.field = messageDescriptor.field.map(f => {
+        f.name = f.name.split('_')
+            .map((word, index) => {
+            if (index === 0) return word
+            return word.slice(0, 1).toUpperCase() + word.slice(1).toLowerCase()
+            })
+            .join('');
+        return f;
+    });
 
     // Create constructor
     members.push(


### PR DESCRIPTION
As discuss in the #78 issue, protocol buffer use snake_case for their field name, however the use of camelCase is more appropriate in JS/TS and more generally in generated code.