### PR TITLE
Update Unary callback return type

### DIFF
--- a/src/rpc.js
+++ b/src/rpc.js
@@ -245,7 +245,7 @@ function createUnimplementedService(
           ts.factory.createTypeReferenceNode(
             ts.factory.createQualifiedName(
               grpcIdentifier,
-              ts.factory.createIdentifier("requestCallback"),
+              ts.factory.createIdentifier("sendUnaryData"),
             ),
             [getRPCOutputType(rootDescriptor, methodDescriptor)],
           ),


### PR DESCRIPTION
In my testing, the return type of unary callback doesn't align with the grpc-js package.

I've tried to fix the return type. The tests passed but I wasn't sure how to build the compiler to test it on my proto files. 
