### PR TITLE
fix: load path

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ protoc -I=sourcedir --ts_out=dist myproto.proto
 ```py
 # Add protoc-gen-ts to dependencies section of your package.json file.
 
-load("@npm//protoc-gen-ts//:index.bzl", "ts_proto_library")
+load("@npm//protoc-gen-ts:index.bzl", "ts_proto_library")
 
 ts_proto_library(
     name = "protos",


### PR DESCRIPTION
Changes
- Update Bazel instructions in the README.md file. 

This change fixes the following error:
ERROR: .../BUILD.bazel:2:6: in load statement: invalid package name 'protoc-gen-ts//': package names may not end with '/'
ERROR: Skipping '//protos:ts_protos': error loading package 'protos': malformed load statements
WARNING: Target pattern parsing failed.
ERROR: error loading package 'protos': malformed load statements