### PR TITLE
Change from class methods to arrow functions

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+proseWrap: always
+singleQuote: false
+trailingComma: all

--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 ![npm](https://img.shields.io/npm/v/protoc-gen-ts)
 ![npm](https://img.shields.io/npm/dm/protoc-gen-ts)
 
-Generates appropriate Protocol Buffer sources from Proto files directly through _TypeScript Compiler API_.
+Aim of this protoc plugin is to make usage of protocol buffers easy in Javascript/Typescript by taking modern approaches.  This plugin generates plain **Typescript** files that can be used AMD, UMD, CommonJS module systems.
 
-This plugin generates plain **Typescript** files that can be used AMD, UMD, CommonJS module systems.
-
-Aim of this protoc plugin is to make usage of protocol buffers easy in Javascript/Typescript by taking modern approaches.
 
 ## Example
 
@@ -72,7 +69,7 @@ To overcome this problem, every generated message class has a static method call
 which can handle the mapping bidirectionally for you, even with the deeply structured messages. since it is 
 aware of the field graph, it does not rely on any runtime type information thus we get the chance to keep it fast.
 
-given the change example above, one can write code as;
+One can write code as;
 
 ```typescript
 const change = Change.fromObject({
@@ -85,13 +82,15 @@ const change = Change.fromObject({
         role: "maintainer"
     }
 });
+
 console.log(change.author instanceof Author) // true
 ```
 
 
 ## Usage with `@grpc/grpc-js` or `grpc`
 
-There is a seperate documentation for the usage of protoc-gen-ts along with either `@grpc/grpc-js` or `grpc`.
+There is a seperate documentation for the usage of protoc-gen-ts along with either `@grpc/grpc-js` or `grpc`.  By default
+this generated gRPC interfaces will use `@grpc/grpc-js`.
 
 Checkout [rpcs](docs/rpc.md).
 
@@ -140,20 +139,12 @@ ts_proto_library(
 # Checkout the examples/bazel directory for an example.
 ```
 
-## Environment variables
+## Supported Options
 
-```sh
-# This controls experimental features such as 'Promise' based rpcs.
-export EXPERIMENTAL_FEATURES=true;
+* With `--ts_opt=unary_rpc_promise=true`, the service definition will contain a promise based rpc with a calling pattern of `const result = await client.METHOD(message)`.  Note: all othe `metadata` and `options` parameters are still available to you.
 
+* With `--ts_opt=grpc_package=xxxx`, you can specify a different package to import rather than `@grpc/grpc-js`.
 
-# This controls the "import statement" for the outputs.
-# this is here for legacy purposes.
-export GRPC_PACKAGE_NAME="@grpc/grpc-js";
-# or 
-export GRPC_PACKAGE_NAME="@grpc/grpc";
-
-```
 ## Roadmap
 
 - <s>Support for repeated non-integer fields</s>
@@ -178,6 +169,8 @@ export GRPC_PACKAGE_NAME="@grpc/grpc";
 
 ## Development
 
+Generates appropriate Protocol Buffer sources from Proto files directly through _TypeScript Compiler API_.
+
 ```sh
 # to run test invoke
 yarn test
@@ -185,3 +178,7 @@ yarn test
 yarn test --test_output=errors
 
 ```
+
+## Contributors
+
+![GitHub Contributors Image](https://contrib.rocks/image?repo=thesayyn/protoc-gen-ts)

--- a/index.bzl
+++ b/index.bzl
@@ -52,14 +52,14 @@ def _ts_proto_library(ctx):
 
     protoc_args.add("--descriptor_set_in=%s" % (":".join([desc.path for desc in transitive_descriptors])))
 
-    protoc_args.add_all(direct_sources)
-
     env = dict()
 
-    env["GRPC_PACKAGE_NAME"] = ctx.attr.grpc_package_name
+    protoc_args.add("--ts_opt=grpc_package=%s" % ctx.attr.grpc_package_name)
     
     if ctx.attr.experimental_features:
-        env['EXPERIMENTAL_FEATURES'] = "true"
+        protoc_args.add("--ts_opt=unary_rpc_promise")
+
+    protoc_args.add_all(direct_sources)
 
     ctx.actions.run(
         inputs = direct_sources + transitive_descriptors,

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ for (const fileDescriptor of request.proto_file) {
       )
     );
     statements.push(
-      rpc.createGrpcInterfaceType(fileDescriptor, grpcIdentifier)
+      ...rpc.createGrpcInterfaceType(fileDescriptor, grpcIdentifier)
     );
     // Create all services and clients
     for (const serviceDescriptor of fileDescriptor.service) {

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ function parseParameters(parameters) {
   const inputParams = {};
 
   // comma separated
-  (parameters ?? "").split(',').forEach(param => {
+  (parameters || "").split(',').forEach(param => {
     const [key, value = "true"] = param.split('=', 2)
 
     if (key in parsers) {

--- a/src/index.js
+++ b/src/index.js
@@ -65,17 +65,35 @@ for (const fileDescriptor of request.proto_file) {
     importStatements.push(createImport(pbIdentifier, "google-protobuf"));
   }
 
-  // Create all services and clients
-  for (const serviceDescriptor of fileDescriptor.service) {
-    statements.push(rpc.createUnimplementedServer(fileDescriptor, serviceDescriptor, grpcIdentifier));
-    statements.push(rpc.createServiceClient(fileDescriptor, serviceDescriptor, grpcIdentifier));
-  }
-
-  // Import grpc only if there is service statements
   if (fileDescriptor.service.length) {
-    importStatements.push(createImport(grpcIdentifier, process.env.GRPC_PACKAGE_NAME || "@grpc/grpc-js"));
+    // Import grpc only if there is service statements
+    importStatements.push(
+      createImport(
+        grpcIdentifier,
+        process.env.GRPC_PACKAGE_NAME || "@grpc/grpc-js"
+      )
+    );
+    statements.push(
+      rpc.createGrpcInterfaceType(fileDescriptor, grpcIdentifier)
+    );
+    // Create all services and clients
+    for (const serviceDescriptor of fileDescriptor.service) {
+      statements.push(
+        rpc.createUnimplementedServer(
+          fileDescriptor,
+          serviceDescriptor,
+          grpcIdentifier
+        )
+      );
+      statements.push(
+        rpc.createServiceClient(
+          fileDescriptor,
+          serviceDescriptor,
+          grpcIdentifier
+        )
+      );
+    }
   }
-
 
   const {major, minor, patch} = request.compiler_version || {major: 0, minor: 0, patch: 0};
 

--- a/src/rpc.js
+++ b/src/rpc.js
@@ -1,310 +1,286 @@
-
-const type = require('./type');
-const descriptor = require('./compiler/descriptor');
-const ts = require('typescript');
+const type = require("./type");
+const descriptor = require("./compiler/descriptor");
+const ts = require("typescript");
 
 /**
  * Returns grpc-node compatible service description
- * @param {descriptor.FieldDescriptorProto} rootDescriptor 
- * @param {descriptor.ServiceDescriptorProto} serviceDescriptor 
+ * @param {descriptor.FieldDescriptorProto} rootDescriptor
+ * @param {descriptor.ServiceDescriptorProto} serviceDescriptor
  */
 function createServiceDefinition(rootDescriptor, serviceDescriptor) {
-    return ts.factory.createObjectLiteralExpression(
-        serviceDescriptor.method.map((methodDescriptor) => {
-            return ts.factory.createPropertyAssignment(
-                methodDescriptor.name,
-                ts.factory.createObjectLiteralExpression(
-                    [
-                        ts.factory.createPropertyAssignment(
-                            "path",
-                            ts.factory.createStringLiteral(
-                                getRPCPath(
-                                    rootDescriptor,
-                                    serviceDescriptor,
-                                    methodDescriptor
-                                )
-                            )
-                        ),
-                        ts.factory.createPropertyAssignment(
-                            "requestStream",
-                            methodDescriptor.client_streaming
-                                ? ts.factory.createTrue()
-                                : ts.factory.createFalse()
-                        ),
-                        ts.factory.createPropertyAssignment(
-                            "responseStream",
-                            methodDescriptor.server_streaming
-                                ? ts.factory.createTrue()
-                                : ts.factory.createFalse()
-                        ),
-                        ts.factory.createPropertyAssignment(
-                            "requestSerialize",
-                            ts.factory.createArrowFunction(
-                                undefined,
-                                undefined,
-                                [
-                                    ts.factory.createParameterDeclaration(
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        "message",
-                                        undefined,
-                                        ts.factory.createTypeReferenceNode(
-                                            getRPCInputType(rootDescriptor, methodDescriptor),
-                                            undefined
-                                        )
-                                    ),
-                                ],
-                                undefined,
-                                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                ts.factory.createCallExpression(
-                                    ts.factory.createPropertyAccessExpression(
-                                        ts.factory.createIdentifier("Buffer"),
-                                        "from"
-                                    ),
-                                    undefined,
-                                    [
-                                        ts.factory.createCallExpression(
-                                            ts.factory.createPropertyAccessExpression(
-                                                ts.factory.createIdentifier("message"),
-                                                "serialize"
-                                            ),
-                                            undefined,
-                                            undefined
-                                        ),
-                                    ]
-                                )
-                            )
-                        ),
-                        ts.factory.createPropertyAssignment(
-                            "requestDeserialize",
-                            ts.factory.createArrowFunction(
-                                undefined,
-                                undefined,
-                                [
-                                    ts.factory.createParameterDeclaration(
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        "bytes",
-                                        undefined,
-                                        ts.factory.createTypeReferenceNode(
-                                            ts.factory.createIdentifier("Buffer"),
-                                            undefined
-                                        )
-                                    ),
-                                ],
-                                undefined,
-                                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                ts.factory.createCallExpression(
-                                    ts.factory.createPropertyAccessExpression(
-                                        getRPCInputType(rootDescriptor, methodDescriptor),
-                                        "deserialize"
-                                    ),
-                                    undefined,
-                                    [
-                                        ts.factory.createNewExpression(
-                                            ts.factory.createIdentifier("Uint8Array"),
-                                            undefined,
-                                            [ts.factory.createIdentifier("bytes")]
-                                        ),
-                                    ]
-                                )
-                            )
-                        ),
-                        ts.factory.createPropertyAssignment(
-                            "responseSerialize",
-                            ts.factory.createArrowFunction(
-                                undefined,
-                                undefined,
-                                [
-                                    ts.factory.createParameterDeclaration(
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        "message",
-                                        undefined,
-                                        ts.factory.createTypeReferenceNode(
-                                            getRPCOutputType(rootDescriptor, methodDescriptor),
-                                            undefined
-                                        )
-                                    ),
-                                ],
-                                undefined,
-                                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                ts.factory.createCallExpression(
-                                    ts.factory.createPropertyAccessExpression(
-                                        ts.factory.createIdentifier("Buffer"),
-                                        "from"
-                                    ),
-                                    undefined,
-                                    [
-                                        ts.factory.createCallExpression(
-                                            ts.factory.createPropertyAccessExpression(
-                                                ts.factory.createIdentifier("message"),
-                                                "serialize"
-                                            ),
-                                            undefined,
-                                            []
-                                        ),
-                                    ]
-                                )
-                            )
-                        ),
-                        ts.factory.createPropertyAssignment(
-                            "responseDeserialize",
-                            ts.factory.createArrowFunction(
-                                undefined,
-                                undefined,
-                                [
-                                    ts.factory.createParameterDeclaration(
-                                        undefined,
-                                        undefined,
-                                        undefined,
-                                        "bytes",
-                                        undefined,
-                                        ts.factory.createTypeReferenceNode(
-                                            ts.factory.createIdentifier("Buffer"),
-                                            undefined
-                                        )
-                                    ),
-                                ],
-                                undefined,
-                                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                                ts.factory.createCallExpression(
-                                    ts.factory.createPropertyAccessExpression(
-                                        getRPCOutputType(rootDescriptor, methodDescriptor),
-                                        "deserialize"
-                                    ),
-                                    undefined,
-                                    [
-                                        ts.factory.createNewExpression(
-                                            ts.factory.createIdentifier("Uint8Array"),
-                                            undefined,
-                                            [ts.factory.createIdentifier("bytes")]
-                                        ),
-                                    ]
-                                )
-                            )
-                        ),
-                    ],
-                    true
-                )
-            );
-        }),
-        true
-    )
+  return ts.factory.createObjectLiteralExpression(
+    serviceDescriptor.method.map((methodDescriptor) => {
+      return ts.factory.createPropertyAssignment(
+        methodDescriptor.name,
+        ts.factory.createObjectLiteralExpression(
+          [
+            ts.factory.createPropertyAssignment(
+              "path",
+              ts.factory.createStringLiteral(
+                getRPCPath(rootDescriptor, serviceDescriptor, methodDescriptor),
+              ),
+            ),
+            ts.factory.createPropertyAssignment(
+              "requestStream",
+              methodDescriptor.client_streaming
+                ? ts.factory.createTrue()
+                : ts.factory.createFalse(),
+            ),
+            ts.factory.createPropertyAssignment(
+              "responseStream",
+              methodDescriptor.server_streaming
+                ? ts.factory.createTrue()
+                : ts.factory.createFalse(),
+            ),
+            ts.factory.createPropertyAssignment(
+              "requestSerialize",
+              ts.factory.createArrowFunction(
+                undefined,
+                undefined,
+                [
+                  createParameter(
+                    "message",
+                    ts.factory.createTypeReferenceNode(
+                      getRPCInputType(rootDescriptor, methodDescriptor),
+                      undefined,
+                    ),
+                  ),
+                ],
+                undefined,
+                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                ts.factory.createCallExpression(
+                  ts.factory.createPropertyAccessExpression(
+                    ts.factory.createIdentifier("Buffer"),
+                    "from",
+                  ),
+                  undefined,
+                  [
+                    ts.factory.createCallExpression(
+                      ts.factory.createPropertyAccessExpression(
+                        ts.factory.createIdentifier("message"),
+                        "serialize",
+                      ),
+                      undefined,
+                      undefined,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            ts.factory.createPropertyAssignment(
+              "requestDeserialize",
+              ts.factory.createArrowFunction(
+                undefined,
+                undefined,
+                [
+                  createParameter(
+                    "bytes",
+                    ts.factory.createTypeReferenceNode(
+                      ts.factory.createIdentifier("Buffer"),
+                      undefined,
+                    ),
+                  ),
+                ],
+                undefined,
+                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                ts.factory.createCallExpression(
+                  ts.factory.createPropertyAccessExpression(
+                    getRPCInputType(rootDescriptor, methodDescriptor),
+                    "deserialize",
+                  ),
+                  undefined,
+                  [
+                    ts.factory.createNewExpression(
+                      ts.factory.createIdentifier("Uint8Array"),
+                      undefined,
+                      [ts.factory.createIdentifier("bytes")],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            ts.factory.createPropertyAssignment(
+              "responseSerialize",
+              ts.factory.createArrowFunction(
+                undefined,
+                undefined,
+                [
+                  createParameter(
+                    "message",
+                    ts.factory.createTypeReferenceNode(
+                      getRPCOutputType(rootDescriptor, methodDescriptor),
+                      undefined,
+                    ),
+                  ),
+                ],
+                undefined,
+                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                ts.factory.createCallExpression(
+                  ts.factory.createPropertyAccessExpression(
+                    ts.factory.createIdentifier("Buffer"),
+                    "from",
+                  ),
+                  undefined,
+                  [
+                    ts.factory.createCallExpression(
+                      ts.factory.createPropertyAccessExpression(
+                        ts.factory.createIdentifier("message"),
+                        "serialize",
+                      ),
+                      undefined,
+                      [],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            ts.factory.createPropertyAssignment(
+              "responseDeserialize",
+              ts.factory.createArrowFunction(
+                undefined,
+                undefined,
+                [
+                  createParameter(
+                    "bytes",
+                    ts.factory.createTypeReferenceNode(
+                      ts.factory.createIdentifier("Buffer"),
+                      undefined,
+                    ),
+                  ),
+                ],
+                undefined,
+                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+                ts.factory.createCallExpression(
+                  ts.factory.createPropertyAccessExpression(
+                    getRPCOutputType(rootDescriptor, methodDescriptor),
+                    "deserialize",
+                  ),
+                  undefined,
+                  [
+                    ts.factory.createNewExpression(
+                      ts.factory.createIdentifier("Uint8Array"),
+                      undefined,
+                      [ts.factory.createIdentifier("bytes")],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+          true,
+        ),
+      );
+    }),
+    true,
+  );
 }
 
 /**
  * Returns interface definition of the service description
- * @param {descriptor.FileDescriptorProto} rootDescriptor 
- * @param {descriptor.ServiceDescriptorProto} serviceDescriptor 
- * @param {ts.Identifier} grpcIdentifier 
+ * @param {descriptor.FileDescriptorProto} rootDescriptor
+ * @param {descriptor.ServiceDescriptorProto} serviceDescriptor
+ * @param {ts.Identifier} grpcIdentifier
  */
-function createUnimplementedService(rootDescriptor, serviceDescriptor, grpcIdentifier) {
-    const members = [
-        ts.factory.createPropertyDeclaration(
-            undefined,
-            [ts.factory.createModifier(ts.SyntaxKind.StaticKeyword)],
-            "definition",
-            undefined,
-            undefined,
-            createServiceDefinition(rootDescriptor, serviceDescriptor)
+function createUnimplementedService(
+  rootDescriptor,
+  serviceDescriptor,
+  grpcIdentifier,
+) {
+  const members = [
+    ts.factory.createPropertyDeclaration(
+      undefined,
+      [ts.factory.createModifier(ts.SyntaxKind.StaticKeyword)],
+      "definition",
+      undefined,
+      undefined,
+      createServiceDefinition(rootDescriptor, serviceDescriptor),
+    ),
+    ts.factory.createIndexSignature(
+      undefined,
+      undefined,
+      [createParameter("method", ts.factory.createIdentifier("string"))],
+      ts.factory.createTypeReferenceNode(
+        ts.factory.createPropertyAccessExpression(
+          grpcIdentifier,
+          "UntypedHandleCall",
         ),
-        ts.factory.createIndexSignature(
-            undefined,
-            undefined,
-            [
-                ts.factory.createParameterDeclaration(
-                    undefined,
-                    undefined,
-                    undefined,
-                    "method",
-                    undefined,
-                    ts.factory.createIdentifier("string")
-                )
-            ],
-            ts.factory.createTypeReferenceNode(
-                ts.factory.createPropertyAccessExpression(grpcIdentifier, "UntypedHandleCall")
-            )
-        )
-    ];
+      ),
+    ),
+  ];
 
-    for (const methodDescriptor of serviceDescriptor.method) {
-        const parameters = [];
-        let callType;
+  for (const methodDescriptor of serviceDescriptor.method) {
+    const parameters = [];
+    let callType;
 
-        if (isUnary(methodDescriptor)) {
-            callType = "ServerUnaryCall";
-        } else if (isClientStreaming(methodDescriptor)) {
-            callType = "ServerReadableStream";
-        } else if (isServerStreaming(methodDescriptor)) {
-            callType = "ServerWritableStream";
-        } else if (isBidi(methodDescriptor)) {
-            callType = "ServerDuplexStream";
-        }
-
-        parameters.push(
-            ts.factory.createParameterDeclaration(
-                undefined,
-                undefined,
-                undefined,
-                "call",
-                undefined,
-                ts.factory.createTypeReferenceNode(
-                    ts.factory.createQualifiedName(grpcIdentifier, ts.factory.createIdentifier(callType)),
-                    [
-                        getRPCInputType(rootDescriptor, methodDescriptor),
-                        getRPCOutputType(rootDescriptor, methodDescriptor)
-                    ]
-                )
-            )
-        );
-
-        if (isUnary(methodDescriptor) || isClientStreaming(methodDescriptor)) {
-            parameters.push(
-                ts.factory.createParameterDeclaration(
-                    undefined,
-                    undefined,
-                    undefined,
-                    "callback",
-                    undefined,
-                    ts.factory.createTypeReferenceNode(
-                        ts.factory.createQualifiedName(grpcIdentifier, ts.factory.createIdentifier("requestCallback")),
-                        [getRPCOutputType(rootDescriptor, methodDescriptor)]
-                    )
-                )
-            );
-        }
-
-        members.push(
-            ts.factory.createMethodDeclaration(
-                undefined,
-                [ts.factory.createModifier(ts.SyntaxKind.AbstractKeyword)],
-                undefined,
-                methodDescriptor.name,
-                undefined,
-                undefined,
-                parameters,
-                ts.factory.createTypeReferenceNode("void")
-            )
-        )
+    if (isUnary(methodDescriptor)) {
+      callType = "ServerUnaryCall";
+    } else if (isClientStreaming(methodDescriptor)) {
+      callType = "ServerReadableStream";
+    } else if (isServerStreaming(methodDescriptor)) {
+      callType = "ServerWritableStream";
+    } else if (isBidi(methodDescriptor)) {
+      callType = "ServerDuplexStream";
     }
 
-    return ts.factory.createClassDeclaration(
-        undefined,
-        [
-            ts.factory.createModifier(ts.SyntaxKind.ExportKeyword),
-            ts.factory.createModifier(ts.SyntaxKind.AbstractKeyword)
-        ],
-        ts.factory.createIdentifier(`Unimplemented${serviceDescriptor.name}Service`),
-        undefined,
-        undefined,
-        members
-    )
-}
+    parameters.push(
+      createParameter(
+        "call",
+        ts.factory.createTypeReferenceNode(
+          ts.factory.createQualifiedName(
+            grpcIdentifier,
+            ts.factory.createIdentifier(callType),
+          ),
+          [
+            getRPCInputType(rootDescriptor, methodDescriptor),
+            getRPCOutputType(rootDescriptor, methodDescriptor),
+          ],
+        ),
+      ),
+    );
 
+    if (isUnary(methodDescriptor) || isClientStreaming(methodDescriptor)) {
+      parameters.push(
+        createParameter(
+          "callback",
+          ts.factory.createTypeReferenceNode(
+            ts.factory.createQualifiedName(
+              grpcIdentifier,
+              ts.factory.createIdentifier("requestCallback"),
+            ),
+            [getRPCOutputType(rootDescriptor, methodDescriptor)],
+          ),
+        ),
+      );
+    }
+
+    members.push(
+      ts.factory.createMethodDeclaration(
+        undefined,
+        [ts.factory.createModifier(ts.SyntaxKind.AbstractKeyword)],
+        undefined,
+        methodDescriptor.name,
+        undefined,
+        undefined,
+        parameters,
+        ts.factory.createTypeReferenceNode("void"),
+      ),
+    );
+  }
+
+  return ts.factory.createClassDeclaration(
+    undefined,
+    [
+      ts.factory.createModifier(ts.SyntaxKind.ExportKeyword),
+      ts.factory.createModifier(ts.SyntaxKind.AbstractKeyword),
+    ],
+    ts.factory.createIdentifier(
+      `Unimplemented${serviceDescriptor.name}Service`,
+    ),
+    undefined,
+    undefined,
+    members,
+  );
+}
 
 /**
  * Returns grpc-node compatible client unary promise method
@@ -312,183 +288,210 @@ function createUnimplementedService(rootDescriptor, serviceDescriptor, grpcIdent
  * @param {descriptor.MethodDescriptorProto} methodDescriptor
  */
 function createUnaryRpcPromiseMethod(
-    rootDescriptor,
-    methodDescriptor,
-    grpcIdentifier
+  rootDescriptor,
+  methodDescriptor,
+  grpcIdentifier,
 ) {
-    const responseType = getRPCOutputType(rootDescriptor, methodDescriptor);
-    const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
+  const responseType = getRPCOutputType(rootDescriptor, methodDescriptor);
+  const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
 
-    const promiseBody = ts.factory.createCallExpression(
-        ts.factory.createPropertyAccessExpression(ts.factory.createSuper(), methodDescriptor.name),
-        undefined,
-        [
-            ts.factory.createIdentifier("request"),
-            ts.factory.createIdentifier("metadata"),
-            ts.factory.createIdentifier("options"),
-            ts.factory.createArrowFunction(
-                undefined,
-                undefined,
-                [
-                    ts.factory.createParameterDeclaration(
-                        undefined,
-                        undefined,
-                        undefined,
-                        "error",
-                        undefined,
-                        ts.factory.createQualifiedName(grpcIdentifier, "ServiceError")
-                    ),
-                    ts.factory.createParameterDeclaration(
-                        undefined,
-                        undefined,
-                        undefined,
-                        "response",
-                        undefined,
-                        responseType
-                    ),
-                ],
-                undefined,
-                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                ts.factory.createBlock(
-                    [
-                        ts.factory.createIfStatement(
-                            ts.factory.createIdentifier("error"),
-                            ts.factory.createBlock([
-                                ts.factory.createExpressionStatement(
-                                    ts.factory.createCallExpression(ts.factory.createIdentifier("reject"), undefined, [
-                                        ts.factory.createIdentifier("error"),
-                                    ])
-                                ),
-                            ]),
-                            ts.factory.createBlock([
-                                ts.factory.createExpressionStatement(
-                                    ts.factory.createCallExpression(ts.factory.createIdentifier("resolve"), undefined, [
-                                        ts.factory.createIdentifier("response"),
-                                    ])
-                                ),
-                            ])
-                        ),
-                    ],
-                    true
-                )
-            ),
-        ]
-    );
-
-    return ts.factory.createMethodDeclaration(
-        undefined,
-        undefined,
-        undefined,
-        methodDescriptor.name,
+  // super.put(message, metadata, options, (error: grpc_1.ServiceError, response: Result) => {
+  //   if (error) {
+  //     reject(error);
+  //   } else {
+  //      resolve(response);
+  //   }
+  // }
+  const promiseBody = ts.factory.createCallExpression(
+    ts.factory.createPropertyAccessExpression(
+      ts.factory.createSuper(),
+      methodDescriptor.name,
+    ),
+    undefined,
+    [
+      ts.factory.createIdentifier("message"),
+      ts.factory.createIdentifier("metadata"),
+      ts.factory.createIdentifier("options"),
+      ts.factory.createArrowFunction(
         undefined,
         undefined,
         [
-            ts.factory.createParameterDeclaration(
-                undefined,
-                undefined,
-                undefined,
-                "request",
-                undefined,
-                requestType
-            ),
-            ts.factory.createParameterDeclaration(
-                undefined,
-                undefined,
-                undefined,
-                "metadata",
-                ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-                ts.factory.createQualifiedName(grpcIdentifier, "Metadata")
-            ),
-            ts.factory.createParameterDeclaration(
-                undefined,
-                undefined,
-                undefined,
-                "options",
-                ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-                ts.factory.createQualifiedName(grpcIdentifier, "CallOptions")
-            ),
+          createParameter(
+            "error",
+            ts.factory.createQualifiedName(grpcIdentifier, "ServiceError"),
+          ),
+          createParameter("response", responseType),
         ],
-        ts.factory.createTypeReferenceNode("Promise", [responseType]),
+        undefined,
+        ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
         ts.factory.createBlock(
-            [
-                ts.factory.createIfStatement(
-                    ts.factory.createPrefixUnaryExpression(
-                        ts.SyntaxKind.ExclamationToken,
-                        ts.factory.createIdentifier("metadata")
-                    ),
-                    ts.factory.createExpressionStatement(
-                        ts.factory.createBinaryExpression(
-                            ts.factory.createIdentifier("metadata"),
-                            ts.factory.createToken(ts.SyntaxKind.EqualsToken),
-                            ts.factory.createNewExpression(
-                                ts.factory.createPropertyAccessExpression(grpcIdentifier, "Metadata")
-                            )
-                        )
-                    )
+          [
+            ts.factory.createIfStatement(
+              ts.factory.createIdentifier("error"),
+              ts.factory.createBlock([
+                ts.factory.createExpressionStatement(
+                  ts.factory.createCallExpression(
+                    ts.factory.createIdentifier("reject"),
+                    undefined,
+                    [ts.factory.createIdentifier("error")],
+                  ),
                 ),
-                ts.factory.createIfStatement(
-                    ts.factory.createPrefixUnaryExpression(
-                        ts.SyntaxKind.ExclamationToken,
-                        ts.factory.createIdentifier("options")
-                    ),
-                    ts.factory.createExpressionStatement(
-                        ts.factory.createBinaryExpression(
-                            ts.factory.createIdentifier("options"),
-                            ts.factory.createToken(ts.SyntaxKind.EqualsToken),
-                            ts.factory.createObjectLiteralExpression([])
-                        )
-                    )
+              ]),
+              ts.factory.createBlock([
+                ts.factory.createExpressionStatement(
+                  ts.factory.createCallExpression(
+                    ts.factory.createIdentifier("resolve"),
+                    undefined,
+                    [ts.factory.createIdentifier("response")],
+                  ),
                 ),
-                ts.factory.createReturnStatement(
-                    ts.factory.createNewExpression(ts.factory.createIdentifier("Promise"), undefined, [
-                        ts.factory.createArrowFunction(
-                            undefined,
-                            undefined,
-                            [
-                                ts.factory.createParameterDeclaration(undefined, undefined, undefined, "resolve"),
-                                ts.factory.createParameterDeclaration(undefined, undefined, undefined, "reject"),
-                            ],
-                            undefined,
-                            ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                            promiseBody
-                        ),
-                    ])
-                ),
-            ],
-            true
-        )
-    );
+              ]),
+            ),
+          ],
+          true,
+        ),
+      ),
+    ],
+  );
+
+  // {
+  //    if (!metadata) metadata = new grpc_1.Metadata;
+  //    if (!options) options = {};
+  //    return new Promise((resolve, reject) => PROMISE_BODY)
+  // }
+  const functionBody = ts.factory.createBlock([
+    ts.factory.createIfStatement(
+      ts.factory.createPrefixUnaryExpression(
+        ts.SyntaxKind.ExclamationToken,
+        ts.factory.createIdentifier("metadata"),
+      ),
+      ts.factory.createBlock([
+        ts.factory.createExpressionStatement(
+          ts.factory.createBinaryExpression(
+            ts.factory.createIdentifier("metadata"),
+            ts.factory.createToken(ts.SyntaxKind.EqualsToken),
+            ts.factory.createNewExpression(
+              ts.factory.createPropertyAccessExpression(
+                grpcIdentifier,
+                "Metadata",
+              ),
+            ),
+          ),
+        ),
+      ]),
+    ),
+    ts.factory.createIfStatement(
+      ts.factory.createPrefixUnaryExpression(
+        ts.SyntaxKind.ExclamationToken,
+        ts.factory.createIdentifier("options"),
+      ),
+      ts.factory.createBlock([
+        ts.factory.createExpressionStatement(
+          ts.factory.createBinaryExpression(
+            ts.factory.createIdentifier("options"),
+            ts.factory.createToken(ts.SyntaxKind.EqualsToken),
+            ts.factory.createObjectLiteralExpression([]),
+          ),
+        ),
+      ]),
+    ),
+    ts.factory.createReturnStatement(
+      ts.factory.createNewExpression(
+        ts.factory.createIdentifier("Promise"),
+        undefined,
+        [
+          ts.factory.createArrowFunction(
+            undefined,
+            undefined,
+            [createParameter("resolve"), createParameter("reject")],
+            undefined,
+            ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+            promiseBody,
+          ),
+        ],
+      ),
+    ),
+  ]);
+
+  const messageParameter = createParameter("message", requestType);
+  const metadataParameter = createParameter(
+    "metadata",
+    ts.factory.createQualifiedName(grpcIdentifier, "Metadata"),
+    true,
+  );
+  const callOptionsParameter = createParameter(
+    "options",
+    ts.factory.createQualifiedName(grpcIdentifier, "CallOptions"),
+    true,
+  );
+  const returnType = ts.factory.createTypeReferenceNode("Promise", [
+    responseType,
+  ]);
+
+  return [
+    ts.factory.createPropertyDeclaration(
+      undefined,
+      undefined,
+      methodDescriptor.name,
+      undefined,
+      ts.factory.createTypeReferenceNode("GrpcPromiseServiceInterface", [
+        requestType,
+        responseType,
+      ]),
+
+      ts.factory.createArrowFunction(
+        undefined,
+        undefined,
+        [
+          messageParameter,
+          createParameter(
+            "metadata",
+            ts.factory.createUnionTypeNode([
+              metadataParameter.type,
+              callOptionsParameter.type,
+            ]),
+            true,
+          ),
+          callOptionsParameter,
+        ],
+        returnType,
+        ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+        functionBody,
+      ),
+    ),
+  ];
 }
 
 /**
  * Create typed parameter
- * 
- * @param {string} name 
- * @param {ts.TypeReferenceNode | ts.QualifiedName} typename 
+ *
+ * @param {string} name
+ * @param {ts.TypeReferenceNode | ts.QualifiedName | undefined} typename
  */
 function createParameter(name, typename, optional = false) {
-    return ts.factory.createParameterDeclaration(
-        undefined,
-        undefined,
-        undefined,
-        name,
-        optional ? ts.factory.createToken(ts.SyntaxKind.QuestionToken) : undefined,
-        typename,
-    );
+  return ts.factory.createParameterDeclaration(
+    undefined,
+    undefined,
+    undefined,
+    name,
+    optional ? ts.factory.createToken(ts.SyntaxKind.QuestionToken) : undefined,
+    typename,
+  );
 }
 
 /**
  * Returns grpc-node compatible service interface.
- * 
+ *
  * @param {descriptor.FieldDescriptorProto} rootDescriptor
  * @param {descriptor.MethodDescriptorProto} methodDescriptor
  * @param {ts.Identifier} grpcIdentifier
+ * @param {ConfigParameters} config
  * @returns {ts.Statement[]}
  */
-function createGrpcInterfaceType(rootDescriptor, grpcIdentifier) {
+function createGrpcInterfaceType(rootDescriptor, grpcIdentifier, config) {
   const messageParameter = createParameter(
-    "message", 
-    ts.factory.createTypeReferenceNode("P")
+    "message",
+    ts.factory.createTypeReferenceNode("P"),
   );
   const metadataParameter = createParameter(
     "metadata",
@@ -526,9 +529,12 @@ function createGrpcInterfaceType(rootDescriptor, grpcIdentifier) {
     ts.factory.createQualifiedName(grpcIdentifier, "ClientDuplexStream"),
     [
       ts.factory.createTypeReferenceNode("P"),
-      ts.factory.createTypeReferenceNode("R")
+      ts.factory.createTypeReferenceNode("R"),
     ],
   );
+  const promiseReturnType = ts.factory.createTypeReferenceNode("Promise", [
+    ts.factory.createTypeReferenceNode("R"),
+  ]);
 
   // interface GrpcUnaryInterface<P, R> {
   //   (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>) : grpc_1.ClientUnaryCall;
@@ -574,10 +580,37 @@ function createGrpcInterfaceType(rootDescriptor, grpcIdentifier) {
     ],
   );
 
+  // interface GrpcPromiseServerInterface<P, R> {
+  //   (request: P, metadata?: grpc_1.Metadata, options?: grpc_1.CallOptions): Promise<R> {
+  //   (request: P, options?: grpc_1.CallOptions): Promise<R> {
+  // }
+  const promiseIface = ts.factory.createInterfaceDeclaration(
+    undefined,
+    undefined,
+    "GrpcPromiseServiceInterface",
+    [
+      ts.factory.createTypeParameterDeclaration("P"),
+      ts.factory.createTypeParameterDeclaration("R"),
+    ],
+    undefined,
+    [
+      ts.factory.createCallSignature(
+        undefined,
+        [messageParameter, metadataParameter, callOptionsParameterOpt],
+        promiseReturnType,
+      ),
+      ts.factory.createCallSignature(
+        undefined,
+        [messageParameter, callOptionsParameterOpt],
+        promiseReturnType,
+      ),
+    ],
+  );
+
   // interface GrpcStreamInterface<P, R> {
   //   (message: P, metadata: grpc_1.Metadata, options?: grpc_1.CallOptions): grpc_1.ClientReadableStream<R>;
   //   (message: P, options?: grpc_1.CallOptions): grpc_1.ClientReadableStream<R>;
-  // } 
+  // }
   const streamIface = ts.factory.createInterfaceDeclaration(
     undefined,
     undefined,
@@ -640,7 +673,6 @@ function createGrpcInterfaceType(rootDescriptor, grpcIdentifier) {
     ],
   );
 
-
   // interface GrpcChunkInterface<P, R> {
   //   (metadata: grpc_1.Metadata, options?: grpc_1.CallOptions): grpc_1.ClientDuplexStream<P, R>;
   //   (options?: grpc_1.CallOptions): grpc_1.ClientDuplexStream<P, R>;
@@ -668,7 +700,7 @@ function createGrpcInterfaceType(rootDescriptor, grpcIdentifier) {
     ],
   );
 
-  return [unaryIface, streamIface, writableIface, chunkIface];
+  return [unaryIface, streamIface, writableIface, chunkIface, promiseIface];
 }
 
 /**
@@ -683,10 +715,7 @@ function createUnaryRpcMethod(
 ) {
   const responseType = getRPCOutputType(rootDescriptor, methodDescriptor);
   const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
-  const messageParameter = createParameter(
-    "message",
-    requestType,
-  );
+  const messageParameter = createParameter("message", requestType);
   const metadataParameter = createParameter(
     "metadata",
     ts.factory.createQualifiedName(grpcIdentifier, "Metadata"),
@@ -721,7 +750,6 @@ function createUnaryRpcMethod(
         requestType,
         responseType,
       ]),
-
       ts.factory.createArrowFunction(
         undefined,
         undefined,
@@ -785,99 +813,97 @@ function createUnaryRpcMethod(
  * @param {descriptor.MethodDescriptorProto} methodDescriptor
  */
 function createClientStreamingRpcMethod(
-    rootDescriptor,
-    methodDescriptor,
-    grpcIdentifier
+  rootDescriptor,
+  methodDescriptor,
+  grpcIdentifier,
 ) {
-    const responseType = getRPCOutputType(rootDescriptor, methodDescriptor);
-    const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
-    const metadataParameter = createParameter(
-        "metadata",
-        ts.factory.createQualifiedName(grpcIdentifier, "Metadata")
-    );
-    const callOptionsParameter = createParameter(
-        "options",
-        ts.factory.createQualifiedName(grpcIdentifier, "CallOptions")
-    );
-    const callbackParameter = createParameter(
-        "callback",
-        ts.factory.createTypeReferenceNode(
-            ts.factory.createQualifiedName(grpcIdentifier, "requestCallback"),
-            [responseType]
-        )
-    );
-    const returnType = ts.factory.createTypeReferenceNode(
-        ts.factory.createQualifiedName(grpcIdentifier, "ClientWritableStream"),
-        [requestType]
-    )
+  const responseType = getRPCOutputType(rootDescriptor, methodDescriptor);
+  const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
+  const metadataParameter = createParameter(
+    "metadata",
+    ts.factory.createQualifiedName(grpcIdentifier, "Metadata"),
+  );
+  const callOptionsParameter = createParameter(
+    "options",
+    ts.factory.createQualifiedName(grpcIdentifier, "CallOptions"),
+  );
+  const callbackParameter = createParameter(
+    "callback",
+    ts.factory.createTypeReferenceNode(
+      ts.factory.createQualifiedName(grpcIdentifier, "requestCallback"),
+      [responseType],
+    ),
+  );
+  const returnType = ts.factory.createTypeReferenceNode(
+    ts.factory.createQualifiedName(grpcIdentifier, "ClientWritableStream"),
+    [requestType],
+  );
 
-    //     put(metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<_Object>, 
-    //         options?: grpc_1.CallOptions | grpc_1.requestCallback<_Object>, 
-    //         callback?: grpc_1.requestCallback<_Object>): grpc_1.ClientWritableStream<Put> {
+  //     put(metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<_Object>,
+  //         options?: grpc_1.CallOptions | grpc_1.requestCallback<_Object>,
+  //         callback?: grpc_1.requestCallback<_Object>): grpc_1.ClientWritableStream<Put> {
 
-    return [
-        ts.factory.createPropertyDeclaration(
-          undefined,
-          undefined,
-          methodDescriptor.name,
-          undefined,
-          ts.factory.createTypeReferenceNode("GrpWritableServiceInterface", [
-            requestType,
-            responseType,
-          ]),
-    
-          ts.factory.createArrowFunction(
-            undefined,
-            undefined,
-            [
-              createParameter(
-                "metadata",
-                ts.factory.createUnionTypeNode([
-                  metadataParameter.type,
-                  callOptionsParameter.type,
-                  callbackParameter.type,
-                ]),
-              ),
-              createParameter(
-                "options",
-                ts.factory.createUnionTypeNode([
-                  callOptionsParameter.type,
-                  callbackParameter.type,
-                ]),
-                true,
-              ),
-              createParameter(
-                "callback",
-                ts.factory.createUnionTypeNode([
-                  callbackParameter.type,
-                ]),
-                true,
-              ),
-            ],
-            returnType,
-            ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-            ts.factory.createBlock(
-              [
-                ts.factory.createReturnStatement(
-                  ts.factory.createCallExpression(
-                    ts.factory.createPropertyAccessExpression(
-                      ts.factory.createSuper(),
-                      methodDescriptor.name,
-                    ),
-                    undefined,
-                    [
-                      ts.factory.createIdentifier("metadata"),
-                      ts.factory.createIdentifier("options"),
-                      ts.factory.createIdentifier("callback"),
-                    ],
-                  ),
-                ),
-              ],
-              true,
-            ),
+  return [
+    ts.factory.createPropertyDeclaration(
+      undefined,
+      undefined,
+      methodDescriptor.name,
+      undefined,
+      ts.factory.createTypeReferenceNode("GrpWritableServiceInterface", [
+        requestType,
+        responseType,
+      ]),
+
+      ts.factory.createArrowFunction(
+        undefined,
+        undefined,
+        [
+          createParameter(
+            "metadata",
+            ts.factory.createUnionTypeNode([
+              metadataParameter.type,
+              callOptionsParameter.type,
+              callbackParameter.type,
+            ]),
           ),
+          createParameter(
+            "options",
+            ts.factory.createUnionTypeNode([
+              callOptionsParameter.type,
+              callbackParameter.type,
+            ]),
+            true,
+          ),
+          createParameter(
+            "callback",
+            ts.factory.createUnionTypeNode([callbackParameter.type]),
+            true,
+          ),
+        ],
+        returnType,
+        ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+        ts.factory.createBlock(
+          [
+            ts.factory.createReturnStatement(
+              ts.factory.createCallExpression(
+                ts.factory.createPropertyAccessExpression(
+                  ts.factory.createSuper(),
+                  methodDescriptor.name,
+                ),
+                undefined,
+                [
+                  ts.factory.createIdentifier("metadata"),
+                  ts.factory.createIdentifier("options"),
+                  ts.factory.createIdentifier("callback"),
+                ],
+              ),
+            ),
+          ],
+          true,
         ),
-      ];
+      ),
+    ),
+  ];
 }
 
 /**
@@ -885,115 +911,109 @@ function createClientStreamingRpcMethod(
  * @param {descriptor.FieldDescriptorProto} rootDescriptor
  * @param {descriptor.MethodDescriptorProto} methodDescriptor
  */
- function createServerStreamingRpcMethod(
-    rootDescriptor,
-    methodDescriptor,
-    grpcIdentifier
+function createServerStreamingRpcMethod(
+  rootDescriptor,
+  methodDescriptor,
+  grpcIdentifier,
 ) {
-    const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
-    const messageParameter = createParameter(
-        "message",
-        requestType
-    );
-    const metadataParameter = createParameter(
-        "metadata",
-        ts.factory.createQualifiedName(grpcIdentifier, "Metadata")
-    );
-    const callOptionsParameter = createParameter(
-        "options",
-        ts.factory.createQualifiedName(grpcIdentifier, "CallOptions"),
-        true,
-    );
-    const returnType = ts.factory.createTypeReferenceNode(
-        ts.factory.createQualifiedName(grpcIdentifier, "ClientReadableStream"),
-        [requestType]
-    )
+  const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
+  const messageParameter = createParameter("message", requestType);
+  const metadataParameter = createParameter(
+    "metadata",
+    ts.factory.createQualifiedName(grpcIdentifier, "Metadata"),
+  );
+  const callOptionsParameter = createParameter(
+    "options",
+    ts.factory.createQualifiedName(grpcIdentifier, "CallOptions"),
+    true,
+  );
+  const returnType = ts.factory.createTypeReferenceNode(
+    ts.factory.createQualifiedName(grpcIdentifier, "ClientReadableStream"),
+    [requestType],
+  );
 
-    return [
-        ts.factory.createPropertyDeclaration(
-          undefined,
-          undefined,
-          methodDescriptor.name,
-          undefined,
-          ts.factory.createTypeReferenceNode("GrpcStreamServiceInterface", [
-            requestType,
-            requestType,
-          ]),
-    
-          ts.factory.createArrowFunction(
-            undefined,
-            undefined,
-            [
-              messageParameter,
-              createParameter(
-                "metadata",
-                ts.factory.createUnionTypeNode([
-                  metadataParameter.type,
-                  callOptionsParameter.type,
-                ]),
-                true,
-              ),
-              createParameter(
-                "options",
-                ts.factory.createUnionTypeNode([
-                  callOptionsParameter.type,
-                ]),
-                true,
-              ),
-            ],
-            returnType,
-            ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-            ts.factory.createBlock(
-              [
-                ts.factory.createReturnStatement(
-                  ts.factory.createCallExpression(
-                    ts.factory.createPropertyAccessExpression(
-                      ts.factory.createSuper(),
-                      methodDescriptor.name,
-                    ),
-                    undefined,
-                    [
-                      ts.factory.createIdentifier("message"),
-                      ts.factory.createIdentifier("metadata"),
-                      ts.factory.createIdentifier("options"),
-                    ],
-                  ),
-                ),
-              ],
-              true,
-            ),
+  return [
+    ts.factory.createPropertyDeclaration(
+      undefined,
+      undefined,
+      methodDescriptor.name,
+      undefined,
+      ts.factory.createTypeReferenceNode("GrpcStreamServiceInterface", [
+        requestType,
+        requestType,
+      ]),
+
+      ts.factory.createArrowFunction(
+        undefined,
+        undefined,
+        [
+          messageParameter,
+          createParameter(
+            "metadata",
+            ts.factory.createUnionTypeNode([
+              metadataParameter.type,
+              callOptionsParameter.type,
+            ]),
+            true,
           ),
+          createParameter(
+            "options",
+            ts.factory.createUnionTypeNode([callOptionsParameter.type]),
+            true,
+          ),
+        ],
+        returnType,
+        ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+        ts.factory.createBlock(
+          [
+            ts.factory.createReturnStatement(
+              ts.factory.createCallExpression(
+                ts.factory.createPropertyAccessExpression(
+                  ts.factory.createSuper(),
+                  methodDescriptor.name,
+                ),
+                undefined,
+                [
+                  ts.factory.createIdentifier("message"),
+                  ts.factory.createIdentifier("metadata"),
+                  ts.factory.createIdentifier("options"),
+                ],
+              ),
+            ),
+          ],
+          true,
         ),
-      ];
+      ),
+    ),
+  ];
 }
-
 
 /**
  * Returns grpc-node compatible client streaming call method
  * @param {descriptor.FieldDescriptorProto} rootDescriptor
  * @param {descriptor.MethodDescriptorProto} methodDescriptor
  */
- function createBidiStreamingRpcMethod(
-    rootDescriptor,
-    methodDescriptor,
-    grpcIdentifier
+function createBidiStreamingRpcMethod(
+  rootDescriptor,
+  methodDescriptor,
+  grpcIdentifier,
 ) {
-    const responseType = getRPCOutputType(rootDescriptor, methodDescriptor);
-    const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
+  const responseType = getRPCOutputType(rootDescriptor, methodDescriptor);
+  const requestType = getRPCInputType(rootDescriptor, methodDescriptor);
 
-    const metadataParameter = createParameter(
-        "metadata",
-        ts.factory.createQualifiedName(grpcIdentifier, "Metadata")
-    );
-    const callOptionsParameter = createParameter(
-        "options",
-        ts.factory.createQualifiedName(grpcIdentifier, "CallOptions"),
-        true,
-    );
-    const returnType = ts.factory.createTypeReferenceNode(
-        ts.factory.createQualifiedName(grpcIdentifier, "ClientDuplexStream"),
-        [requestType, responseType]
-    )
+  const metadataParameter = createParameter(
+    "metadata",
+    ts.factory.createQualifiedName(grpcIdentifier, "Metadata"),
+  );
+  const callOptionsParameter = createParameter(
+    "options",
+    ts.factory.createQualifiedName(grpcIdentifier, "CallOptions"),
+    true,
+  );
+  const returnType = ts.factory.createTypeReferenceNode(
+    ts.factory.createQualifiedName(grpcIdentifier, "ClientDuplexStream"),
+    [requestType, responseType],
+  );
 
   return [
     ts.factory.createPropertyDeclaration(
@@ -1020,9 +1040,7 @@ function createClientStreamingRpcMethod(
           ),
           createParameter(
             "options",
-            ts.factory.createUnionTypeNode([
-              callOptionsParameter.type,
-            ]),
+            ts.factory.createUnionTypeNode([callOptionsParameter.type]),
             true,
           ),
         ],
@@ -1051,221 +1069,208 @@ function createClientStreamingRpcMethod(
   ];
 }
 
-
-
 /**
  * Returns grpc-node compatible service client.
  * @param {descriptor.FieldDescriptorProto} rootDescriptor
  * @param {descriptor.MethodDescriptorProto} methodDescriptor
- * @param {ts.Identifier} grpcIdentifier 
- * @returns 
+ * @param {ts.Identifier} grpcIdentifier
+ * @returns
  */
 function createServiceClient(
-    rootDescriptor,
-    serviceDescriptor,
-    grpcIdentifier
+  rootDescriptor,
+  serviceDescriptor,
+  grpcIdentifier,
+  params,
 ) {
-    const members = [
-        ts.factory.createConstructorDeclaration(
-            undefined,
+  const members = [
+    ts.factory.createConstructorDeclaration(
+      undefined,
+      undefined,
+      [
+        createParameter(
+          "address",
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ),
+        createParameter(
+          "credentials",
+          ts.factory.createTypeReferenceNode(
+            ts.factory.createQualifiedName(
+              grpcIdentifier,
+              "ChannelCredentials",
+            ),
+          ),
+        ),
+        createParameter(
+          "options",
+          ts.factory.createTypeReferenceNode("Partial", [
+            ts.factory.createQualifiedName(grpcIdentifier, "ChannelOptions"),
+          ]),
+          true,
+        ),
+      ],
+
+      ts.factory.createBlock(
+        [
+          ts.factory.createCallExpression(ts.factory.createSuper(), undefined, [
+            ts.factory.createIdentifier("address"),
+            ts.factory.createIdentifier("credentials"),
+            ts.factory.createIdentifier("options"),
+          ]),
+        ],
+        true,
+      ),
+    ),
+  ];
+
+  for (const methodDescriptor of serviceDescriptor.method) {
+    if (isUnary(methodDescriptor)) {
+      if (!params.unary_rpc_promise) {
+        members.push(
+          ...createUnaryRpcMethod(
+            rootDescriptor,
+            methodDescriptor,
+            grpcIdentifier,
+          ),
+        );
+      } else {
+        members.push(
+          ...createUnaryRpcPromiseMethod(
+            rootDescriptor,
+            methodDescriptor,
+            grpcIdentifier,
+          ),
+        );
+      }
+    } else if (isClientStreaming(methodDescriptor)) {
+      members.push(
+        ...createClientStreamingRpcMethod(
+          rootDescriptor,
+          methodDescriptor,
+          grpcIdentifier,
+        ),
+      );
+    } else if (isServerStreaming(methodDescriptor)) {
+      members.push(
+        ...createServerStreamingRpcMethod(
+          rootDescriptor,
+          methodDescriptor,
+          grpcIdentifier,
+        ),
+      );
+    } else if (isBidi(methodDescriptor)) {
+      members.push(
+        ...createBidiStreamingRpcMethod(
+          rootDescriptor,
+          methodDescriptor,
+          grpcIdentifier,
+        ),
+      );
+    }
+  }
+
+  return ts.factory.createClassDeclaration(
+    undefined,
+    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+    ts.factory.createIdentifier(`${serviceDescriptor.name}Client`),
+    undefined,
+    [
+      ts.factory.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [
+        ts.factory.createExpressionWithTypeArguments(
+          ts.factory.createCallExpression(
+            ts.factory.createPropertyAccessExpression(
+              grpcIdentifier,
+              "makeGenericClientConstructor",
+            ),
             undefined,
             [
-                ts.factory.createParameterDeclaration(
-                    undefined,
-                    undefined,
-                    undefined,
-                    "address",
-                    undefined,
-                    ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+              ts.factory.createPropertyAccessExpression(
+                ts.factory.createIdentifier(
+                  `Unimplemented${serviceDescriptor.name}Service`,
                 ),
-                ts.factory.createParameterDeclaration(
-                    undefined,
-                    undefined,
-                    undefined,
-                    "credentials",
-                    undefined,
-                    ts.factory.createTypeReferenceNode(
-                        ts.factory.createQualifiedName(grpcIdentifier, "ChannelCredentials")
-                    )
-                ),
-                ts.factory.createParameterDeclaration(
-                    undefined,
-                    undefined,
-                    undefined,
-                    "options",
-                    ts.factory.createToken(ts.SyntaxKind.QuestionToken),
-                    ts.factory.createTypeReferenceNode(
-                        'Partial',
-                        [
-                            ts.factory.createQualifiedName(grpcIdentifier, "ChannelOptions")
-                        ]
-                    )
-                ),
+                "definition",
+              ),
+              ts.factory.createStringLiteral(serviceDescriptor.name),
+              ts.factory.createObjectLiteralExpression(),
             ],
-
-            ts.factory.createBlock(
-                [
-                    ts.factory.createCallExpression(ts.factory.createSuper(), undefined, [
-                        ts.factory.createIdentifier("address"),
-                        ts.factory.createIdentifier("credentials"),
-                        ts.factory.createIdentifier("options"),
-                    ]),
-                ],
-                true
-            )
+          ),
         ),
-    ];
-
-    for (const methodDescriptor of serviceDescriptor.method) {
-        if (isUnary(methodDescriptor)) {
-            if (!process.env.EXPERIMENTAL_FEATURES) {
-                members.push(
-                    ...createUnaryRpcMethod(
-                        rootDescriptor,
-                        methodDescriptor,
-                        grpcIdentifier
-                    )
-                );
-            } else {
-                members.push(
-                    createUnaryRpcPromiseMethod(
-                        rootDescriptor,
-                        methodDescriptor,
-                        grpcIdentifier
-                    )
-                );
-            }
-        } else if (isClientStreaming(methodDescriptor)) {
-            members.push(
-                ...createClientStreamingRpcMethod(
-                    rootDescriptor,
-                    methodDescriptor,
-                    grpcIdentifier
-                )
-            )
-        } else if (isServerStreaming(methodDescriptor)) {
-            members.push(
-                ...createServerStreamingRpcMethod(
-                    rootDescriptor,
-                    methodDescriptor,
-                    grpcIdentifier
-                )
-            )
-        } else if (isBidi(methodDescriptor)) {
-            members.push(
-                ...createBidiStreamingRpcMethod(
-                    rootDescriptor,
-                    methodDescriptor,
-                    grpcIdentifier
-                )
-            )
-        }   
-
-    }
-
-    return ts.factory.createClassDeclaration(
-        undefined,
-        [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
-        ts.factory.createIdentifier(`${serviceDescriptor.name}Client`),
-        undefined,
-        [
-            ts.factory.createHeritageClause(ts.SyntaxKind.ExtendsKeyword, [
-                ts.factory.createExpressionWithTypeArguments(
-                    ts.factory.createCallExpression(
-                        ts.factory.createPropertyAccessExpression(
-                            grpcIdentifier,
-                            "makeGenericClientConstructor"
-                        ),
-                        undefined,
-                        [
-                            ts.factory.createPropertyAccessExpression(
-                                ts.factory.createIdentifier(`Unimplemented${serviceDescriptor.name}Service`),
-                                "definition"
-                            ),
-                            ts.factory.createStringLiteral(serviceDescriptor.name),
-                            ts.factory.createObjectLiteralExpression(),
-                        ]
-                    )
-                ),
-            ]),
-        ],
-        members
-    );
+      ]),
+    ],
+    members,
+  );
 }
 
 /**
- * @param {descriptor.FileDescriptorProto} rootDescriptor 
- * @param {descriptor.MethodDescriptorProto} methodDescriptor 
+ * @param {descriptor.FileDescriptorProto} rootDescriptor
+ * @param {descriptor.MethodDescriptorProto} methodDescriptor
  */
 function getRPCOutputType(rootDescriptor, methodDescriptor) {
-    return type.getTypeReference(rootDescriptor, methodDescriptor.output_type);
+  return type.getTypeReference(rootDescriptor, methodDescriptor.output_type);
 }
 
 /**
-* @param {descriptor.FileDescriptorProto} rootDescriptor 
-* @param {descriptor.MethodDescriptorProto} methodDescriptor 
-*/
+ * @param {descriptor.FileDescriptorProto} rootDescriptor
+ * @param {descriptor.MethodDescriptorProto} methodDescriptor
+ */
 function getRPCInputType(rootDescriptor, methodDescriptor) {
-    return type.getTypeReference(rootDescriptor, methodDescriptor.input_type);
+  return type.getTypeReference(rootDescriptor, methodDescriptor.input_type);
 }
 
-
 /**
- * @param {descriptor.FileDescriptorProto} rootDescriptor 
- * @param {descriptor.ServiceDescriptorProto} serviceDescriptor 
- * @param {descriptor.MethodDescriptorProto} methodDescriptor 
+ * @param {descriptor.FileDescriptorProto} rootDescriptor
+ * @param {descriptor.ServiceDescriptorProto} serviceDescriptor
+ * @param {descriptor.MethodDescriptorProto} methodDescriptor
  */
 function getRPCPath(rootDescriptor, serviceDescriptor, methodDescriptor) {
-    let name = serviceDescriptor.name;
-    if (rootDescriptor.package) {
-        name = `${rootDescriptor.package}.${name}`;
-    }
-    return `/${name}/${methodDescriptor.name}`;
+  let name = serviceDescriptor.name;
+  if (rootDescriptor.package) {
+    name = `${rootDescriptor.package}.${name}`;
+  }
+  return `/${name}/${methodDescriptor.name}`;
 }
 
 /**
- * @param {descriptor.MethodDescriptorProto} methodDescriptor 
+ * @param {descriptor.MethodDescriptorProto} methodDescriptor
  * @returns {boolean}
  */
 function isUnary(methodDescriptor) {
-    return (
-        methodDescriptor.client_streaming == false &&
-        methodDescriptor.server_streaming == false
-    );
+  return (
+    methodDescriptor.client_streaming == false &&
+    methodDescriptor.server_streaming == false
+  );
 }
 
 /**
- * @param {descriptor.MethodDescriptorProto} methodDescriptor 
+ * @param {descriptor.MethodDescriptorProto} methodDescriptor
  * @returns {boolean}
  */
 function isClientStreaming(methodDescriptor) {
-    return (
-        methodDescriptor.client_streaming == true &&
-        methodDescriptor.server_streaming == false
-    );
+  return (
+    methodDescriptor.client_streaming == true &&
+    methodDescriptor.server_streaming == false
+  );
 }
 
 /**
- * @param {descriptor.MethodDescriptorProto} methodDescriptor 
+ * @param {descriptor.MethodDescriptorProto} methodDescriptor
  * @returns {boolean}
  */
 function isServerStreaming(methodDescriptor) {
-    return (
-        methodDescriptor.client_streaming == false &&
-        methodDescriptor.server_streaming == true
-    );
+  return (
+    methodDescriptor.client_streaming == false &&
+    methodDescriptor.server_streaming == true
+  );
 }
 /**
- * @param {descriptor.MethodDescriptorProto} methodDescriptor 
+ * @param {descriptor.MethodDescriptorProto} methodDescriptor
  * @returns {boolean}
  */
 function isBidi(methodDescriptor) {
-    return (
-        methodDescriptor.client_streaming == true &&
-        methodDescriptor.server_streaming == true
-    );
+  return (
+    methodDescriptor.client_streaming == true &&
+    methodDescriptor.server_streaming == true
+  );
 }
-
 
 module.exports = {
   createUnimplementedServer: createUnimplementedService,


### PR DESCRIPTION
One option for making the calls into promises is to use `promisify` however, the current codebase generate class methods rather than arrow functions with means that you need to do a bind prior to calling promisify.

```
import { promisify } from 'util';

// code omitted

/** this is what the change enables */
const addTodo = promisify(client.addTodo)

/** code before the change */
const addTodo = promisify(client.addTodo.bind(client))
```


From output of  `test/rpcs.ts`

```
interface GrpcUnaryServiceInterface<P, R> {
    (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;
    (message: P, metadata: grpc_1.Metadata, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;
    (message: P, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;
    (message: P, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;
}
interface GrpcStreamServiceInterface<P, R> {
    (message: P, metadata: grpc_1.Metadata, options?: grpc_1.CallOptions): grpc_1.ClientReadableStream<R>;
    (message: P, options?: grpc_1.CallOptions): grpc_1.ClientReadableStream<R>;
}
interface GrpWritableServiceInterface<P, R> {
    (metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientWritableStream<P>;
    (metadata: grpc_1.Metadata, callback: grpc_1.requestCallback<R>): grpc_1.ClientWritableStream<P>;
    (options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientWritableStream<P>;
    (callback: grpc_1.requestCallback<R>): grpc_1.ClientWritableStream<P>;
}
interface GrpcChunkServiceInterface<P, R> {
    (metadata: grpc_1.Metadata, options?: grpc_1.CallOptions): grpc_1.ClientDuplexStream<P, R>;
    (options?: grpc_1.CallOptions): grpc_1.ClientDuplexStream<P, R>;
}
export abstract class UnimplementedStorageService {
   /** omitted - no changes **/
}
export class StorageClient extends grpc_1.makeGenericClientConstructor(UnimplementedStorageService.definition, "Storage", {}) {
    constructor(address: string, credentials: grpc_1.ChannelCredentials, options?: Partial<grpc_1.ChannelOptions>) {
        super(address, credentials, options)
    }
    query: GrpcStreamServiceInterface<Query, Query> = (message: Query, metadata?: grpc_1.Metadata | grpc_1.CallOptions, options?: grpc_1.CallOptions): grpc_1.ClientReadableStream<Query> => {
        return super.query(message, metadata, options);
    };
    get: GrpcUnaryServiceInterface<Query, _Object> = (message: Query, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<_Object>, options?: grpc_1.CallOptions | grpc_1.requestCallback<_Object>, callback?: grpc_1.requestCallback<_Object>): grpc_1.ClientUnaryCall => {
        return super.get(message, metadata, options, callback);
    };
    put: GrpWritableServiceInterface<Put, _Object> = (metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<_Object>, options?: grpc_1.CallOptions | grpc_1.requestCallback<_Object>, callback?: grpc_1.requestCallback<_Object>): grpc_1.ClientWritableStream<Put> => {
        return super.put(metadata, options, callback);
    };
    chunk: GrpcChunkServiceInterface<Chunk.Query, Chunk> = (metadata?: grpc_1.Metadata | grpc_1.CallOptions, options?: grpc_1.CallOptions): grpc_1.ClientDuplexStream<Chunk.Query, Chunk> => {
        return super.chunk(metadata, options);
    };
}
```