### PR TITLE
Support noPropertyAccessFromIndexSignature tsconfig option

### DIFF
--- a/src/compiler/descriptor.ts
+++ b/src/compiler/descriptor.ts
@@ -22,7 +22,7 @@ export class FileDescriptorSet extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
     static fromObject(data: {
-        file?: ReturnType<typeof FileDescriptorProto.prototype.toObject>[];
+        file?: Parameters<typeof FileDescriptorProto.fromObject>[0][];
     }): FileDescriptorSet {
         const message = new FileDescriptorSet({
             file: data.file.map(item => FileDescriptorProto.fromObject(item))
@@ -31,11 +31,10 @@ export class FileDescriptorSet extends pb_1.Message {
     }
     toObject() {
         const data: {
-            file?: ReturnType<typeof FileDescriptorProto.prototype.toObject>[];
-        } = {};
-        if (this.file != null) {
-            data.file = this.file.map((item: FileDescriptorProto) => item.toObject());
-        }
+            file: Parameters<typeof FileDescriptorProto.fromObject>[0][];
+        } = {
+            file: this.file.map((item: FileDescriptorProto) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -201,15 +200,15 @@ export class FileDescriptorProto extends pb_1.Message {
     static fromObject(data: {
         name?: string;
         package?: string;
-        dependency: string[];
-        public_dependency: number[];
-        weak_dependency: number[];
-        message_type?: ReturnType<typeof DescriptorProto.prototype.toObject>[];
-        enum_type?: ReturnType<typeof EnumDescriptorProto.prototype.toObject>[];
-        service?: ReturnType<typeof ServiceDescriptorProto.prototype.toObject>[];
-        extension?: ReturnType<typeof FieldDescriptorProto.prototype.toObject>[];
-        options?: ReturnType<typeof FileOptions.prototype.toObject>;
-        source_code_info?: ReturnType<typeof SourceCodeInfo.prototype.toObject>;
+        dependency?: string[];
+        public_dependency?: number[];
+        weak_dependency?: number[];
+        message_type?: Parameters<typeof DescriptorProto.fromObject>[0][];
+        enum_type?: Parameters<typeof EnumDescriptorProto.fromObject>[0][];
+        service?: Parameters<typeof ServiceDescriptorProto.fromObject>[0][];
+        extension?: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
+        options?: Parameters<typeof FileOptions.fromObject>[0];
+        source_code_info?: Parameters<typeof SourceCodeInfo.fromObject>[0];
         syntax?: string;
     }): FileDescriptorProto {
         const message = new FileDescriptorProto({
@@ -240,49 +239,35 @@ export class FileDescriptorProto extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: string;
-            package?: string;
+            name: string;
+            package: string;
             dependency: string[];
             public_dependency: number[];
             weak_dependency: number[];
-            message_type?: ReturnType<typeof DescriptorProto.prototype.toObject>[];
-            enum_type?: ReturnType<typeof EnumDescriptorProto.prototype.toObject>[];
-            service?: ReturnType<typeof ServiceDescriptorProto.prototype.toObject>[];
-            extension?: ReturnType<typeof FieldDescriptorProto.prototype.toObject>[];
-            options?: ReturnType<typeof FileOptions.prototype.toObject>;
-            source_code_info?: ReturnType<typeof SourceCodeInfo.prototype.toObject>;
-            syntax?: string;
+            message_type: Parameters<typeof DescriptorProto.fromObject>[0][];
+            enum_type: Parameters<typeof EnumDescriptorProto.fromObject>[0][];
+            service: Parameters<typeof ServiceDescriptorProto.fromObject>[0][];
+            extension: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
+            options?: Parameters<typeof FileOptions.fromObject>[0];
+            source_code_info?: Parameters<typeof SourceCodeInfo.fromObject>[0];
+            syntax: string;
         } = {
+            name: this.name,
+            package: this.package,
             dependency: this.dependency,
             public_dependency: this.public_dependency,
-            weak_dependency: this.weak_dependency
+            weak_dependency: this.weak_dependency,
+            message_type: this.message_type.map((item: DescriptorProto) => item.toObject()),
+            enum_type: this.enum_type.map((item: EnumDescriptorProto) => item.toObject()),
+            service: this.service.map((item: ServiceDescriptorProto) => item.toObject()),
+            extension: this.extension.map((item: FieldDescriptorProto) => item.toObject()),
+            syntax: this.syntax
         };
-        if (this.name != null) {
-            data.name = this.name;
-        }
-        if (this.package != null) {
-            data.package = this.package;
-        }
-        if (this.message_type != null) {
-            data.message_type = this.message_type.map((item: DescriptorProto) => item.toObject());
-        }
-        if (this.enum_type != null) {
-            data.enum_type = this.enum_type.map((item: EnumDescriptorProto) => item.toObject());
-        }
-        if (this.service != null) {
-            data.service = this.service.map((item: ServiceDescriptorProto) => item.toObject());
-        }
-        if (this.extension != null) {
-            data.extension = this.extension.map((item: FieldDescriptorProto) => item.toObject());
-        }
         if (this.options != null) {
             data.options = this.options.toObject();
         }
         if (this.source_code_info != null) {
             data.source_code_info = this.source_code_info.toObject();
-        }
-        if (this.syntax != null) {
-            data.syntax = this.syntax;
         }
         return data;
     }
@@ -472,15 +457,15 @@ export class DescriptorProto extends pb_1.Message {
     }
     static fromObject(data: {
         name?: string;
-        field?: ReturnType<typeof FieldDescriptorProto.prototype.toObject>[];
-        extension?: ReturnType<typeof FieldDescriptorProto.prototype.toObject>[];
-        nested_type?: ReturnType<typeof DescriptorProto.prototype.toObject>[];
-        enum_type?: ReturnType<typeof EnumDescriptorProto.prototype.toObject>[];
-        extension_range?: ReturnType<typeof DescriptorProto.ExtensionRange.prototype.toObject>[];
-        oneof_decl?: ReturnType<typeof OneofDescriptorProto.prototype.toObject>[];
-        options?: ReturnType<typeof MessageOptions.prototype.toObject>;
-        reserved_range?: ReturnType<typeof DescriptorProto.ReservedRange.prototype.toObject>[];
-        reserved_name: string[];
+        field?: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
+        extension?: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
+        nested_type?: Parameters<typeof DescriptorProto.fromObject>[0][];
+        enum_type?: Parameters<typeof EnumDescriptorProto.fromObject>[0][];
+        extension_range?: Parameters<typeof DescriptorProto.ExtensionRange.fromObject>[0][];
+        oneof_decl?: Parameters<typeof OneofDescriptorProto.fromObject>[0][];
+        options?: Parameters<typeof MessageOptions.fromObject>[0];
+        reserved_range?: Parameters<typeof DescriptorProto.ReservedRange.fromObject>[0][];
+        reserved_name?: string[];
     }): DescriptorProto {
         const message = new DescriptorProto({
             field: data.field.map(item => FieldDescriptorProto.fromObject(item)),
@@ -502,45 +487,29 @@ export class DescriptorProto extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: string;
-            field?: ReturnType<typeof FieldDescriptorProto.prototype.toObject>[];
-            extension?: ReturnType<typeof FieldDescriptorProto.prototype.toObject>[];
-            nested_type?: ReturnType<typeof DescriptorProto.prototype.toObject>[];
-            enum_type?: ReturnType<typeof EnumDescriptorProto.prototype.toObject>[];
-            extension_range?: ReturnType<typeof DescriptorProto.ExtensionRange.prototype.toObject>[];
-            oneof_decl?: ReturnType<typeof OneofDescriptorProto.prototype.toObject>[];
-            options?: ReturnType<typeof MessageOptions.prototype.toObject>;
-            reserved_range?: ReturnType<typeof DescriptorProto.ReservedRange.prototype.toObject>[];
+            name: string;
+            field: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
+            extension: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
+            nested_type: Parameters<typeof DescriptorProto.fromObject>[0][];
+            enum_type: Parameters<typeof EnumDescriptorProto.fromObject>[0][];
+            extension_range: Parameters<typeof DescriptorProto.ExtensionRange.fromObject>[0][];
+            oneof_decl: Parameters<typeof OneofDescriptorProto.fromObject>[0][];
+            options?: Parameters<typeof MessageOptions.fromObject>[0];
+            reserved_range: Parameters<typeof DescriptorProto.ReservedRange.fromObject>[0][];
             reserved_name: string[];
         } = {
+            name: this.name,
+            field: this.field.map((item: FieldDescriptorProto) => item.toObject()),
+            extension: this.extension.map((item: FieldDescriptorProto) => item.toObject()),
+            nested_type: this.nested_type.map((item: DescriptorProto) => item.toObject()),
+            enum_type: this.enum_type.map((item: EnumDescriptorProto) => item.toObject()),
+            extension_range: this.extension_range.map((item: DescriptorProto.ExtensionRange) => item.toObject()),
+            oneof_decl: this.oneof_decl.map((item: OneofDescriptorProto) => item.toObject()),
+            reserved_range: this.reserved_range.map((item: DescriptorProto.ReservedRange) => item.toObject()),
             reserved_name: this.reserved_name
         };
-        if (this.name != null) {
-            data.name = this.name;
-        }
-        if (this.field != null) {
-            data.field = this.field.map((item: FieldDescriptorProto) => item.toObject());
-        }
-        if (this.extension != null) {
-            data.extension = this.extension.map((item: FieldDescriptorProto) => item.toObject());
-        }
-        if (this.nested_type != null) {
-            data.nested_type = this.nested_type.map((item: DescriptorProto) => item.toObject());
-        }
-        if (this.enum_type != null) {
-            data.enum_type = this.enum_type.map((item: EnumDescriptorProto) => item.toObject());
-        }
-        if (this.extension_range != null) {
-            data.extension_range = this.extension_range.map((item: DescriptorProto.ExtensionRange) => item.toObject());
-        }
-        if (this.oneof_decl != null) {
-            data.oneof_decl = this.oneof_decl.map((item: OneofDescriptorProto) => item.toObject());
-        }
         if (this.options != null) {
             data.options = this.options.toObject();
-        }
-        if (this.reserved_range != null) {
-            data.reserved_range = this.reserved_range.map((item: DescriptorProto.ReservedRange) => item.toObject());
         }
         return data;
     }
@@ -671,7 +640,7 @@ export namespace DescriptorProto {
         static fromObject(data: {
             start?: number;
             end?: number;
-            options?: ReturnType<typeof ExtensionRangeOptions.prototype.toObject>;
+            options?: Parameters<typeof ExtensionRangeOptions.fromObject>[0];
         }): ExtensionRange {
             const message = new ExtensionRange({});
             if (data.start != null) {
@@ -687,16 +656,13 @@ export namespace DescriptorProto {
         }
         toObject() {
             const data: {
-                start?: number;
-                end?: number;
-                options?: ReturnType<typeof ExtensionRangeOptions.prototype.toObject>;
-            } = {};
-            if (this.start != null) {
-                data.start = this.start;
-            }
-            if (this.end != null) {
-                data.end = this.end;
-            }
+                start: number;
+                end: number;
+                options?: Parameters<typeof ExtensionRangeOptions.fromObject>[0];
+            } = {
+                start: this.start,
+                end: this.end
+            };
             if (this.options != null) {
                 data.options = this.options.toObject();
             }
@@ -792,15 +758,12 @@ export namespace DescriptorProto {
         }
         toObject() {
             const data: {
-                start?: number;
-                end?: number;
-            } = {};
-            if (this.start != null) {
-                data.start = this.start;
-            }
-            if (this.end != null) {
-                data.end = this.end;
-            }
+                start: number;
+                end: number;
+            } = {
+                start: this.start,
+                end: this.end
+            };
             return data;
         }
         serialize(): Uint8Array;
@@ -857,7 +820,7 @@ export class ExtensionRangeOptions extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
     static fromObject(data: {
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): ExtensionRangeOptions {
         const message = new ExtensionRangeOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -866,11 +829,10 @@ export class ExtensionRangeOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -1065,7 +1027,7 @@ export class FieldDescriptorProto extends pb_1.Message {
         default_value?: string;
         oneof_index?: number;
         json_name?: string;
-        options?: ReturnType<typeof FieldOptions.prototype.toObject>;
+        options?: Parameters<typeof FieldOptions.fromObject>[0];
         proto3_optional?: boolean;
     }): FieldDescriptorProto {
         const message = new FieldDescriptorProto({});
@@ -1106,50 +1068,31 @@ export class FieldDescriptorProto extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: string;
-            number?: number;
-            label?: FieldDescriptorProto.Label;
-            type?: FieldDescriptorProto.Type;
-            type_name?: string;
-            extendee?: string;
-            default_value?: string;
-            oneof_index?: number;
-            json_name?: string;
-            options?: ReturnType<typeof FieldOptions.prototype.toObject>;
-            proto3_optional?: boolean;
-        } = {};
-        if (this.name != null) {
-            data.name = this.name;
-        }
-        if (this.number != null) {
-            data.number = this.number;
-        }
-        if (this.label != null) {
-            data.label = this.label;
-        }
-        if (this.type != null) {
-            data.type = this.type;
-        }
-        if (this.type_name != null) {
-            data.type_name = this.type_name;
-        }
-        if (this.extendee != null) {
-            data.extendee = this.extendee;
-        }
-        if (this.default_value != null) {
-            data.default_value = this.default_value;
-        }
-        if (this.oneof_index != null) {
-            data.oneof_index = this.oneof_index;
-        }
-        if (this.json_name != null) {
-            data.json_name = this.json_name;
-        }
+            name: string;
+            number: number;
+            label: FieldDescriptorProto.Label;
+            type: FieldDescriptorProto.Type;
+            type_name: string;
+            extendee: string;
+            default_value: string;
+            oneof_index: number;
+            json_name: string;
+            options?: Parameters<typeof FieldOptions.fromObject>[0];
+            proto3_optional: boolean;
+        } = {
+            name: this.name,
+            number: this.number,
+            label: this.label,
+            type: this.type,
+            type_name: this.type_name,
+            extendee: this.extendee,
+            default_value: this.default_value,
+            oneof_index: this.oneof_index,
+            json_name: this.json_name,
+            proto3_optional: this.proto3_optional
+        };
         if (this.options != null) {
             data.options = this.options.toObject();
-        }
-        if (this.proto3_optional != null) {
-            data.proto3_optional = this.proto3_optional;
         }
         return data;
     }
@@ -1297,7 +1240,7 @@ export class OneofDescriptorProto extends pb_1.Message {
     }
     static fromObject(data: {
         name?: string;
-        options?: ReturnType<typeof OneofOptions.prototype.toObject>;
+        options?: Parameters<typeof OneofOptions.fromObject>[0];
     }): OneofDescriptorProto {
         const message = new OneofDescriptorProto({});
         if (data.name != null) {
@@ -1310,12 +1253,11 @@ export class OneofDescriptorProto extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: string;
-            options?: ReturnType<typeof OneofOptions.prototype.toObject>;
-        } = {};
-        if (this.name != null) {
-            data.name = this.name;
-        }
+            name: string;
+            options?: Parameters<typeof OneofOptions.fromObject>[0];
+        } = {
+            name: this.name
+        };
         if (this.options != null) {
             data.options = this.options.toObject();
         }
@@ -1417,10 +1359,10 @@ export class EnumDescriptorProto extends pb_1.Message {
     }
     static fromObject(data: {
         name?: string;
-        value?: ReturnType<typeof EnumValueDescriptorProto.prototype.toObject>[];
-        options?: ReturnType<typeof EnumOptions.prototype.toObject>;
-        reserved_range?: ReturnType<typeof EnumDescriptorProto.EnumReservedRange.prototype.toObject>[];
-        reserved_name: string[];
+        value?: Parameters<typeof EnumValueDescriptorProto.fromObject>[0][];
+        options?: Parameters<typeof EnumOptions.fromObject>[0];
+        reserved_range?: Parameters<typeof EnumDescriptorProto.EnumReservedRange.fromObject>[0][];
+        reserved_name?: string[];
     }): EnumDescriptorProto {
         const message = new EnumDescriptorProto({
             value: data.value.map(item => EnumValueDescriptorProto.fromObject(item)),
@@ -1437,25 +1379,19 @@ export class EnumDescriptorProto extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: string;
-            value?: ReturnType<typeof EnumValueDescriptorProto.prototype.toObject>[];
-            options?: ReturnType<typeof EnumOptions.prototype.toObject>;
-            reserved_range?: ReturnType<typeof EnumDescriptorProto.EnumReservedRange.prototype.toObject>[];
+            name: string;
+            value: Parameters<typeof EnumValueDescriptorProto.fromObject>[0][];
+            options?: Parameters<typeof EnumOptions.fromObject>[0];
+            reserved_range: Parameters<typeof EnumDescriptorProto.EnumReservedRange.fromObject>[0][];
             reserved_name: string[];
         } = {
+            name: this.name,
+            value: this.value.map((item: EnumValueDescriptorProto) => item.toObject()),
+            reserved_range: this.reserved_range.map((item: EnumDescriptorProto.EnumReservedRange) => item.toObject()),
             reserved_name: this.reserved_name
         };
-        if (this.name != null) {
-            data.name = this.name;
-        }
-        if (this.value != null) {
-            data.value = this.value.map((item: EnumValueDescriptorProto) => item.toObject());
-        }
         if (this.options != null) {
             data.options = this.options.toObject();
-        }
-        if (this.reserved_range != null) {
-            data.reserved_range = this.reserved_range.map((item: EnumDescriptorProto.EnumReservedRange) => item.toObject());
         }
         return data;
     }
@@ -1560,15 +1496,12 @@ export namespace EnumDescriptorProto {
         }
         toObject() {
             const data: {
-                start?: number;
-                end?: number;
-            } = {};
-            if (this.start != null) {
-                data.start = this.start;
-            }
-            if (this.end != null) {
-                data.end = this.end;
-            }
+                start: number;
+                end: number;
+            } = {
+                start: this.start,
+                end: this.end
+            };
             return data;
         }
         serialize(): Uint8Array;
@@ -1658,7 +1591,7 @@ export class EnumValueDescriptorProto extends pb_1.Message {
     static fromObject(data: {
         name?: string;
         number?: number;
-        options?: ReturnType<typeof EnumValueOptions.prototype.toObject>;
+        options?: Parameters<typeof EnumValueOptions.fromObject>[0];
     }): EnumValueDescriptorProto {
         const message = new EnumValueDescriptorProto({});
         if (data.name != null) {
@@ -1674,16 +1607,13 @@ export class EnumValueDescriptorProto extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: string;
-            number?: number;
-            options?: ReturnType<typeof EnumValueOptions.prototype.toObject>;
-        } = {};
-        if (this.name != null) {
-            data.name = this.name;
-        }
-        if (this.number != null) {
-            data.number = this.number;
-        }
+            name: string;
+            number: number;
+            options?: Parameters<typeof EnumValueOptions.fromObject>[0];
+        } = {
+            name: this.name,
+            number: this.number
+        };
         if (this.options != null) {
             data.options = this.options.toObject();
         }
@@ -1774,8 +1704,8 @@ export class ServiceDescriptorProto extends pb_1.Message {
     }
     static fromObject(data: {
         name?: string;
-        method?: ReturnType<typeof MethodDescriptorProto.prototype.toObject>[];
-        options?: ReturnType<typeof ServiceOptions.prototype.toObject>;
+        method?: Parameters<typeof MethodDescriptorProto.fromObject>[0][];
+        options?: Parameters<typeof ServiceOptions.fromObject>[0];
     }): ServiceDescriptorProto {
         const message = new ServiceDescriptorProto({
             method: data.method.map(item => MethodDescriptorProto.fromObject(item))
@@ -1790,16 +1720,13 @@ export class ServiceDescriptorProto extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: string;
-            method?: ReturnType<typeof MethodDescriptorProto.prototype.toObject>[];
-            options?: ReturnType<typeof ServiceOptions.prototype.toObject>;
-        } = {};
-        if (this.name != null) {
-            data.name = this.name;
-        }
-        if (this.method != null) {
-            data.method = this.method.map((item: MethodDescriptorProto) => item.toObject());
-        }
+            name: string;
+            method: Parameters<typeof MethodDescriptorProto.fromObject>[0][];
+            options?: Parameters<typeof ServiceOptions.fromObject>[0];
+        } = {
+            name: this.name,
+            method: this.method.map((item: MethodDescriptorProto) => item.toObject())
+        };
         if (this.options != null) {
             data.options = this.options.toObject();
         }
@@ -1936,7 +1863,7 @@ export class MethodDescriptorProto extends pb_1.Message {
         name?: string;
         input_type?: string;
         output_type?: string;
-        options?: ReturnType<typeof MethodOptions.prototype.toObject>;
+        options?: Parameters<typeof MethodOptions.fromObject>[0];
         client_streaming?: boolean;
         server_streaming?: boolean;
     }): MethodDescriptorProto {
@@ -1963,30 +1890,21 @@ export class MethodDescriptorProto extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: string;
-            input_type?: string;
-            output_type?: string;
-            options?: ReturnType<typeof MethodOptions.prototype.toObject>;
-            client_streaming?: boolean;
-            server_streaming?: boolean;
-        } = {};
-        if (this.name != null) {
-            data.name = this.name;
-        }
-        if (this.input_type != null) {
-            data.input_type = this.input_type;
-        }
-        if (this.output_type != null) {
-            data.output_type = this.output_type;
-        }
+            name: string;
+            input_type: string;
+            output_type: string;
+            options?: Parameters<typeof MethodOptions.fromObject>[0];
+            client_streaming: boolean;
+            server_streaming: boolean;
+        } = {
+            name: this.name,
+            input_type: this.input_type,
+            output_type: this.output_type,
+            client_streaming: this.client_streaming,
+            server_streaming: this.server_streaming
+        };
         if (this.options != null) {
             data.options = this.options.toObject();
-        }
-        if (this.client_streaming != null) {
-            data.client_streaming = this.client_streaming;
-        }
-        if (this.server_streaming != null) {
-            data.server_streaming = this.server_streaming;
         }
         return data;
     }
@@ -2347,7 +2265,7 @@ export class FileOptions extends pb_1.Message {
         php_namespace?: string;
         php_metadata_namespace?: string;
         ruby_package?: string;
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): FileOptions {
         const message = new FileOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -2416,91 +2334,50 @@ export class FileOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            java_package?: string;
-            java_outer_classname?: string;
-            java_multiple_files?: boolean;
-            java_generate_equals_and_hash?: boolean;
-            java_string_check_utf8?: boolean;
-            optimize_for?: FileOptions.OptimizeMode;
-            go_package?: string;
-            cc_generic_services?: boolean;
-            java_generic_services?: boolean;
-            py_generic_services?: boolean;
-            php_generic_services?: boolean;
-            deprecated?: boolean;
-            cc_enable_arenas?: boolean;
-            objc_class_prefix?: string;
-            csharp_namespace?: string;
-            swift_prefix?: string;
-            php_class_prefix?: string;
-            php_namespace?: string;
-            php_metadata_namespace?: string;
-            ruby_package?: string;
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.java_package != null) {
-            data.java_package = this.java_package;
-        }
-        if (this.java_outer_classname != null) {
-            data.java_outer_classname = this.java_outer_classname;
-        }
-        if (this.java_multiple_files != null) {
-            data.java_multiple_files = this.java_multiple_files;
-        }
-        if (this.java_generate_equals_and_hash != null) {
-            data.java_generate_equals_and_hash = this.java_generate_equals_and_hash;
-        }
-        if (this.java_string_check_utf8 != null) {
-            data.java_string_check_utf8 = this.java_string_check_utf8;
-        }
-        if (this.optimize_for != null) {
-            data.optimize_for = this.optimize_for;
-        }
-        if (this.go_package != null) {
-            data.go_package = this.go_package;
-        }
-        if (this.cc_generic_services != null) {
-            data.cc_generic_services = this.cc_generic_services;
-        }
-        if (this.java_generic_services != null) {
-            data.java_generic_services = this.java_generic_services;
-        }
-        if (this.py_generic_services != null) {
-            data.py_generic_services = this.py_generic_services;
-        }
-        if (this.php_generic_services != null) {
-            data.php_generic_services = this.php_generic_services;
-        }
-        if (this.deprecated != null) {
-            data.deprecated = this.deprecated;
-        }
-        if (this.cc_enable_arenas != null) {
-            data.cc_enable_arenas = this.cc_enable_arenas;
-        }
-        if (this.objc_class_prefix != null) {
-            data.objc_class_prefix = this.objc_class_prefix;
-        }
-        if (this.csharp_namespace != null) {
-            data.csharp_namespace = this.csharp_namespace;
-        }
-        if (this.swift_prefix != null) {
-            data.swift_prefix = this.swift_prefix;
-        }
-        if (this.php_class_prefix != null) {
-            data.php_class_prefix = this.php_class_prefix;
-        }
-        if (this.php_namespace != null) {
-            data.php_namespace = this.php_namespace;
-        }
-        if (this.php_metadata_namespace != null) {
-            data.php_metadata_namespace = this.php_metadata_namespace;
-        }
-        if (this.ruby_package != null) {
-            data.ruby_package = this.ruby_package;
-        }
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            java_package: string;
+            java_outer_classname: string;
+            java_multiple_files: boolean;
+            java_generate_equals_and_hash: boolean;
+            java_string_check_utf8: boolean;
+            optimize_for: FileOptions.OptimizeMode;
+            go_package: string;
+            cc_generic_services: boolean;
+            java_generic_services: boolean;
+            py_generic_services: boolean;
+            php_generic_services: boolean;
+            deprecated: boolean;
+            cc_enable_arenas: boolean;
+            objc_class_prefix: string;
+            csharp_namespace: string;
+            swift_prefix: string;
+            php_class_prefix: string;
+            php_namespace: string;
+            php_metadata_namespace: string;
+            ruby_package: string;
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            java_package: this.java_package,
+            java_outer_classname: this.java_outer_classname,
+            java_multiple_files: this.java_multiple_files,
+            java_generate_equals_and_hash: this.java_generate_equals_and_hash,
+            java_string_check_utf8: this.java_string_check_utf8,
+            optimize_for: this.optimize_for,
+            go_package: this.go_package,
+            cc_generic_services: this.cc_generic_services,
+            java_generic_services: this.java_generic_services,
+            py_generic_services: this.py_generic_services,
+            php_generic_services: this.php_generic_services,
+            deprecated: this.deprecated,
+            cc_enable_arenas: this.cc_enable_arenas,
+            objc_class_prefix: this.objc_class_prefix,
+            csharp_namespace: this.csharp_namespace,
+            swift_prefix: this.swift_prefix,
+            php_class_prefix: this.php_class_prefix,
+            php_namespace: this.php_namespace,
+            php_metadata_namespace: this.php_metadata_namespace,
+            ruby_package: this.ruby_package,
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -2714,7 +2591,7 @@ export class MessageOptions extends pb_1.Message {
         no_standard_descriptor_accessor?: boolean;
         deprecated?: boolean;
         map_entry?: boolean;
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): MessageOptions {
         const message = new MessageOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -2735,27 +2612,18 @@ export class MessageOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            message_set_wire_format?: boolean;
-            no_standard_descriptor_accessor?: boolean;
-            deprecated?: boolean;
-            map_entry?: boolean;
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.message_set_wire_format != null) {
-            data.message_set_wire_format = this.message_set_wire_format;
-        }
-        if (this.no_standard_descriptor_accessor != null) {
-            data.no_standard_descriptor_accessor = this.no_standard_descriptor_accessor;
-        }
-        if (this.deprecated != null) {
-            data.deprecated = this.deprecated;
-        }
-        if (this.map_entry != null) {
-            data.map_entry = this.map_entry;
-        }
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            message_set_wire_format: boolean;
+            no_standard_descriptor_accessor: boolean;
+            deprecated: boolean;
+            map_entry: boolean;
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            message_set_wire_format: this.message_set_wire_format,
+            no_standard_descriptor_accessor: this.no_standard_descriptor_accessor,
+            deprecated: this.deprecated,
+            map_entry: this.map_entry,
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -2910,7 +2778,7 @@ export class FieldOptions extends pb_1.Message {
         lazy?: boolean;
         deprecated?: boolean;
         weak?: boolean;
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): FieldOptions {
         const message = new FieldOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -2937,35 +2805,22 @@ export class FieldOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            ctype?: FieldOptions.CType;
-            packed?: boolean;
-            jstype?: FieldOptions.JSType;
-            lazy?: boolean;
-            deprecated?: boolean;
-            weak?: boolean;
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.ctype != null) {
-            data.ctype = this.ctype;
-        }
-        if (this.packed != null) {
-            data.packed = this.packed;
-        }
-        if (this.jstype != null) {
-            data.jstype = this.jstype;
-        }
-        if (this.lazy != null) {
-            data.lazy = this.lazy;
-        }
-        if (this.deprecated != null) {
-            data.deprecated = this.deprecated;
-        }
-        if (this.weak != null) {
-            data.weak = this.weak;
-        }
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            ctype: FieldOptions.CType;
+            packed: boolean;
+            jstype: FieldOptions.JSType;
+            lazy: boolean;
+            deprecated: boolean;
+            weak: boolean;
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            ctype: this.ctype,
+            packed: this.packed,
+            jstype: this.jstype,
+            lazy: this.lazy,
+            deprecated: this.deprecated,
+            weak: this.weak,
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -3058,7 +2913,7 @@ export class OneofOptions extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
     static fromObject(data: {
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): OneofOptions {
         const message = new OneofOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -3067,11 +2922,10 @@ export class OneofOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -3150,7 +3004,7 @@ export class EnumOptions extends pb_1.Message {
     static fromObject(data: {
         allow_alias?: boolean;
         deprecated?: boolean;
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): EnumOptions {
         const message = new EnumOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -3165,19 +3019,14 @@ export class EnumOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            allow_alias?: boolean;
-            deprecated?: boolean;
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.allow_alias != null) {
-            data.allow_alias = this.allow_alias;
-        }
-        if (this.deprecated != null) {
-            data.deprecated = this.deprecated;
-        }
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            allow_alias: boolean;
+            deprecated: boolean;
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            allow_alias: this.allow_alias,
+            deprecated: this.deprecated,
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -3252,7 +3101,7 @@ export class EnumValueOptions extends pb_1.Message {
     }
     static fromObject(data: {
         deprecated?: boolean;
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): EnumValueOptions {
         const message = new EnumValueOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -3264,15 +3113,12 @@ export class EnumValueOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            deprecated?: boolean;
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.deprecated != null) {
-            data.deprecated = this.deprecated;
-        }
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            deprecated: boolean;
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            deprecated: this.deprecated,
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -3342,7 +3188,7 @@ export class ServiceOptions extends pb_1.Message {
     }
     static fromObject(data: {
         deprecated?: boolean;
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): ServiceOptions {
         const message = new ServiceOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -3354,15 +3200,12 @@ export class ServiceOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            deprecated?: boolean;
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.deprecated != null) {
-            data.deprecated = this.deprecated;
-        }
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            deprecated: boolean;
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            deprecated: this.deprecated,
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -3446,7 +3289,7 @@ export class MethodOptions extends pb_1.Message {
     static fromObject(data: {
         deprecated?: boolean;
         idempotency_level?: MethodOptions.IdempotencyLevel;
-        uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
+        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
     }): MethodOptions {
         const message = new MethodOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
@@ -3461,19 +3304,14 @@ export class MethodOptions extends pb_1.Message {
     }
     toObject() {
         const data: {
-            deprecated?: boolean;
-            idempotency_level?: MethodOptions.IdempotencyLevel;
-            uninterpreted_option?: ReturnType<typeof UninterpretedOption.prototype.toObject>[];
-        } = {};
-        if (this.deprecated != null) {
-            data.deprecated = this.deprecated;
-        }
-        if (this.idempotency_level != null) {
-            data.idempotency_level = this.idempotency_level;
-        }
-        if (this.uninterpreted_option != null) {
-            data.uninterpreted_option = this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject());
-        }
+            deprecated: boolean;
+            idempotency_level: MethodOptions.IdempotencyLevel;
+            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
+        } = {
+            deprecated: this.deprecated,
+            idempotency_level: this.idempotency_level,
+            uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -3619,7 +3457,7 @@ export class UninterpretedOption extends pb_1.Message {
         return pb_1.Message.getField(this, 8) != null;
     }
     static fromObject(data: {
-        name?: ReturnType<typeof UninterpretedOption.NamePart.prototype.toObject>[];
+        name?: Parameters<typeof UninterpretedOption.NamePart.fromObject>[0][];
         identifier_value?: string;
         positive_int_value?: number;
         negative_int_value?: number;
@@ -3652,35 +3490,22 @@ export class UninterpretedOption extends pb_1.Message {
     }
     toObject() {
         const data: {
-            name?: ReturnType<typeof UninterpretedOption.NamePart.prototype.toObject>[];
-            identifier_value?: string;
-            positive_int_value?: number;
-            negative_int_value?: number;
-            double_value?: number;
-            string_value?: Uint8Array;
-            aggregate_value?: string;
-        } = {};
-        if (this.name != null) {
-            data.name = this.name.map((item: UninterpretedOption.NamePart) => item.toObject());
-        }
-        if (this.identifier_value != null) {
-            data.identifier_value = this.identifier_value;
-        }
-        if (this.positive_int_value != null) {
-            data.positive_int_value = this.positive_int_value;
-        }
-        if (this.negative_int_value != null) {
-            data.negative_int_value = this.negative_int_value;
-        }
-        if (this.double_value != null) {
-            data.double_value = this.double_value;
-        }
-        if (this.string_value != null) {
-            data.string_value = this.string_value;
-        }
-        if (this.aggregate_value != null) {
-            data.aggregate_value = this.aggregate_value;
-        }
+            name: Parameters<typeof UninterpretedOption.NamePart.fromObject>[0][];
+            identifier_value: string;
+            positive_int_value: number;
+            negative_int_value: number;
+            double_value: number;
+            string_value: Uint8Array;
+            aggregate_value: string;
+        } = {
+            name: this.name.map((item: UninterpretedOption.NamePart) => item.toObject()),
+            identifier_value: this.identifier_value,
+            positive_int_value: this.positive_int_value,
+            negative_int_value: this.negative_int_value,
+            double_value: this.double_value,
+            string_value: this.string_value,
+            aggregate_value: this.aggregate_value
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -3852,7 +3677,7 @@ export class SourceCodeInfo extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
     static fromObject(data: {
-        location?: ReturnType<typeof SourceCodeInfo.Location.prototype.toObject>[];
+        location?: Parameters<typeof SourceCodeInfo.Location.fromObject>[0][];
     }): SourceCodeInfo {
         const message = new SourceCodeInfo({
             location: data.location.map(item => SourceCodeInfo.Location.fromObject(item))
@@ -3861,11 +3686,10 @@ export class SourceCodeInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            location?: ReturnType<typeof SourceCodeInfo.Location.prototype.toObject>[];
-        } = {};
-        if (this.location != null) {
-            data.location = this.location.map((item: SourceCodeInfo.Location) => item.toObject());
-        }
+            location: Parameters<typeof SourceCodeInfo.Location.fromObject>[0][];
+        } = {
+            location: this.location.map((item: SourceCodeInfo.Location) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -3959,11 +3783,11 @@ export namespace SourceCodeInfo {
             pb_1.Message.setField(this, 6, value);
         }
         static fromObject(data: {
-            path: number[];
-            span: number[];
+            path?: number[];
+            span?: number[];
             leading_comments?: string;
             trailing_comments?: string;
-            leading_detached_comments: string[];
+            leading_detached_comments?: string[];
         }): Location {
             const message = new Location({
                 path: data.path,
@@ -3982,20 +3806,16 @@ export namespace SourceCodeInfo {
             const data: {
                 path: number[];
                 span: number[];
-                leading_comments?: string;
-                trailing_comments?: string;
+                leading_comments: string;
+                trailing_comments: string;
                 leading_detached_comments: string[];
             } = {
                 path: this.path,
                 span: this.span,
+                leading_comments: this.leading_comments,
+                trailing_comments: this.trailing_comments,
                 leading_detached_comments: this.leading_detached_comments
             };
-            if (this.leading_comments != null) {
-                data.leading_comments = this.leading_comments;
-            }
-            if (this.trailing_comments != null) {
-                data.trailing_comments = this.trailing_comments;
-            }
             return data;
         }
         serialize(): Uint8Array;
@@ -4067,7 +3887,7 @@ export class GeneratedCodeInfo extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
     static fromObject(data: {
-        annotation?: ReturnType<typeof GeneratedCodeInfo.Annotation.prototype.toObject>[];
+        annotation?: Parameters<typeof GeneratedCodeInfo.Annotation.fromObject>[0][];
     }): GeneratedCodeInfo {
         const message = new GeneratedCodeInfo({
             annotation: data.annotation.map(item => GeneratedCodeInfo.Annotation.fromObject(item))
@@ -4076,11 +3896,10 @@ export class GeneratedCodeInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            annotation?: ReturnType<typeof GeneratedCodeInfo.Annotation.prototype.toObject>[];
-        } = {};
-        if (this.annotation != null) {
-            data.annotation = this.annotation.map((item: GeneratedCodeInfo.Annotation) => item.toObject());
-        }
+            annotation: Parameters<typeof GeneratedCodeInfo.Annotation.fromObject>[0][];
+        } = {
+            annotation: this.annotation.map((item: GeneratedCodeInfo.Annotation) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -4171,7 +3990,7 @@ export namespace GeneratedCodeInfo {
             return pb_1.Message.getField(this, 4) != null;
         }
         static fromObject(data: {
-            path: number[];
+            path?: number[];
             source_file?: string;
             begin?: number;
             end?: number;
@@ -4193,21 +4012,15 @@ export namespace GeneratedCodeInfo {
         toObject() {
             const data: {
                 path: number[];
-                source_file?: string;
-                begin?: number;
-                end?: number;
+                source_file: string;
+                begin: number;
+                end: number;
             } = {
-                path: this.path
+                path: this.path,
+                source_file: this.source_file,
+                begin: this.begin,
+                end: this.end
             };
-            if (this.source_file != null) {
-                data.source_file = this.source_file;
-            }
-            if (this.begin != null) {
-                data.begin = this.begin;
-            }
-            if (this.end != null) {
-                data.end = this.end;
-            }
             return data;
         }
         serialize(): Uint8Array;

--- a/src/compiler/descriptor.ts
+++ b/src/compiler/descriptor.ts
@@ -4,6 +4,9 @@
  * source: descriptor.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class FileDescriptorSet extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -21,18 +24,14 @@ export class FileDescriptorSet extends pb_1.Message {
     set file(value: FileDescriptorProto[]) {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
-    static fromObject(data: {
-        file?: Parameters<typeof FileDescriptorProto.fromObject>[0][];
-    }): FileDescriptorSet {
+    static fromObject(data: RecursivePartial<FileDescriptorSet.AsObject>): FileDescriptorSet {
         const message = new FileDescriptorSet({
             file: data.file.map(item => FileDescriptorProto.fromObject(item))
         });
         return message;
     }
     toObject() {
-        const data: {
-            file: Parameters<typeof FileDescriptorProto.fromObject>[0][];
-        } = {
+        const data: FileDescriptorSet.AsObject = {
             file: this.file.map((item: FileDescriptorProto) => item.toObject())
         };
         return data;
@@ -66,6 +65,11 @@ export class FileDescriptorSet extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): FileDescriptorSet {
         return FileDescriptorSet.deserialize(bytes);
     }
+}
+export namespace FileDescriptorSet {
+    export type AsObject = {
+        file: FileDescriptorProto.AsObject[];
+    };
 }
 export class FileDescriptorProto extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -197,20 +201,7 @@ export class FileDescriptorProto extends pb_1.Message {
     get has_syntax() {
         return pb_1.Message.getField(this, 12) != null;
     }
-    static fromObject(data: {
-        name?: string;
-        package?: string;
-        dependency?: string[];
-        public_dependency?: number[];
-        weak_dependency?: number[];
-        message_type?: Parameters<typeof DescriptorProto.fromObject>[0][];
-        enum_type?: Parameters<typeof EnumDescriptorProto.fromObject>[0][];
-        service?: Parameters<typeof ServiceDescriptorProto.fromObject>[0][];
-        extension?: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
-        options?: Parameters<typeof FileOptions.fromObject>[0];
-        source_code_info?: Parameters<typeof SourceCodeInfo.fromObject>[0];
-        syntax?: string;
-    }): FileDescriptorProto {
+    static fromObject(data: RecursivePartial<FileDescriptorProto.AsObject>): FileDescriptorProto {
         const message = new FileDescriptorProto({
             dependency: data.dependency,
             public_dependency: data.public_dependency,
@@ -238,20 +229,7 @@ export class FileDescriptorProto extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: string;
-            package: string;
-            dependency: string[];
-            public_dependency: number[];
-            weak_dependency: number[];
-            message_type: Parameters<typeof DescriptorProto.fromObject>[0][];
-            enum_type: Parameters<typeof EnumDescriptorProto.fromObject>[0][];
-            service: Parameters<typeof ServiceDescriptorProto.fromObject>[0][];
-            extension: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
-            options?: Parameters<typeof FileOptions.fromObject>[0];
-            source_code_info?: Parameters<typeof SourceCodeInfo.fromObject>[0];
-            syntax: string;
-        } = {
+        const data: FileDescriptorProto.AsObject = {
             name: this.name,
             package: this.package,
             dependency: this.dependency,
@@ -356,6 +334,22 @@ export class FileDescriptorProto extends pb_1.Message {
         return FileDescriptorProto.deserialize(bytes);
     }
 }
+export namespace FileDescriptorProto {
+    export type AsObject = {
+        name: string;
+        package: string;
+        dependency: string[];
+        public_dependency: number[];
+        weak_dependency: number[];
+        message_type: DescriptorProto.AsObject[];
+        enum_type: EnumDescriptorProto.AsObject[];
+        service: ServiceDescriptorProto.AsObject[];
+        extension: FieldDescriptorProto.AsObject[];
+        options?: FileOptions.AsObject;
+        source_code_info?: SourceCodeInfo.AsObject;
+        syntax: string;
+    };
+}
 export class DescriptorProto extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -455,18 +449,7 @@ export class DescriptorProto extends pb_1.Message {
     set reserved_name(value: string[]) {
         pb_1.Message.setField(this, 10, value);
     }
-    static fromObject(data: {
-        name?: string;
-        field?: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
-        extension?: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
-        nested_type?: Parameters<typeof DescriptorProto.fromObject>[0][];
-        enum_type?: Parameters<typeof EnumDescriptorProto.fromObject>[0][];
-        extension_range?: Parameters<typeof DescriptorProto.ExtensionRange.fromObject>[0][];
-        oneof_decl?: Parameters<typeof OneofDescriptorProto.fromObject>[0][];
-        options?: Parameters<typeof MessageOptions.fromObject>[0];
-        reserved_range?: Parameters<typeof DescriptorProto.ReservedRange.fromObject>[0][];
-        reserved_name?: string[];
-    }): DescriptorProto {
+    static fromObject(data: RecursivePartial<DescriptorProto.AsObject>): DescriptorProto {
         const message = new DescriptorProto({
             field: data.field.map(item => FieldDescriptorProto.fromObject(item)),
             extension: data.extension.map(item => FieldDescriptorProto.fromObject(item)),
@@ -486,18 +469,7 @@ export class DescriptorProto extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: string;
-            field: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
-            extension: Parameters<typeof FieldDescriptorProto.fromObject>[0][];
-            nested_type: Parameters<typeof DescriptorProto.fromObject>[0][];
-            enum_type: Parameters<typeof EnumDescriptorProto.fromObject>[0][];
-            extension_range: Parameters<typeof DescriptorProto.ExtensionRange.fromObject>[0][];
-            oneof_decl: Parameters<typeof OneofDescriptorProto.fromObject>[0][];
-            options?: Parameters<typeof MessageOptions.fromObject>[0];
-            reserved_range: Parameters<typeof DescriptorProto.ReservedRange.fromObject>[0][];
-            reserved_name: string[];
-        } = {
+        const data: DescriptorProto.AsObject = {
             name: this.name,
             field: this.field.map((item: FieldDescriptorProto) => item.toObject()),
             extension: this.extension.map((item: FieldDescriptorProto) => item.toObject()),
@@ -589,6 +561,18 @@ export class DescriptorProto extends pb_1.Message {
     }
 }
 export namespace DescriptorProto {
+    export type AsObject = {
+        name: string;
+        field: FieldDescriptorProto.AsObject[];
+        extension: FieldDescriptorProto.AsObject[];
+        nested_type: DescriptorProto.AsObject[];
+        enum_type: EnumDescriptorProto.AsObject[];
+        extension_range: DescriptorProto.ExtensionRange.AsObject[];
+        oneof_decl: OneofDescriptorProto.AsObject[];
+        options?: MessageOptions.AsObject;
+        reserved_range: DescriptorProto.ReservedRange.AsObject[];
+        reserved_name: string[];
+    };
     export class ExtensionRange extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -637,11 +621,7 @@ export namespace DescriptorProto {
         get has_options() {
             return pb_1.Message.getField(this, 3) != null;
         }
-        static fromObject(data: {
-            start?: number;
-            end?: number;
-            options?: Parameters<typeof ExtensionRangeOptions.fromObject>[0];
-        }): ExtensionRange {
+        static fromObject(data: RecursivePartial<ExtensionRange.AsObject>): ExtensionRange {
             const message = new ExtensionRange({});
             if (data.start != null) {
                 message.start = data.start;
@@ -655,11 +635,7 @@ export namespace DescriptorProto {
             return message;
         }
         toObject() {
-            const data: {
-                start: number;
-                end: number;
-                options?: Parameters<typeof ExtensionRangeOptions.fromObject>[0];
-            } = {
+            const data: ExtensionRange.AsObject = {
                 start: this.start,
                 end: this.end
             };
@@ -708,6 +684,13 @@ export namespace DescriptorProto {
             return ExtensionRange.deserialize(bytes);
         }
     }
+    export namespace ExtensionRange {
+        export type AsObject = {
+            start: number;
+            end: number;
+            options?: ExtensionRangeOptions.AsObject;
+        };
+    }
     export class ReservedRange extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -743,10 +726,7 @@ export namespace DescriptorProto {
         get has_end() {
             return pb_1.Message.getField(this, 2) != null;
         }
-        static fromObject(data: {
-            start?: number;
-            end?: number;
-        }): ReservedRange {
+        static fromObject(data: RecursivePartial<ReservedRange.AsObject>): ReservedRange {
             const message = new ReservedRange({});
             if (data.start != null) {
                 message.start = data.start;
@@ -757,10 +737,7 @@ export namespace DescriptorProto {
             return message;
         }
         toObject() {
-            const data: {
-                start: number;
-                end: number;
-            } = {
+            const data: ReservedRange.AsObject = {
                 start: this.start,
                 end: this.end
             };
@@ -801,6 +778,12 @@ export namespace DescriptorProto {
             return ReservedRange.deserialize(bytes);
         }
     }
+    export namespace ReservedRange {
+        export type AsObject = {
+            start: number;
+            end: number;
+        };
+    }
 }
 export class ExtensionRangeOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -819,18 +802,14 @@ export class ExtensionRangeOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): ExtensionRangeOptions {
+    static fromObject(data: RecursivePartial<ExtensionRangeOptions.AsObject>): ExtensionRangeOptions {
         const message = new ExtensionRangeOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
         return message;
     }
     toObject() {
-        const data: {
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: ExtensionRangeOptions.AsObject = {
             uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
         };
         return data;
@@ -864,6 +843,11 @@ export class ExtensionRangeOptions extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): ExtensionRangeOptions {
         return ExtensionRangeOptions.deserialize(bytes);
     }
+}
+export namespace ExtensionRangeOptions {
+    export type AsObject = {
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
 }
 export class FieldDescriptorProto extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -1017,19 +1001,7 @@ export class FieldDescriptorProto extends pb_1.Message {
     get has_proto3_optional() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        name?: string;
-        number?: number;
-        label?: FieldDescriptorProto.Label;
-        type?: FieldDescriptorProto.Type;
-        type_name?: string;
-        extendee?: string;
-        default_value?: string;
-        oneof_index?: number;
-        json_name?: string;
-        options?: Parameters<typeof FieldOptions.fromObject>[0];
-        proto3_optional?: boolean;
-    }): FieldDescriptorProto {
+    static fromObject(data: RecursivePartial<FieldDescriptorProto.AsObject>): FieldDescriptorProto {
         const message = new FieldDescriptorProto({});
         if (data.name != null) {
             message.name = data.name;
@@ -1067,19 +1039,7 @@ export class FieldDescriptorProto extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: string;
-            number: number;
-            label: FieldDescriptorProto.Label;
-            type: FieldDescriptorProto.Type;
-            type_name: string;
-            extendee: string;
-            default_value: string;
-            oneof_index: number;
-            json_name: string;
-            options?: Parameters<typeof FieldOptions.fromObject>[0];
-            proto3_optional: boolean;
-        } = {
+        const data: FieldDescriptorProto.AsObject = {
             name: this.name,
             number: this.number,
             label: this.label,
@@ -1177,6 +1137,19 @@ export class FieldDescriptorProto extends pb_1.Message {
     }
 }
 export namespace FieldDescriptorProto {
+    export type AsObject = {
+        name: string;
+        number: number;
+        label: FieldDescriptorProto.Label;
+        type: FieldDescriptorProto.Type;
+        type_name: string;
+        extendee: string;
+        default_value: string;
+        oneof_index: number;
+        json_name: string;
+        options?: FieldOptions.AsObject;
+        proto3_optional: boolean;
+    };
     export enum Type {
         TYPE_DOUBLE = 1,
         TYPE_FLOAT = 2,
@@ -1238,10 +1211,7 @@ export class OneofDescriptorProto extends pb_1.Message {
     get has_options() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        name?: string;
-        options?: Parameters<typeof OneofOptions.fromObject>[0];
-    }): OneofDescriptorProto {
+    static fromObject(data: RecursivePartial<OneofDescriptorProto.AsObject>): OneofDescriptorProto {
         const message = new OneofDescriptorProto({});
         if (data.name != null) {
             message.name = data.name;
@@ -1252,10 +1222,7 @@ export class OneofDescriptorProto extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: string;
-            options?: Parameters<typeof OneofOptions.fromObject>[0];
-        } = {
+        const data: OneofDescriptorProto.AsObject = {
             name: this.name
         };
         if (this.options != null) {
@@ -1297,6 +1264,12 @@ export class OneofDescriptorProto extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): OneofDescriptorProto {
         return OneofDescriptorProto.deserialize(bytes);
     }
+}
+export namespace OneofDescriptorProto {
+    export type AsObject = {
+        name: string;
+        options?: OneofOptions.AsObject;
+    };
 }
 export class EnumDescriptorProto extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -1357,13 +1330,7 @@ export class EnumDescriptorProto extends pb_1.Message {
     set reserved_name(value: string[]) {
         pb_1.Message.setField(this, 5, value);
     }
-    static fromObject(data: {
-        name?: string;
-        value?: Parameters<typeof EnumValueDescriptorProto.fromObject>[0][];
-        options?: Parameters<typeof EnumOptions.fromObject>[0];
-        reserved_range?: Parameters<typeof EnumDescriptorProto.EnumReservedRange.fromObject>[0][];
-        reserved_name?: string[];
-    }): EnumDescriptorProto {
+    static fromObject(data: RecursivePartial<EnumDescriptorProto.AsObject>): EnumDescriptorProto {
         const message = new EnumDescriptorProto({
             value: data.value.map(item => EnumValueDescriptorProto.fromObject(item)),
             reserved_range: data.reserved_range.map(item => EnumDescriptorProto.EnumReservedRange.fromObject(item)),
@@ -1378,13 +1345,7 @@ export class EnumDescriptorProto extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: string;
-            value: Parameters<typeof EnumValueDescriptorProto.fromObject>[0][];
-            options?: Parameters<typeof EnumOptions.fromObject>[0];
-            reserved_range: Parameters<typeof EnumDescriptorProto.EnumReservedRange.fromObject>[0][];
-            reserved_name: string[];
-        } = {
+        const data: EnumDescriptorProto.AsObject = {
             name: this.name,
             value: this.value.map((item: EnumValueDescriptorProto) => item.toObject()),
             reserved_range: this.reserved_range.map((item: EnumDescriptorProto.EnumReservedRange) => item.toObject()),
@@ -1446,6 +1407,13 @@ export class EnumDescriptorProto extends pb_1.Message {
     }
 }
 export namespace EnumDescriptorProto {
+    export type AsObject = {
+        name: string;
+        value: EnumValueDescriptorProto.AsObject[];
+        options?: EnumOptions.AsObject;
+        reserved_range: EnumDescriptorProto.EnumReservedRange.AsObject[];
+        reserved_name: string[];
+    };
     export class EnumReservedRange extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -1481,10 +1449,7 @@ export namespace EnumDescriptorProto {
         get has_end() {
             return pb_1.Message.getField(this, 2) != null;
         }
-        static fromObject(data: {
-            start?: number;
-            end?: number;
-        }): EnumReservedRange {
+        static fromObject(data: RecursivePartial<EnumReservedRange.AsObject>): EnumReservedRange {
             const message = new EnumReservedRange({});
             if (data.start != null) {
                 message.start = data.start;
@@ -1495,10 +1460,7 @@ export namespace EnumDescriptorProto {
             return message;
         }
         toObject() {
-            const data: {
-                start: number;
-                end: number;
-            } = {
+            const data: EnumReservedRange.AsObject = {
                 start: this.start,
                 end: this.end
             };
@@ -1538,6 +1500,12 @@ export namespace EnumDescriptorProto {
         static deserializeBinary(bytes: Uint8Array): EnumReservedRange {
             return EnumReservedRange.deserialize(bytes);
         }
+    }
+    export namespace EnumReservedRange {
+        export type AsObject = {
+            start: number;
+            end: number;
+        };
     }
 }
 export class EnumValueDescriptorProto extends pb_1.Message {
@@ -1588,11 +1556,7 @@ export class EnumValueDescriptorProto extends pb_1.Message {
     get has_options() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        name?: string;
-        number?: number;
-        options?: Parameters<typeof EnumValueOptions.fromObject>[0];
-    }): EnumValueDescriptorProto {
+    static fromObject(data: RecursivePartial<EnumValueDescriptorProto.AsObject>): EnumValueDescriptorProto {
         const message = new EnumValueDescriptorProto({});
         if (data.name != null) {
             message.name = data.name;
@@ -1606,11 +1570,7 @@ export class EnumValueDescriptorProto extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: string;
-            number: number;
-            options?: Parameters<typeof EnumValueOptions.fromObject>[0];
-        } = {
+        const data: EnumValueDescriptorProto.AsObject = {
             name: this.name,
             number: this.number
         };
@@ -1659,6 +1619,13 @@ export class EnumValueDescriptorProto extends pb_1.Message {
         return EnumValueDescriptorProto.deserialize(bytes);
     }
 }
+export namespace EnumValueDescriptorProto {
+    export type AsObject = {
+        name: string;
+        number: number;
+        options?: EnumValueOptions.AsObject;
+    };
+}
 export class ServiceDescriptorProto extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -1702,11 +1669,7 @@ export class ServiceDescriptorProto extends pb_1.Message {
     get has_options() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        name?: string;
-        method?: Parameters<typeof MethodDescriptorProto.fromObject>[0][];
-        options?: Parameters<typeof ServiceOptions.fromObject>[0];
-    }): ServiceDescriptorProto {
+    static fromObject(data: RecursivePartial<ServiceDescriptorProto.AsObject>): ServiceDescriptorProto {
         const message = new ServiceDescriptorProto({
             method: data.method.map(item => MethodDescriptorProto.fromObject(item))
         });
@@ -1719,11 +1682,7 @@ export class ServiceDescriptorProto extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: string;
-            method: Parameters<typeof MethodDescriptorProto.fromObject>[0][];
-            options?: Parameters<typeof ServiceOptions.fromObject>[0];
-        } = {
+        const data: ServiceDescriptorProto.AsObject = {
             name: this.name,
             method: this.method.map((item: MethodDescriptorProto) => item.toObject())
         };
@@ -1771,6 +1730,13 @@ export class ServiceDescriptorProto extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): ServiceDescriptorProto {
         return ServiceDescriptorProto.deserialize(bytes);
     }
+}
+export namespace ServiceDescriptorProto {
+    export type AsObject = {
+        name: string;
+        method: MethodDescriptorProto.AsObject[];
+        options?: ServiceOptions.AsObject;
+    };
 }
 export class MethodDescriptorProto extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -1859,14 +1825,7 @@ export class MethodDescriptorProto extends pb_1.Message {
     get has_server_streaming() {
         return pb_1.Message.getField(this, 6) != null;
     }
-    static fromObject(data: {
-        name?: string;
-        input_type?: string;
-        output_type?: string;
-        options?: Parameters<typeof MethodOptions.fromObject>[0];
-        client_streaming?: boolean;
-        server_streaming?: boolean;
-    }): MethodDescriptorProto {
+    static fromObject(data: RecursivePartial<MethodDescriptorProto.AsObject>): MethodDescriptorProto {
         const message = new MethodDescriptorProto({});
         if (data.name != null) {
             message.name = data.name;
@@ -1889,14 +1848,7 @@ export class MethodDescriptorProto extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: string;
-            input_type: string;
-            output_type: string;
-            options?: Parameters<typeof MethodOptions.fromObject>[0];
-            client_streaming: boolean;
-            server_streaming: boolean;
-        } = {
+        const data: MethodDescriptorProto.AsObject = {
             name: this.name,
             input_type: this.input_type,
             output_type: this.output_type,
@@ -1962,6 +1914,16 @@ export class MethodDescriptorProto extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): MethodDescriptorProto {
         return MethodDescriptorProto.deserialize(bytes);
     }
+}
+export namespace MethodDescriptorProto {
+    export type AsObject = {
+        name: string;
+        input_type: string;
+        output_type: string;
+        options?: MethodOptions.AsObject;
+        client_streaming: boolean;
+        server_streaming: boolean;
+    };
 }
 export class FileOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -2244,29 +2206,7 @@ export class FileOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        java_package?: string;
-        java_outer_classname?: string;
-        java_multiple_files?: boolean;
-        java_generate_equals_and_hash?: boolean;
-        java_string_check_utf8?: boolean;
-        optimize_for?: FileOptions.OptimizeMode;
-        go_package?: string;
-        cc_generic_services?: boolean;
-        java_generic_services?: boolean;
-        py_generic_services?: boolean;
-        php_generic_services?: boolean;
-        deprecated?: boolean;
-        cc_enable_arenas?: boolean;
-        objc_class_prefix?: string;
-        csharp_namespace?: string;
-        swift_prefix?: string;
-        php_class_prefix?: string;
-        php_namespace?: string;
-        php_metadata_namespace?: string;
-        ruby_package?: string;
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): FileOptions {
+    static fromObject(data: RecursivePartial<FileOptions.AsObject>): FileOptions {
         const message = new FileOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -2333,29 +2273,7 @@ export class FileOptions extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            java_package: string;
-            java_outer_classname: string;
-            java_multiple_files: boolean;
-            java_generate_equals_and_hash: boolean;
-            java_string_check_utf8: boolean;
-            optimize_for: FileOptions.OptimizeMode;
-            go_package: string;
-            cc_generic_services: boolean;
-            java_generic_services: boolean;
-            py_generic_services: boolean;
-            php_generic_services: boolean;
-            deprecated: boolean;
-            cc_enable_arenas: boolean;
-            objc_class_prefix: string;
-            csharp_namespace: string;
-            swift_prefix: string;
-            php_class_prefix: string;
-            php_namespace: string;
-            php_metadata_namespace: string;
-            ruby_package: string;
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: FileOptions.AsObject = {
             java_package: this.java_package,
             java_outer_classname: this.java_outer_classname,
             java_multiple_files: this.java_multiple_files,
@@ -2511,6 +2429,29 @@ export class FileOptions extends pb_1.Message {
     }
 }
 export namespace FileOptions {
+    export type AsObject = {
+        java_package: string;
+        java_outer_classname: string;
+        java_multiple_files: boolean;
+        java_generate_equals_and_hash: boolean;
+        java_string_check_utf8: boolean;
+        optimize_for: FileOptions.OptimizeMode;
+        go_package: string;
+        cc_generic_services: boolean;
+        java_generic_services: boolean;
+        py_generic_services: boolean;
+        php_generic_services: boolean;
+        deprecated: boolean;
+        cc_enable_arenas: boolean;
+        objc_class_prefix: string;
+        csharp_namespace: string;
+        swift_prefix: string;
+        php_class_prefix: string;
+        php_namespace: string;
+        php_metadata_namespace: string;
+        ruby_package: string;
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
     export enum OptimizeMode {
         SPEED = 1,
         CODE_SIZE = 2,
@@ -2586,13 +2527,7 @@ export class MessageOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        message_set_wire_format?: boolean;
-        no_standard_descriptor_accessor?: boolean;
-        deprecated?: boolean;
-        map_entry?: boolean;
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): MessageOptions {
+    static fromObject(data: RecursivePartial<MessageOptions.AsObject>): MessageOptions {
         const message = new MessageOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -2611,13 +2546,7 @@ export class MessageOptions extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            message_set_wire_format: boolean;
-            no_standard_descriptor_accessor: boolean;
-            deprecated: boolean;
-            map_entry: boolean;
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: MessageOptions.AsObject = {
             message_set_wire_format: this.message_set_wire_format,
             no_standard_descriptor_accessor: this.no_standard_descriptor_accessor,
             deprecated: this.deprecated,
@@ -2675,6 +2604,15 @@ export class MessageOptions extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): MessageOptions {
         return MessageOptions.deserialize(bytes);
     }
+}
+export namespace MessageOptions {
+    export type AsObject = {
+        message_set_wire_format: boolean;
+        no_standard_descriptor_accessor: boolean;
+        deprecated: boolean;
+        map_entry: boolean;
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
 }
 export class FieldOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -2771,15 +2709,7 @@ export class FieldOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        ctype?: FieldOptions.CType;
-        packed?: boolean;
-        jstype?: FieldOptions.JSType;
-        lazy?: boolean;
-        deprecated?: boolean;
-        weak?: boolean;
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): FieldOptions {
+    static fromObject(data: RecursivePartial<FieldOptions.AsObject>): FieldOptions {
         const message = new FieldOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -2804,15 +2734,7 @@ export class FieldOptions extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            ctype: FieldOptions.CType;
-            packed: boolean;
-            jstype: FieldOptions.JSType;
-            lazy: boolean;
-            deprecated: boolean;
-            weak: boolean;
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: FieldOptions.AsObject = {
             ctype: this.ctype,
             packed: this.packed,
             jstype: this.jstype,
@@ -2884,6 +2806,15 @@ export class FieldOptions extends pb_1.Message {
     }
 }
 export namespace FieldOptions {
+    export type AsObject = {
+        ctype: FieldOptions.CType;
+        packed: boolean;
+        jstype: FieldOptions.JSType;
+        lazy: boolean;
+        deprecated: boolean;
+        weak: boolean;
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
     export enum CType {
         STRING = 0,
         CORD = 1,
@@ -2912,18 +2843,14 @@ export class OneofOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): OneofOptions {
+    static fromObject(data: RecursivePartial<OneofOptions.AsObject>): OneofOptions {
         const message = new OneofOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
         return message;
     }
     toObject() {
-        const data: {
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: OneofOptions.AsObject = {
             uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
         };
         return data;
@@ -2957,6 +2884,11 @@ export class OneofOptions extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): OneofOptions {
         return OneofOptions.deserialize(bytes);
     }
+}
+export namespace OneofOptions {
+    export type AsObject = {
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
 }
 export class EnumOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -3001,11 +2933,7 @@ export class EnumOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        allow_alias?: boolean;
-        deprecated?: boolean;
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): EnumOptions {
+    static fromObject(data: RecursivePartial<EnumOptions.AsObject>): EnumOptions {
         const message = new EnumOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -3018,11 +2946,7 @@ export class EnumOptions extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            allow_alias: boolean;
-            deprecated: boolean;
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: EnumOptions.AsObject = {
             allow_alias: this.allow_alias,
             deprecated: this.deprecated,
             uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
@@ -3069,6 +2993,13 @@ export class EnumOptions extends pb_1.Message {
         return EnumOptions.deserialize(bytes);
     }
 }
+export namespace EnumOptions {
+    export type AsObject = {
+        allow_alias: boolean;
+        deprecated: boolean;
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
+}
 export class EnumValueOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -3099,10 +3030,7 @@ export class EnumValueOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        deprecated?: boolean;
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): EnumValueOptions {
+    static fromObject(data: RecursivePartial<EnumValueOptions.AsObject>): EnumValueOptions {
         const message = new EnumValueOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -3112,10 +3040,7 @@ export class EnumValueOptions extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            deprecated: boolean;
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: EnumValueOptions.AsObject = {
             deprecated: this.deprecated,
             uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
         };
@@ -3156,6 +3081,12 @@ export class EnumValueOptions extends pb_1.Message {
         return EnumValueOptions.deserialize(bytes);
     }
 }
+export namespace EnumValueOptions {
+    export type AsObject = {
+        deprecated: boolean;
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
+}
 export class ServiceOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -3186,10 +3117,7 @@ export class ServiceOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        deprecated?: boolean;
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): ServiceOptions {
+    static fromObject(data: RecursivePartial<ServiceOptions.AsObject>): ServiceOptions {
         const message = new ServiceOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -3199,10 +3127,7 @@ export class ServiceOptions extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            deprecated: boolean;
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: ServiceOptions.AsObject = {
             deprecated: this.deprecated,
             uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
         };
@@ -3242,6 +3167,12 @@ export class ServiceOptions extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): ServiceOptions {
         return ServiceOptions.deserialize(bytes);
     }
+}
+export namespace ServiceOptions {
+    export type AsObject = {
+        deprecated: boolean;
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
 }
 export class MethodOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -3286,11 +3217,7 @@ export class MethodOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: {
-        deprecated?: boolean;
-        idempotency_level?: MethodOptions.IdempotencyLevel;
-        uninterpreted_option?: Parameters<typeof UninterpretedOption.fromObject>[0][];
-    }): MethodOptions {
+    static fromObject(data: RecursivePartial<MethodOptions.AsObject>): MethodOptions {
         const message = new MethodOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -3303,11 +3230,7 @@ export class MethodOptions extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            deprecated: boolean;
-            idempotency_level: MethodOptions.IdempotencyLevel;
-            uninterpreted_option: Parameters<typeof UninterpretedOption.fromObject>[0][];
-        } = {
+        const data: MethodOptions.AsObject = {
             deprecated: this.deprecated,
             idempotency_level: this.idempotency_level,
             uninterpreted_option: this.uninterpreted_option.map((item: UninterpretedOption) => item.toObject())
@@ -3355,6 +3278,11 @@ export class MethodOptions extends pb_1.Message {
     }
 }
 export namespace MethodOptions {
+    export type AsObject = {
+        deprecated: boolean;
+        idempotency_level: MethodOptions.IdempotencyLevel;
+        uninterpreted_option: UninterpretedOption.AsObject[];
+    };
     export enum IdempotencyLevel {
         IDEMPOTENCY_UNKNOWN = 0,
         NO_SIDE_EFFECTS = 1,
@@ -3456,15 +3384,7 @@ export class UninterpretedOption extends pb_1.Message {
     get has_aggregate_value() {
         return pb_1.Message.getField(this, 8) != null;
     }
-    static fromObject(data: {
-        name?: Parameters<typeof UninterpretedOption.NamePart.fromObject>[0][];
-        identifier_value?: string;
-        positive_int_value?: number;
-        negative_int_value?: number;
-        double_value?: number;
-        string_value?: Uint8Array;
-        aggregate_value?: string;
-    }): UninterpretedOption {
+    static fromObject(data: RecursivePartial<UninterpretedOption.AsObject>): UninterpretedOption {
         const message = new UninterpretedOption({
             name: data.name.map(item => UninterpretedOption.NamePart.fromObject(item))
         });
@@ -3489,15 +3409,7 @@ export class UninterpretedOption extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            name: Parameters<typeof UninterpretedOption.NamePart.fromObject>[0][];
-            identifier_value: string;
-            positive_int_value: number;
-            negative_int_value: number;
-            double_value: number;
-            string_value: Uint8Array;
-            aggregate_value: string;
-        } = {
+        const data: UninterpretedOption.AsObject = {
             name: this.name.map((item: UninterpretedOption.NamePart) => item.toObject()),
             identifier_value: this.identifier_value,
             positive_int_value: this.positive_int_value,
@@ -3569,6 +3481,15 @@ export class UninterpretedOption extends pb_1.Message {
     }
 }
 export namespace UninterpretedOption {
+    export type AsObject = {
+        name: UninterpretedOption.NamePart.AsObject[];
+        identifier_value: string;
+        positive_int_value: number;
+        negative_int_value: number;
+        double_value: number;
+        string_value: Uint8Array;
+        aggregate_value: string;
+    };
     export class NamePart extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -3600,10 +3521,7 @@ export namespace UninterpretedOption {
         get has_is_extension() {
             return pb_1.Message.getField(this, 2) != null;
         }
-        static fromObject(data: {
-            name_part?: string;
-            is_extension?: boolean;
-        }): NamePart {
+        static fromObject(data: RecursivePartial<NamePart.AsObject>): NamePart {
             const message = new NamePart({
                 name_part: data.name_part,
                 is_extension: data.is_extension
@@ -3611,10 +3529,7 @@ export namespace UninterpretedOption {
             return message;
         }
         toObject() {
-            const data: {
-                name_part?: string;
-                is_extension?: boolean;
-            } = {};
+            const data: NamePart.AsObject = {};
             if (this.name_part != null) {
                 data.name_part = this.name_part;
             }
@@ -3658,6 +3573,12 @@ export namespace UninterpretedOption {
             return NamePart.deserialize(bytes);
         }
     }
+    export namespace NamePart {
+        export type AsObject = {
+            name_part?: string;
+            is_extension?: boolean;
+        };
+    }
 }
 export class SourceCodeInfo extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -3676,18 +3597,14 @@ export class SourceCodeInfo extends pb_1.Message {
     set location(value: SourceCodeInfo.Location[]) {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
-    static fromObject(data: {
-        location?: Parameters<typeof SourceCodeInfo.Location.fromObject>[0][];
-    }): SourceCodeInfo {
+    static fromObject(data: RecursivePartial<SourceCodeInfo.AsObject>): SourceCodeInfo {
         const message = new SourceCodeInfo({
             location: data.location.map(item => SourceCodeInfo.Location.fromObject(item))
         });
         return message;
     }
     toObject() {
-        const data: {
-            location: Parameters<typeof SourceCodeInfo.Location.fromObject>[0][];
-        } = {
+        const data: SourceCodeInfo.AsObject = {
             location: this.location.map((item: SourceCodeInfo.Location) => item.toObject())
         };
         return data;
@@ -3723,6 +3640,9 @@ export class SourceCodeInfo extends pb_1.Message {
     }
 }
 export namespace SourceCodeInfo {
+    export type AsObject = {
+        location: SourceCodeInfo.Location.AsObject[];
+    };
     export class Location extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -3782,13 +3702,7 @@ export namespace SourceCodeInfo {
         set leading_detached_comments(value: string[]) {
             pb_1.Message.setField(this, 6, value);
         }
-        static fromObject(data: {
-            path?: number[];
-            span?: number[];
-            leading_comments?: string;
-            trailing_comments?: string;
-            leading_detached_comments?: string[];
-        }): Location {
+        static fromObject(data: RecursivePartial<Location.AsObject>): Location {
             const message = new Location({
                 path: data.path,
                 span: data.span,
@@ -3803,13 +3717,7 @@ export namespace SourceCodeInfo {
             return message;
         }
         toObject() {
-            const data: {
-                path: number[];
-                span: number[];
-                leading_comments: string;
-                trailing_comments: string;
-                leading_detached_comments: string[];
-            } = {
+            const data: Location.AsObject = {
                 path: this.path,
                 span: this.span,
                 leading_comments: this.leading_comments,
@@ -3868,6 +3776,15 @@ export namespace SourceCodeInfo {
             return Location.deserialize(bytes);
         }
     }
+    export namespace Location {
+        export type AsObject = {
+            path: number[];
+            span: number[];
+            leading_comments: string;
+            trailing_comments: string;
+            leading_detached_comments: string[];
+        };
+    }
 }
 export class GeneratedCodeInfo extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -3886,18 +3803,14 @@ export class GeneratedCodeInfo extends pb_1.Message {
     set annotation(value: GeneratedCodeInfo.Annotation[]) {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
-    static fromObject(data: {
-        annotation?: Parameters<typeof GeneratedCodeInfo.Annotation.fromObject>[0][];
-    }): GeneratedCodeInfo {
+    static fromObject(data: RecursivePartial<GeneratedCodeInfo.AsObject>): GeneratedCodeInfo {
         const message = new GeneratedCodeInfo({
             annotation: data.annotation.map(item => GeneratedCodeInfo.Annotation.fromObject(item))
         });
         return message;
     }
     toObject() {
-        const data: {
-            annotation: Parameters<typeof GeneratedCodeInfo.Annotation.fromObject>[0][];
-        } = {
+        const data: GeneratedCodeInfo.AsObject = {
             annotation: this.annotation.map((item: GeneratedCodeInfo.Annotation) => item.toObject())
         };
         return data;
@@ -3933,6 +3846,9 @@ export class GeneratedCodeInfo extends pb_1.Message {
     }
 }
 export namespace GeneratedCodeInfo {
+    export type AsObject = {
+        annotation: GeneratedCodeInfo.Annotation.AsObject[];
+    };
     export class Annotation extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -3989,12 +3905,7 @@ export namespace GeneratedCodeInfo {
         get has_end() {
             return pb_1.Message.getField(this, 4) != null;
         }
-        static fromObject(data: {
-            path?: number[];
-            source_file?: string;
-            begin?: number;
-            end?: number;
-        }): Annotation {
+        static fromObject(data: RecursivePartial<Annotation.AsObject>): Annotation {
             const message = new Annotation({
                 path: data.path
             });
@@ -4010,12 +3921,7 @@ export namespace GeneratedCodeInfo {
             return message;
         }
         toObject() {
-            const data: {
-                path: number[];
-                source_file: string;
-                begin: number;
-                end: number;
-            } = {
+            const data: Annotation.AsObject = {
                 path: this.path,
                 source_file: this.source_file,
                 begin: this.begin,
@@ -4067,5 +3973,13 @@ export namespace GeneratedCodeInfo {
         static deserializeBinary(bytes: Uint8Array): Annotation {
             return Annotation.deserialize(bytes);
         }
+    }
+    export namespace Annotation {
+        export type AsObject = {
+            path: number[];
+            source_file: string;
+            begin: number;
+            end: number;
+        };
     }
 }

--- a/src/compiler/descriptor.ts
+++ b/src/compiler/descriptor.ts
@@ -175,18 +175,18 @@ export class FileDescriptorProto extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 7, value);
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, FileOptions, 8) as FileOptions;
+        return pb_1.Message.getWrapperField(this, FileOptions, 8) as FileOptions | undefined | null;
     }
-    set options(value: FileOptions) {
+    set options(value: FileOptions | undefined | null) {
         pb_1.Message.setWrapperField(this, 8, value);
     }
     get has_options() {
         return pb_1.Message.getField(this, 8) != null;
     }
     get source_code_info() {
-        return pb_1.Message.getWrapperField(this, SourceCodeInfo, 9) as SourceCodeInfo;
+        return pb_1.Message.getWrapperField(this, SourceCodeInfo, 9) as SourceCodeInfo | undefined | null;
     }
-    set source_code_info(value: SourceCodeInfo) {
+    set source_code_info(value: SourceCodeInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 9, value);
     }
     get has_source_code_info() {
@@ -429,9 +429,9 @@ export class DescriptorProto extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 8, value);
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, MessageOptions, 7) as MessageOptions;
+        return pb_1.Message.getWrapperField(this, MessageOptions, 7) as MessageOptions | undefined | null;
     }
-    set options(value: MessageOptions) {
+    set options(value: MessageOptions | undefined | null) {
         pb_1.Message.setWrapperField(this, 7, value);
     }
     get has_options() {
@@ -613,9 +613,9 @@ export namespace DescriptorProto {
             return pb_1.Message.getField(this, 2) != null;
         }
         get options() {
-            return pb_1.Message.getWrapperField(this, ExtensionRangeOptions, 3) as ExtensionRangeOptions;
+            return pb_1.Message.getWrapperField(this, ExtensionRangeOptions, 3) as ExtensionRangeOptions | undefined | null;
         }
-        set options(value: ExtensionRangeOptions) {
+        set options(value: ExtensionRangeOptions | undefined | null) {
             pb_1.Message.setWrapperField(this, 3, value);
         }
         get has_options() {
@@ -984,9 +984,9 @@ export class FieldDescriptorProto extends pb_1.Message {
         return pb_1.Message.getField(this, 10) != null;
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, FieldOptions, 8) as FieldOptions;
+        return pb_1.Message.getWrapperField(this, FieldOptions, 8) as FieldOptions | undefined | null;
     }
-    set options(value: FieldOptions) {
+    set options(value: FieldOptions | undefined | null) {
         pb_1.Message.setWrapperField(this, 8, value);
     }
     get has_options() {
@@ -1203,9 +1203,9 @@ export class OneofDescriptorProto extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, OneofOptions, 2) as OneofOptions;
+        return pb_1.Message.getWrapperField(this, OneofOptions, 2) as OneofOptions | undefined | null;
     }
-    set options(value: OneofOptions) {
+    set options(value: OneofOptions | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_options() {
@@ -1310,9 +1310,9 @@ export class EnumDescriptorProto extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, EnumOptions, 3) as EnumOptions;
+        return pb_1.Message.getWrapperField(this, EnumOptions, 3) as EnumOptions | undefined | null;
     }
-    set options(value: EnumOptions) {
+    set options(value: EnumOptions | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_options() {
@@ -1548,9 +1548,9 @@ export class EnumValueDescriptorProto extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, EnumValueOptions, 3) as EnumValueOptions;
+        return pb_1.Message.getWrapperField(this, EnumValueOptions, 3) as EnumValueOptions | undefined | null;
     }
-    set options(value: EnumValueOptions) {
+    set options(value: EnumValueOptions | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_options() {
@@ -1661,9 +1661,9 @@ export class ServiceDescriptorProto extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, ServiceOptions, 3) as ServiceOptions;
+        return pb_1.Message.getWrapperField(this, ServiceOptions, 3) as ServiceOptions | undefined | null;
     }
-    set options(value: ServiceOptions) {
+    set options(value: ServiceOptions | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_options() {
@@ -1799,9 +1799,9 @@ export class MethodDescriptorProto extends pb_1.Message {
         return pb_1.Message.getField(this, 3) != null;
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, MethodOptions, 4) as MethodOptions;
+        return pb_1.Message.getWrapperField(this, MethodOptions, 4) as MethodOptions | undefined | null;
     }
-    set options(value: MethodOptions) {
+    set options(value: MethodOptions | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_options() {
@@ -3504,18 +3504,18 @@ export namespace UninterpretedOption {
             }
         }
         get name_part() {
-            return pb_1.Message.getField(this, 1) as string;
+            return pb_1.Message.getField(this, 1) as string | undefined | null;
         }
-        set name_part(value: string) {
+        set name_part(value: string | undefined | null) {
             pb_1.Message.setField(this, 1, value);
         }
         get has_name_part() {
             return pb_1.Message.getField(this, 1) != null;
         }
         get is_extension() {
-            return pb_1.Message.getField(this, 2) as boolean;
+            return pb_1.Message.getField(this, 2) as boolean | undefined | null;
         }
-        set is_extension(value: boolean) {
+        set is_extension(value: boolean | undefined | null) {
             pb_1.Message.setField(this, 2, value);
         }
         get has_is_extension() {

--- a/src/compiler/descriptor.ts
+++ b/src/compiler/descriptor.ts
@@ -4,9 +4,6 @@
  * source: descriptor.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class FileDescriptorSet extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -24,7 +21,7 @@ export class FileDescriptorSet extends pb_1.Message {
     set file(value: FileDescriptorProto[]) {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<FileDescriptorSet.AsObject>): FileDescriptorSet {
+    static fromObject(data: FileDescriptorSet.AsObjectPartial): FileDescriptorSet {
         const message = new FileDescriptorSet({
             file: data.file.map(item => FileDescriptorProto.fromObject(item))
         });
@@ -41,7 +38,7 @@ export class FileDescriptorSet extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.file.length)
-            writer.writeRepeatedMessage(1, this.file, (item: FileDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(1, this.file, (item: FileDescriptorProto) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -69,6 +66,9 @@ export class FileDescriptorSet extends pb_1.Message {
 export namespace FileDescriptorSet {
     export type AsObject = {
         file: FileDescriptorProto.AsObject[];
+    };
+    export type AsObjectPartial = {
+        file: FileDescriptorProto.AsObjectPartial[];
     };
 }
 export class FileDescriptorProto extends pb_1.Message {
@@ -175,18 +175,18 @@ export class FileDescriptorProto extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 7, value);
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, FileOptions, 8) as FileOptions | undefined | null;
+        return pb_1.Message.getWrapperField(this, FileOptions, 8) as FileOptions | undefined;
     }
-    set options(value: FileOptions | undefined | null) {
+    set options(value: FileOptions | undefined) {
         pb_1.Message.setWrapperField(this, 8, value);
     }
     get has_options() {
         return pb_1.Message.getField(this, 8) != null;
     }
     get source_code_info() {
-        return pb_1.Message.getWrapperField(this, SourceCodeInfo, 9) as SourceCodeInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, SourceCodeInfo, 9) as SourceCodeInfo | undefined;
     }
-    set source_code_info(value: SourceCodeInfo | undefined | null) {
+    set source_code_info(value: SourceCodeInfo | undefined) {
         pb_1.Message.setWrapperField(this, 9, value);
     }
     get has_source_code_info() {
@@ -201,7 +201,7 @@ export class FileDescriptorProto extends pb_1.Message {
     get has_syntax() {
         return pb_1.Message.getField(this, 12) != null;
     }
-    static fromObject(data: RecursivePartial<FileDescriptorProto.AsObject>): FileDescriptorProto {
+    static fromObject(data: FileDescriptorProto.AsObjectPartial): FileDescriptorProto {
         const message = new FileDescriptorProto({
             dependency: data.dependency,
             public_dependency: data.public_dependency,
@@ -253,9 +253,9 @@ export class FileDescriptorProto extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(1, this.name);
-        if (this.has_package && this.package.length)
+        if (this.has_package && this.package!.length)
             writer.writeString(2, this.package);
         if (this.dependency.length)
             writer.writeRepeatedString(3, this.dependency);
@@ -264,18 +264,18 @@ export class FileDescriptorProto extends pb_1.Message {
         if (this.weak_dependency.length)
             writer.writeRepeatedInt32(11, this.weak_dependency);
         if (this.message_type.length)
-            writer.writeRepeatedMessage(4, this.message_type, (item: DescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(4, this.message_type, (item: DescriptorProto) => item!.serialize(writer));
         if (this.enum_type.length)
-            writer.writeRepeatedMessage(5, this.enum_type, (item: EnumDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(5, this.enum_type, (item: EnumDescriptorProto) => item!.serialize(writer));
         if (this.service.length)
-            writer.writeRepeatedMessage(6, this.service, (item: ServiceDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(6, this.service, (item: ServiceDescriptorProto) => item!.serialize(writer));
         if (this.extension.length)
-            writer.writeRepeatedMessage(7, this.extension, (item: FieldDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(7, this.extension, (item: FieldDescriptorProto) => item!.serialize(writer));
         if (this.has_options)
-            writer.writeMessage(8, this.options, () => this.options.serialize(writer));
+            writer.writeMessage(8, this.options, () => this.options!.serialize(writer));
         if (this.has_source_code_info)
-            writer.writeMessage(9, this.source_code_info, () => this.source_code_info.serialize(writer));
-        if (this.has_syntax && this.syntax.length)
+            writer.writeMessage(9, this.source_code_info, () => this.source_code_info!.serialize(writer));
+        if (this.has_syntax && this.syntax!.length)
             writer.writeString(12, this.syntax);
         if (!w)
             return writer.getResultBuffer();
@@ -348,6 +348,20 @@ export namespace FileDescriptorProto {
         options?: FileOptions.AsObject;
         source_code_info?: SourceCodeInfo.AsObject;
         syntax: string;
+    };
+    export type AsObjectPartial = {
+        name?: string;
+        package?: string;
+        dependency: string[];
+        public_dependency: number[];
+        weak_dependency: number[];
+        message_type: DescriptorProto.AsObjectPartial[];
+        enum_type: EnumDescriptorProto.AsObjectPartial[];
+        service: ServiceDescriptorProto.AsObjectPartial[];
+        extension: FieldDescriptorProto.AsObjectPartial[];
+        options?: FileOptions.AsObjectPartial;
+        source_code_info?: SourceCodeInfo.AsObjectPartial;
+        syntax?: string;
     };
 }
 export class DescriptorProto extends pb_1.Message {
@@ -429,9 +443,9 @@ export class DescriptorProto extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 8, value);
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, MessageOptions, 7) as MessageOptions | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageOptions, 7) as MessageOptions | undefined;
     }
-    set options(value: MessageOptions | undefined | null) {
+    set options(value: MessageOptions | undefined) {
         pb_1.Message.setWrapperField(this, 7, value);
     }
     get has_options() {
@@ -449,7 +463,7 @@ export class DescriptorProto extends pb_1.Message {
     set reserved_name(value: string[]) {
         pb_1.Message.setField(this, 10, value);
     }
-    static fromObject(data: RecursivePartial<DescriptorProto.AsObject>): DescriptorProto {
+    static fromObject(data: DescriptorProto.AsObjectPartial): DescriptorProto {
         const message = new DescriptorProto({
             field: data.field.map(item => FieldDescriptorProto.fromObject(item)),
             extension: data.extension.map(item => FieldDescriptorProto.fromObject(item)),
@@ -489,24 +503,24 @@ export class DescriptorProto extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(1, this.name);
         if (this.field.length)
-            writer.writeRepeatedMessage(2, this.field, (item: FieldDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(2, this.field, (item: FieldDescriptorProto) => item!.serialize(writer));
         if (this.extension.length)
-            writer.writeRepeatedMessage(6, this.extension, (item: FieldDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(6, this.extension, (item: FieldDescriptorProto) => item!.serialize(writer));
         if (this.nested_type.length)
-            writer.writeRepeatedMessage(3, this.nested_type, (item: DescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(3, this.nested_type, (item: DescriptorProto) => item!.serialize(writer));
         if (this.enum_type.length)
-            writer.writeRepeatedMessage(4, this.enum_type, (item: EnumDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(4, this.enum_type, (item: EnumDescriptorProto) => item!.serialize(writer));
         if (this.extension_range.length)
-            writer.writeRepeatedMessage(5, this.extension_range, (item: DescriptorProto.ExtensionRange) => item.serialize(writer));
+            writer.writeRepeatedMessage(5, this.extension_range, (item: DescriptorProto.ExtensionRange) => item!.serialize(writer));
         if (this.oneof_decl.length)
-            writer.writeRepeatedMessage(8, this.oneof_decl, (item: OneofDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(8, this.oneof_decl, (item: OneofDescriptorProto) => item!.serialize(writer));
         if (this.has_options)
-            writer.writeMessage(7, this.options, () => this.options.serialize(writer));
+            writer.writeMessage(7, this.options, () => this.options!.serialize(writer));
         if (this.reserved_range.length)
-            writer.writeRepeatedMessage(9, this.reserved_range, (item: DescriptorProto.ReservedRange) => item.serialize(writer));
+            writer.writeRepeatedMessage(9, this.reserved_range, (item: DescriptorProto.ReservedRange) => item!.serialize(writer));
         if (this.reserved_name.length)
             writer.writeRepeatedString(10, this.reserved_name);
         if (!w)
@@ -573,6 +587,18 @@ export namespace DescriptorProto {
         reserved_range: DescriptorProto.ReservedRange.AsObject[];
         reserved_name: string[];
     };
+    export type AsObjectPartial = {
+        name?: string;
+        field: FieldDescriptorProto.AsObjectPartial[];
+        extension: FieldDescriptorProto.AsObjectPartial[];
+        nested_type: DescriptorProto.AsObjectPartial[];
+        enum_type: EnumDescriptorProto.AsObjectPartial[];
+        extension_range: DescriptorProto.ExtensionRange.AsObjectPartial[];
+        oneof_decl: OneofDescriptorProto.AsObjectPartial[];
+        options?: MessageOptions.AsObjectPartial;
+        reserved_range: DescriptorProto.ReservedRange.AsObjectPartial[];
+        reserved_name: string[];
+    };
     export class ExtensionRange extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -613,15 +639,15 @@ export namespace DescriptorProto {
             return pb_1.Message.getField(this, 2) != null;
         }
         get options() {
-            return pb_1.Message.getWrapperField(this, ExtensionRangeOptions, 3) as ExtensionRangeOptions | undefined | null;
+            return pb_1.Message.getWrapperField(this, ExtensionRangeOptions, 3) as ExtensionRangeOptions | undefined;
         }
-        set options(value: ExtensionRangeOptions | undefined | null) {
+        set options(value: ExtensionRangeOptions | undefined) {
             pb_1.Message.setWrapperField(this, 3, value);
         }
         get has_options() {
             return pb_1.Message.getField(this, 3) != null;
         }
-        static fromObject(data: RecursivePartial<ExtensionRange.AsObject>): ExtensionRange {
+        static fromObject(data: ExtensionRange.AsObjectPartial): ExtensionRange {
             const message = new ExtensionRange({});
             if (data.start != null) {
                 message.start = data.start;
@@ -653,7 +679,7 @@ export namespace DescriptorProto {
             if (this.has_end)
                 writer.writeInt32(2, this.end);
             if (this.has_options)
-                writer.writeMessage(3, this.options, () => this.options.serialize(writer));
+                writer.writeMessage(3, this.options, () => this.options!.serialize(writer));
             if (!w)
                 return writer.getResultBuffer();
         }
@@ -689,6 +715,11 @@ export namespace DescriptorProto {
             start: number;
             end: number;
             options?: ExtensionRangeOptions.AsObject;
+        };
+        export type AsObjectPartial = {
+            start?: number;
+            end?: number;
+            options?: ExtensionRangeOptions.AsObjectPartial;
         };
     }
     export class ReservedRange extends pb_1.Message {
@@ -726,7 +757,7 @@ export namespace DescriptorProto {
         get has_end() {
             return pb_1.Message.getField(this, 2) != null;
         }
-        static fromObject(data: RecursivePartial<ReservedRange.AsObject>): ReservedRange {
+        static fromObject(data: ReservedRange.AsObjectPartial): ReservedRange {
             const message = new ReservedRange({});
             if (data.start != null) {
                 message.start = data.start;
@@ -783,6 +814,10 @@ export namespace DescriptorProto {
             start: number;
             end: number;
         };
+        export type AsObjectPartial = {
+            start?: number;
+            end?: number;
+        };
     }
 }
 export class ExtensionRangeOptions extends pb_1.Message {
@@ -802,7 +837,7 @@ export class ExtensionRangeOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<ExtensionRangeOptions.AsObject>): ExtensionRangeOptions {
+    static fromObject(data: ExtensionRangeOptions.AsObjectPartial): ExtensionRangeOptions {
         const message = new ExtensionRangeOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -819,7 +854,7 @@ export class ExtensionRangeOptions extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -847,6 +882,9 @@ export class ExtensionRangeOptions extends pb_1.Message {
 export namespace ExtensionRangeOptions {
     export type AsObject = {
         uninterpreted_option: UninterpretedOption.AsObject[];
+    };
+    export type AsObjectPartial = {
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
     };
 }
 export class FieldDescriptorProto extends pb_1.Message {
@@ -984,9 +1022,9 @@ export class FieldDescriptorProto extends pb_1.Message {
         return pb_1.Message.getField(this, 10) != null;
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, FieldOptions, 8) as FieldOptions | undefined | null;
+        return pb_1.Message.getWrapperField(this, FieldOptions, 8) as FieldOptions | undefined;
     }
-    set options(value: FieldOptions | undefined | null) {
+    set options(value: FieldOptions | undefined) {
         pb_1.Message.setWrapperField(this, 8, value);
     }
     get has_options() {
@@ -1001,7 +1039,7 @@ export class FieldDescriptorProto extends pb_1.Message {
     get has_proto3_optional() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<FieldDescriptorProto.AsObject>): FieldDescriptorProto {
+    static fromObject(data: FieldDescriptorProto.AsObjectPartial): FieldDescriptorProto {
         const message = new FieldDescriptorProto({});
         if (data.name != null) {
             message.name = data.name;
@@ -1060,7 +1098,7 @@ export class FieldDescriptorProto extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(1, this.name);
         if (this.has_number)
             writer.writeInt32(3, this.number);
@@ -1068,18 +1106,18 @@ export class FieldDescriptorProto extends pb_1.Message {
             writer.writeEnum(4, this.label);
         if (this.has_type)
             writer.writeEnum(5, this.type);
-        if (this.has_type_name && this.type_name.length)
+        if (this.has_type_name && this.type_name!.length)
             writer.writeString(6, this.type_name);
-        if (this.has_extendee && this.extendee.length)
+        if (this.has_extendee && this.extendee!.length)
             writer.writeString(2, this.extendee);
-        if (this.has_default_value && this.default_value.length)
+        if (this.has_default_value && this.default_value!.length)
             writer.writeString(7, this.default_value);
         if (this.has_oneof_index)
             writer.writeInt32(9, this.oneof_index);
-        if (this.has_json_name && this.json_name.length)
+        if (this.has_json_name && this.json_name!.length)
             writer.writeString(10, this.json_name);
         if (this.has_options)
-            writer.writeMessage(8, this.options, () => this.options.serialize(writer));
+            writer.writeMessage(8, this.options, () => this.options!.serialize(writer));
         if (this.has_proto3_optional)
             writer.writeBool(17, this.proto3_optional);
         if (!w)
@@ -1150,6 +1188,19 @@ export namespace FieldDescriptorProto {
         options?: FieldOptions.AsObject;
         proto3_optional: boolean;
     };
+    export type AsObjectPartial = {
+        name?: string;
+        number?: number;
+        label?: FieldDescriptorProto.Label;
+        type?: FieldDescriptorProto.Type;
+        type_name?: string;
+        extendee?: string;
+        default_value?: string;
+        oneof_index?: number;
+        json_name?: string;
+        options?: FieldOptions.AsObjectPartial;
+        proto3_optional?: boolean;
+    };
     export enum Type {
         TYPE_DOUBLE = 1,
         TYPE_FLOAT = 2,
@@ -1203,15 +1254,15 @@ export class OneofDescriptorProto extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, OneofOptions, 2) as OneofOptions | undefined | null;
+        return pb_1.Message.getWrapperField(this, OneofOptions, 2) as OneofOptions | undefined;
     }
-    set options(value: OneofOptions | undefined | null) {
+    set options(value: OneofOptions | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_options() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<OneofDescriptorProto.AsObject>): OneofDescriptorProto {
+    static fromObject(data: OneofDescriptorProto.AsObjectPartial): OneofDescriptorProto {
         const message = new OneofDescriptorProto({});
         if (data.name != null) {
             message.name = data.name;
@@ -1234,10 +1285,10 @@ export class OneofDescriptorProto extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(1, this.name);
         if (this.has_options)
-            writer.writeMessage(2, this.options, () => this.options.serialize(writer));
+            writer.writeMessage(2, this.options, () => this.options!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -1269,6 +1320,10 @@ export namespace OneofDescriptorProto {
     export type AsObject = {
         name: string;
         options?: OneofOptions.AsObject;
+    };
+    export type AsObjectPartial = {
+        name?: string;
+        options?: OneofOptions.AsObjectPartial;
     };
 }
 export class EnumDescriptorProto extends pb_1.Message {
@@ -1310,9 +1365,9 @@ export class EnumDescriptorProto extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, EnumOptions, 3) as EnumOptions | undefined | null;
+        return pb_1.Message.getWrapperField(this, EnumOptions, 3) as EnumOptions | undefined;
     }
-    set options(value: EnumOptions | undefined | null) {
+    set options(value: EnumOptions | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_options() {
@@ -1330,7 +1385,7 @@ export class EnumDescriptorProto extends pb_1.Message {
     set reserved_name(value: string[]) {
         pb_1.Message.setField(this, 5, value);
     }
-    static fromObject(data: RecursivePartial<EnumDescriptorProto.AsObject>): EnumDescriptorProto {
+    static fromObject(data: EnumDescriptorProto.AsObjectPartial): EnumDescriptorProto {
         const message = new EnumDescriptorProto({
             value: data.value.map(item => EnumValueDescriptorProto.fromObject(item)),
             reserved_range: data.reserved_range.map(item => EnumDescriptorProto.EnumReservedRange.fromObject(item)),
@@ -1360,14 +1415,14 @@ export class EnumDescriptorProto extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(1, this.name);
         if (this.value.length)
-            writer.writeRepeatedMessage(2, this.value, (item: EnumValueDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(2, this.value, (item: EnumValueDescriptorProto) => item!.serialize(writer));
         if (this.has_options)
-            writer.writeMessage(3, this.options, () => this.options.serialize(writer));
+            writer.writeMessage(3, this.options, () => this.options!.serialize(writer));
         if (this.reserved_range.length)
-            writer.writeRepeatedMessage(4, this.reserved_range, (item: EnumDescriptorProto.EnumReservedRange) => item.serialize(writer));
+            writer.writeRepeatedMessage(4, this.reserved_range, (item: EnumDescriptorProto.EnumReservedRange) => item!.serialize(writer));
         if (this.reserved_name.length)
             writer.writeRepeatedString(5, this.reserved_name);
         if (!w)
@@ -1414,6 +1469,13 @@ export namespace EnumDescriptorProto {
         reserved_range: EnumDescriptorProto.EnumReservedRange.AsObject[];
         reserved_name: string[];
     };
+    export type AsObjectPartial = {
+        name?: string;
+        value: EnumValueDescriptorProto.AsObjectPartial[];
+        options?: EnumOptions.AsObjectPartial;
+        reserved_range: EnumDescriptorProto.EnumReservedRange.AsObjectPartial[];
+        reserved_name: string[];
+    };
     export class EnumReservedRange extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -1449,7 +1511,7 @@ export namespace EnumDescriptorProto {
         get has_end() {
             return pb_1.Message.getField(this, 2) != null;
         }
-        static fromObject(data: RecursivePartial<EnumReservedRange.AsObject>): EnumReservedRange {
+        static fromObject(data: EnumReservedRange.AsObjectPartial): EnumReservedRange {
             const message = new EnumReservedRange({});
             if (data.start != null) {
                 message.start = data.start;
@@ -1506,6 +1568,10 @@ export namespace EnumDescriptorProto {
             start: number;
             end: number;
         };
+        export type AsObjectPartial = {
+            start?: number;
+            end?: number;
+        };
     }
 }
 export class EnumValueDescriptorProto extends pb_1.Message {
@@ -1548,15 +1614,15 @@ export class EnumValueDescriptorProto extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, EnumValueOptions, 3) as EnumValueOptions | undefined | null;
+        return pb_1.Message.getWrapperField(this, EnumValueOptions, 3) as EnumValueOptions | undefined;
     }
-    set options(value: EnumValueOptions | undefined | null) {
+    set options(value: EnumValueOptions | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_options() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<EnumValueDescriptorProto.AsObject>): EnumValueDescriptorProto {
+    static fromObject(data: EnumValueDescriptorProto.AsObjectPartial): EnumValueDescriptorProto {
         const message = new EnumValueDescriptorProto({});
         if (data.name != null) {
             message.name = data.name;
@@ -1583,12 +1649,12 @@ export class EnumValueDescriptorProto extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(1, this.name);
         if (this.has_number)
             writer.writeInt32(2, this.number);
         if (this.has_options)
-            writer.writeMessage(3, this.options, () => this.options.serialize(writer));
+            writer.writeMessage(3, this.options, () => this.options!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -1624,6 +1690,11 @@ export namespace EnumValueDescriptorProto {
         name: string;
         number: number;
         options?: EnumValueOptions.AsObject;
+    };
+    export type AsObjectPartial = {
+        name?: string;
+        number?: number;
+        options?: EnumValueOptions.AsObjectPartial;
     };
 }
 export class ServiceDescriptorProto extends pb_1.Message {
@@ -1661,15 +1732,15 @@ export class ServiceDescriptorProto extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, ServiceOptions, 3) as ServiceOptions | undefined | null;
+        return pb_1.Message.getWrapperField(this, ServiceOptions, 3) as ServiceOptions | undefined;
     }
-    set options(value: ServiceOptions | undefined | null) {
+    set options(value: ServiceOptions | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_options() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<ServiceDescriptorProto.AsObject>): ServiceDescriptorProto {
+    static fromObject(data: ServiceDescriptorProto.AsObjectPartial): ServiceDescriptorProto {
         const message = new ServiceDescriptorProto({
             method: data.method.map(item => MethodDescriptorProto.fromObject(item))
         });
@@ -1695,12 +1766,12 @@ export class ServiceDescriptorProto extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(1, this.name);
         if (this.method.length)
-            writer.writeRepeatedMessage(2, this.method, (item: MethodDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(2, this.method, (item: MethodDescriptorProto) => item!.serialize(writer));
         if (this.has_options)
-            writer.writeMessage(3, this.options, () => this.options.serialize(writer));
+            writer.writeMessage(3, this.options, () => this.options!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -1736,6 +1807,11 @@ export namespace ServiceDescriptorProto {
         name: string;
         method: MethodDescriptorProto.AsObject[];
         options?: ServiceOptions.AsObject;
+    };
+    export type AsObjectPartial = {
+        name?: string;
+        method: MethodDescriptorProto.AsObjectPartial[];
+        options?: ServiceOptions.AsObjectPartial;
     };
 }
 export class MethodDescriptorProto extends pb_1.Message {
@@ -1799,9 +1875,9 @@ export class MethodDescriptorProto extends pb_1.Message {
         return pb_1.Message.getField(this, 3) != null;
     }
     get options() {
-        return pb_1.Message.getWrapperField(this, MethodOptions, 4) as MethodOptions | undefined | null;
+        return pb_1.Message.getWrapperField(this, MethodOptions, 4) as MethodOptions | undefined;
     }
-    set options(value: MethodOptions | undefined | null) {
+    set options(value: MethodOptions | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_options() {
@@ -1825,7 +1901,7 @@ export class MethodDescriptorProto extends pb_1.Message {
     get has_server_streaming() {
         return pb_1.Message.getField(this, 6) != null;
     }
-    static fromObject(data: RecursivePartial<MethodDescriptorProto.AsObject>): MethodDescriptorProto {
+    static fromObject(data: MethodDescriptorProto.AsObjectPartial): MethodDescriptorProto {
         const message = new MethodDescriptorProto({});
         if (data.name != null) {
             message.name = data.name;
@@ -1864,14 +1940,14 @@ export class MethodDescriptorProto extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(1, this.name);
-        if (this.has_input_type && this.input_type.length)
+        if (this.has_input_type && this.input_type!.length)
             writer.writeString(2, this.input_type);
-        if (this.has_output_type && this.output_type.length)
+        if (this.has_output_type && this.output_type!.length)
             writer.writeString(3, this.output_type);
         if (this.has_options)
-            writer.writeMessage(4, this.options, () => this.options.serialize(writer));
+            writer.writeMessage(4, this.options, () => this.options!.serialize(writer));
         if (this.has_client_streaming)
             writer.writeBool(5, this.client_streaming);
         if (this.has_server_streaming)
@@ -1923,6 +1999,14 @@ export namespace MethodDescriptorProto {
         options?: MethodOptions.AsObject;
         client_streaming: boolean;
         server_streaming: boolean;
+    };
+    export type AsObjectPartial = {
+        name?: string;
+        input_type?: string;
+        output_type?: string;
+        options?: MethodOptions.AsObjectPartial;
+        client_streaming?: boolean;
+        server_streaming?: boolean;
     };
 }
 export class FileOptions extends pb_1.Message {
@@ -2206,7 +2290,7 @@ export class FileOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<FileOptions.AsObject>): FileOptions {
+    static fromObject(data: FileOptions.AsObjectPartial): FileOptions {
         const message = new FileOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -2302,9 +2386,9 @@ export class FileOptions extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_java_package && this.java_package.length)
+        if (this.has_java_package && this.java_package!.length)
             writer.writeString(1, this.java_package);
-        if (this.has_java_outer_classname && this.java_outer_classname.length)
+        if (this.has_java_outer_classname && this.java_outer_classname!.length)
             writer.writeString(8, this.java_outer_classname);
         if (this.has_java_multiple_files)
             writer.writeBool(10, this.java_multiple_files);
@@ -2314,7 +2398,7 @@ export class FileOptions extends pb_1.Message {
             writer.writeBool(27, this.java_string_check_utf8);
         if (this.has_optimize_for)
             writer.writeEnum(9, this.optimize_for);
-        if (this.has_go_package && this.go_package.length)
+        if (this.has_go_package && this.go_package!.length)
             writer.writeString(11, this.go_package);
         if (this.has_cc_generic_services)
             writer.writeBool(16, this.cc_generic_services);
@@ -2328,22 +2412,22 @@ export class FileOptions extends pb_1.Message {
             writer.writeBool(23, this.deprecated);
         if (this.has_cc_enable_arenas)
             writer.writeBool(31, this.cc_enable_arenas);
-        if (this.has_objc_class_prefix && this.objc_class_prefix.length)
+        if (this.has_objc_class_prefix && this.objc_class_prefix!.length)
             writer.writeString(36, this.objc_class_prefix);
-        if (this.has_csharp_namespace && this.csharp_namespace.length)
+        if (this.has_csharp_namespace && this.csharp_namespace!.length)
             writer.writeString(37, this.csharp_namespace);
-        if (this.has_swift_prefix && this.swift_prefix.length)
+        if (this.has_swift_prefix && this.swift_prefix!.length)
             writer.writeString(39, this.swift_prefix);
-        if (this.has_php_class_prefix && this.php_class_prefix.length)
+        if (this.has_php_class_prefix && this.php_class_prefix!.length)
             writer.writeString(40, this.php_class_prefix);
-        if (this.has_php_namespace && this.php_namespace.length)
+        if (this.has_php_namespace && this.php_namespace!.length)
             writer.writeString(41, this.php_namespace);
-        if (this.has_php_metadata_namespace && this.php_metadata_namespace.length)
+        if (this.has_php_metadata_namespace && this.php_metadata_namespace!.length)
             writer.writeString(44, this.php_metadata_namespace);
-        if (this.has_ruby_package && this.ruby_package.length)
+        if (this.has_ruby_package && this.ruby_package!.length)
             writer.writeString(45, this.ruby_package);
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -2452,6 +2536,29 @@ export namespace FileOptions {
         ruby_package: string;
         uninterpreted_option: UninterpretedOption.AsObject[];
     };
+    export type AsObjectPartial = {
+        java_package?: string;
+        java_outer_classname?: string;
+        java_multiple_files?: boolean;
+        java_generate_equals_and_hash?: boolean;
+        java_string_check_utf8?: boolean;
+        optimize_for?: FileOptions.OptimizeMode;
+        go_package?: string;
+        cc_generic_services?: boolean;
+        java_generic_services?: boolean;
+        py_generic_services?: boolean;
+        php_generic_services?: boolean;
+        deprecated?: boolean;
+        cc_enable_arenas?: boolean;
+        objc_class_prefix?: string;
+        csharp_namespace?: string;
+        swift_prefix?: string;
+        php_class_prefix?: string;
+        php_namespace?: string;
+        php_metadata_namespace?: string;
+        ruby_package?: string;
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
+    };
     export enum OptimizeMode {
         SPEED = 1,
         CODE_SIZE = 2,
@@ -2527,7 +2634,7 @@ export class MessageOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<MessageOptions.AsObject>): MessageOptions {
+    static fromObject(data: MessageOptions.AsObjectPartial): MessageOptions {
         const message = new MessageOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -2568,7 +2675,7 @@ export class MessageOptions extends pb_1.Message {
         if (this.has_map_entry)
             writer.writeBool(7, this.map_entry);
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -2612,6 +2719,13 @@ export namespace MessageOptions {
         deprecated: boolean;
         map_entry: boolean;
         uninterpreted_option: UninterpretedOption.AsObject[];
+    };
+    export type AsObjectPartial = {
+        message_set_wire_format?: boolean;
+        no_standard_descriptor_accessor?: boolean;
+        deprecated?: boolean;
+        map_entry?: boolean;
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
     };
 }
 export class FieldOptions extends pb_1.Message {
@@ -2709,7 +2823,7 @@ export class FieldOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<FieldOptions.AsObject>): FieldOptions {
+    static fromObject(data: FieldOptions.AsObjectPartial): FieldOptions {
         const message = new FieldOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -2762,7 +2876,7 @@ export class FieldOptions extends pb_1.Message {
         if (this.has_weak)
             writer.writeBool(10, this.weak);
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -2815,6 +2929,15 @@ export namespace FieldOptions {
         weak: boolean;
         uninterpreted_option: UninterpretedOption.AsObject[];
     };
+    export type AsObjectPartial = {
+        ctype?: FieldOptions.CType;
+        packed?: boolean;
+        jstype?: FieldOptions.JSType;
+        lazy?: boolean;
+        deprecated?: boolean;
+        weak?: boolean;
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
+    };
     export enum CType {
         STRING = 0,
         CORD = 1,
@@ -2843,7 +2966,7 @@ export class OneofOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<OneofOptions.AsObject>): OneofOptions {
+    static fromObject(data: OneofOptions.AsObjectPartial): OneofOptions {
         const message = new OneofOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -2860,7 +2983,7 @@ export class OneofOptions extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -2888,6 +3011,9 @@ export class OneofOptions extends pb_1.Message {
 export namespace OneofOptions {
     export type AsObject = {
         uninterpreted_option: UninterpretedOption.AsObject[];
+    };
+    export type AsObjectPartial = {
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
     };
 }
 export class EnumOptions extends pb_1.Message {
@@ -2933,7 +3059,7 @@ export class EnumOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<EnumOptions.AsObject>): EnumOptions {
+    static fromObject(data: EnumOptions.AsObjectPartial): EnumOptions {
         const message = new EnumOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -2962,7 +3088,7 @@ export class EnumOptions extends pb_1.Message {
         if (this.has_deprecated)
             writer.writeBool(3, this.deprecated);
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -2999,6 +3125,11 @@ export namespace EnumOptions {
         deprecated: boolean;
         uninterpreted_option: UninterpretedOption.AsObject[];
     };
+    export type AsObjectPartial = {
+        allow_alias?: boolean;
+        deprecated?: boolean;
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
+    };
 }
 export class EnumValueOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -3030,7 +3161,7 @@ export class EnumValueOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<EnumValueOptions.AsObject>): EnumValueOptions {
+    static fromObject(data: EnumValueOptions.AsObjectPartial): EnumValueOptions {
         const message = new EnumValueOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -3053,7 +3184,7 @@ export class EnumValueOptions extends pb_1.Message {
         if (this.has_deprecated)
             writer.writeBool(1, this.deprecated);
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -3086,6 +3217,10 @@ export namespace EnumValueOptions {
         deprecated: boolean;
         uninterpreted_option: UninterpretedOption.AsObject[];
     };
+    export type AsObjectPartial = {
+        deprecated?: boolean;
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
+    };
 }
 export class ServiceOptions extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -3117,7 +3252,7 @@ export class ServiceOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<ServiceOptions.AsObject>): ServiceOptions {
+    static fromObject(data: ServiceOptions.AsObjectPartial): ServiceOptions {
         const message = new ServiceOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -3140,7 +3275,7 @@ export class ServiceOptions extends pb_1.Message {
         if (this.has_deprecated)
             writer.writeBool(33, this.deprecated);
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -3172,6 +3307,10 @@ export namespace ServiceOptions {
     export type AsObject = {
         deprecated: boolean;
         uninterpreted_option: UninterpretedOption.AsObject[];
+    };
+    export type AsObjectPartial = {
+        deprecated?: boolean;
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
     };
 }
 export class MethodOptions extends pb_1.Message {
@@ -3217,7 +3356,7 @@ export class MethodOptions extends pb_1.Message {
     set uninterpreted_option(value: UninterpretedOption[]) {
         pb_1.Message.setRepeatedWrapperField(this, 999, value);
     }
-    static fromObject(data: RecursivePartial<MethodOptions.AsObject>): MethodOptions {
+    static fromObject(data: MethodOptions.AsObjectPartial): MethodOptions {
         const message = new MethodOptions({
             uninterpreted_option: data.uninterpreted_option.map(item => UninterpretedOption.fromObject(item))
         });
@@ -3246,7 +3385,7 @@ export class MethodOptions extends pb_1.Message {
         if (this.has_idempotency_level)
             writer.writeEnum(34, this.idempotency_level);
         if (this.uninterpreted_option.length)
-            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item.serialize(writer));
+            writer.writeRepeatedMessage(999, this.uninterpreted_option, (item: UninterpretedOption) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -3282,6 +3421,11 @@ export namespace MethodOptions {
         deprecated: boolean;
         idempotency_level: MethodOptions.IdempotencyLevel;
         uninterpreted_option: UninterpretedOption.AsObject[];
+    };
+    export type AsObjectPartial = {
+        deprecated?: boolean;
+        idempotency_level?: MethodOptions.IdempotencyLevel;
+        uninterpreted_option: UninterpretedOption.AsObjectPartial[];
     };
     export enum IdempotencyLevel {
         IDEMPOTENCY_UNKNOWN = 0,
@@ -3384,7 +3528,7 @@ export class UninterpretedOption extends pb_1.Message {
     get has_aggregate_value() {
         return pb_1.Message.getField(this, 8) != null;
     }
-    static fromObject(data: RecursivePartial<UninterpretedOption.AsObject>): UninterpretedOption {
+    static fromObject(data: UninterpretedOption.AsObjectPartial): UninterpretedOption {
         const message = new UninterpretedOption({
             name: data.name.map(item => UninterpretedOption.NamePart.fromObject(item))
         });
@@ -3425,8 +3569,8 @@ export class UninterpretedOption extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.name.length)
-            writer.writeRepeatedMessage(2, this.name, (item: UninterpretedOption.NamePart) => item.serialize(writer));
-        if (this.has_identifier_value && this.identifier_value.length)
+            writer.writeRepeatedMessage(2, this.name, (item: UninterpretedOption.NamePart) => item!.serialize(writer));
+        if (this.has_identifier_value && this.identifier_value!.length)
             writer.writeString(3, this.identifier_value);
         if (this.has_positive_int_value)
             writer.writeUint64(4, this.positive_int_value);
@@ -3434,9 +3578,9 @@ export class UninterpretedOption extends pb_1.Message {
             writer.writeInt64(5, this.negative_int_value);
         if (this.has_double_value)
             writer.writeDouble(6, this.double_value);
-        if (this.has_string_value && this.string_value.length)
+        if (this.has_string_value && this.string_value!.length)
             writer.writeBytes(7, this.string_value);
-        if (this.has_aggregate_value && this.aggregate_value.length)
+        if (this.has_aggregate_value && this.aggregate_value!.length)
             writer.writeString(8, this.aggregate_value);
         if (!w)
             return writer.getResultBuffer();
@@ -3490,6 +3634,15 @@ export namespace UninterpretedOption {
         string_value: Uint8Array;
         aggregate_value: string;
     };
+    export type AsObjectPartial = {
+        name: UninterpretedOption.NamePart.AsObjectPartial[];
+        identifier_value?: string;
+        positive_int_value?: number;
+        negative_int_value?: number;
+        double_value?: number;
+        string_value?: Uint8Array;
+        aggregate_value?: string;
+    };
     export class NamePart extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -3504,24 +3657,24 @@ export namespace UninterpretedOption {
             }
         }
         get name_part() {
-            return pb_1.Message.getField(this, 1) as string | undefined | null;
+            return pb_1.Message.getField(this, 1) as string | undefined;
         }
-        set name_part(value: string | undefined | null) {
+        set name_part(value: string | undefined) {
             pb_1.Message.setField(this, 1, value);
         }
         get has_name_part() {
             return pb_1.Message.getField(this, 1) != null;
         }
         get is_extension() {
-            return pb_1.Message.getField(this, 2) as boolean | undefined | null;
+            return pb_1.Message.getField(this, 2) as boolean | undefined;
         }
-        set is_extension(value: boolean | undefined | null) {
+        set is_extension(value: boolean | undefined) {
             pb_1.Message.setField(this, 2, value);
         }
         get has_is_extension() {
             return pb_1.Message.getField(this, 2) != null;
         }
-        static fromObject(data: RecursivePartial<NamePart.AsObject>): NamePart {
+        static fromObject(data: NamePart.AsObjectPartial): NamePart {
             const message = new NamePart({
                 name_part: data.name_part,
                 is_extension: data.is_extension
@@ -3542,7 +3695,7 @@ export namespace UninterpretedOption {
         serialize(w: pb_1.BinaryWriter): void;
         serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
             const writer = w || new pb_1.BinaryWriter();
-            if (this.has_name_part && this.name_part.length)
+            if (this.has_name_part && this.name_part!.length)
                 writer.writeString(1, this.name_part);
             if (this.has_is_extension)
                 writer.writeBool(2, this.is_extension);
@@ -3578,6 +3731,10 @@ export namespace UninterpretedOption {
             name_part?: string;
             is_extension?: boolean;
         };
+        export type AsObjectPartial = {
+            name_part: string;
+            is_extension: boolean;
+        };
     }
 }
 export class SourceCodeInfo extends pb_1.Message {
@@ -3597,7 +3754,7 @@ export class SourceCodeInfo extends pb_1.Message {
     set location(value: SourceCodeInfo.Location[]) {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<SourceCodeInfo.AsObject>): SourceCodeInfo {
+    static fromObject(data: SourceCodeInfo.AsObjectPartial): SourceCodeInfo {
         const message = new SourceCodeInfo({
             location: data.location.map(item => SourceCodeInfo.Location.fromObject(item))
         });
@@ -3614,7 +3771,7 @@ export class SourceCodeInfo extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.location.length)
-            writer.writeRepeatedMessage(1, this.location, (item: SourceCodeInfo.Location) => item.serialize(writer));
+            writer.writeRepeatedMessage(1, this.location, (item: SourceCodeInfo.Location) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -3642,6 +3799,9 @@ export class SourceCodeInfo extends pb_1.Message {
 export namespace SourceCodeInfo {
     export type AsObject = {
         location: SourceCodeInfo.Location.AsObject[];
+    };
+    export type AsObjectPartial = {
+        location: SourceCodeInfo.Location.AsObjectPartial[];
     };
     export class Location extends pb_1.Message {
         #one_of_decls: number[][] = [];
@@ -3702,7 +3862,7 @@ export namespace SourceCodeInfo {
         set leading_detached_comments(value: string[]) {
             pb_1.Message.setField(this, 6, value);
         }
-        static fromObject(data: RecursivePartial<Location.AsObject>): Location {
+        static fromObject(data: Location.AsObjectPartial): Location {
             const message = new Location({
                 path: data.path,
                 span: data.span,
@@ -3734,9 +3894,9 @@ export namespace SourceCodeInfo {
                 writer.writePackedInt32(1, this.path);
             if (this.span.length)
                 writer.writePackedInt32(2, this.span);
-            if (this.has_leading_comments && this.leading_comments.length)
+            if (this.has_leading_comments && this.leading_comments!.length)
                 writer.writeString(3, this.leading_comments);
-            if (this.has_trailing_comments && this.trailing_comments.length)
+            if (this.has_trailing_comments && this.trailing_comments!.length)
                 writer.writeString(4, this.trailing_comments);
             if (this.leading_detached_comments.length)
                 writer.writeRepeatedString(6, this.leading_detached_comments);
@@ -3784,6 +3944,13 @@ export namespace SourceCodeInfo {
             trailing_comments: string;
             leading_detached_comments: string[];
         };
+        export type AsObjectPartial = {
+            path: number[];
+            span: number[];
+            leading_comments?: string;
+            trailing_comments?: string;
+            leading_detached_comments: string[];
+        };
     }
 }
 export class GeneratedCodeInfo extends pb_1.Message {
@@ -3803,7 +3970,7 @@ export class GeneratedCodeInfo extends pb_1.Message {
     set annotation(value: GeneratedCodeInfo.Annotation[]) {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<GeneratedCodeInfo.AsObject>): GeneratedCodeInfo {
+    static fromObject(data: GeneratedCodeInfo.AsObjectPartial): GeneratedCodeInfo {
         const message = new GeneratedCodeInfo({
             annotation: data.annotation.map(item => GeneratedCodeInfo.Annotation.fromObject(item))
         });
@@ -3820,7 +3987,7 @@ export class GeneratedCodeInfo extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.annotation.length)
-            writer.writeRepeatedMessage(1, this.annotation, (item: GeneratedCodeInfo.Annotation) => item.serialize(writer));
+            writer.writeRepeatedMessage(1, this.annotation, (item: GeneratedCodeInfo.Annotation) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -3848,6 +4015,9 @@ export class GeneratedCodeInfo extends pb_1.Message {
 export namespace GeneratedCodeInfo {
     export type AsObject = {
         annotation: GeneratedCodeInfo.Annotation.AsObject[];
+    };
+    export type AsObjectPartial = {
+        annotation: GeneratedCodeInfo.Annotation.AsObjectPartial[];
     };
     export class Annotation extends pb_1.Message {
         #one_of_decls: number[][] = [];
@@ -3905,7 +4075,7 @@ export namespace GeneratedCodeInfo {
         get has_end() {
             return pb_1.Message.getField(this, 4) != null;
         }
-        static fromObject(data: RecursivePartial<Annotation.AsObject>): Annotation {
+        static fromObject(data: Annotation.AsObjectPartial): Annotation {
             const message = new Annotation({
                 path: data.path
             });
@@ -3935,7 +4105,7 @@ export namespace GeneratedCodeInfo {
             const writer = w || new pb_1.BinaryWriter();
             if (this.path.length)
                 writer.writePackedInt32(1, this.path);
-            if (this.has_source_file && this.source_file.length)
+            if (this.has_source_file && this.source_file!.length)
                 writer.writeString(2, this.source_file);
             if (this.has_begin)
                 writer.writeInt32(3, this.begin);
@@ -3980,6 +4150,12 @@ export namespace GeneratedCodeInfo {
             source_file: string;
             begin: number;
             end: number;
+        };
+        export type AsObjectPartial = {
+            path: number[];
+            source_file?: string;
+            begin?: number;
+            end?: number;
         };
     }
 }

--- a/src/compiler/plugin.ts
+++ b/src/compiler/plugin.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./descriptor";
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class Version extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -69,7 +66,7 @@ export class Version extends pb_1.Message {
     get has_suffix() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: RecursivePartial<Version.AsObject>): Version {
+    static fromObject(data: Version.AsObjectPartial): Version {
         const message = new Version({});
         if (data.major != null) {
             message.major = data.major;
@@ -104,7 +101,7 @@ export class Version extends pb_1.Message {
             writer.writeInt32(2, this.minor);
         if (this.has_patch)
             writer.writeInt32(3, this.patch);
-        if (this.has_suffix && this.suffix.length)
+        if (this.has_suffix && this.suffix!.length)
             writer.writeString(4, this.suffix);
         if (!w)
             return writer.getResultBuffer();
@@ -145,6 +142,12 @@ export namespace Version {
         minor: number;
         patch: number;
         suffix: string;
+    };
+    export type AsObjectPartial = {
+        major?: number;
+        minor?: number;
+        patch?: number;
+        suffix?: string;
     };
 }
 export class CodeGeneratorRequest extends pb_1.Message {
@@ -190,15 +193,15 @@ export class CodeGeneratorRequest extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 15, value);
     }
     get compiler_version() {
-        return pb_1.Message.getWrapperField(this, Version, 3) as Version | undefined | null;
+        return pb_1.Message.getWrapperField(this, Version, 3) as Version | undefined;
     }
-    set compiler_version(value: Version | undefined | null) {
+    set compiler_version(value: Version | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_compiler_version() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<CodeGeneratorRequest.AsObject>): CodeGeneratorRequest {
+    static fromObject(data: CodeGeneratorRequest.AsObjectPartial): CodeGeneratorRequest {
         const message = new CodeGeneratorRequest({
             file_to_generate: data.file_to_generate,
             proto_file: data.proto_file.map(item => dependency_1.FileDescriptorProto.fromObject(item))
@@ -228,12 +231,12 @@ export class CodeGeneratorRequest extends pb_1.Message {
         const writer = w || new pb_1.BinaryWriter();
         if (this.file_to_generate.length)
             writer.writeRepeatedString(1, this.file_to_generate);
-        if (this.has_parameter && this.parameter.length)
+        if (this.has_parameter && this.parameter!.length)
             writer.writeString(2, this.parameter);
         if (this.proto_file.length)
-            writer.writeRepeatedMessage(15, this.proto_file, (item: dependency_1.FileDescriptorProto) => item.serialize(writer));
+            writer.writeRepeatedMessage(15, this.proto_file, (item: dependency_1.FileDescriptorProto) => item!.serialize(writer));
         if (this.has_compiler_version)
-            writer.writeMessage(3, this.compiler_version, () => this.compiler_version.serialize(writer));
+            writer.writeMessage(3, this.compiler_version, () => this.compiler_version!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -273,6 +276,12 @@ export namespace CodeGeneratorRequest {
         parameter: string;
         proto_file: dependency_1.FileDescriptorProto.AsObject[];
         compiler_version?: Version.AsObject;
+    };
+    export type AsObjectPartial = {
+        file_to_generate: string[];
+        parameter?: string;
+        proto_file: dependency_1.FileDescriptorProto.AsObjectPartial[];
+        compiler_version?: Version.AsObjectPartial;
     };
 }
 export class CodeGeneratorResponse extends pb_1.Message {
@@ -318,7 +327,7 @@ export class CodeGeneratorResponse extends pb_1.Message {
     set file(value: CodeGeneratorResponse.File[]) {
         pb_1.Message.setRepeatedWrapperField(this, 15, value);
     }
-    static fromObject(data: RecursivePartial<CodeGeneratorResponse.AsObject>): CodeGeneratorResponse {
+    static fromObject(data: CodeGeneratorResponse.AsObjectPartial): CodeGeneratorResponse {
         const message = new CodeGeneratorResponse({
             file: data.file.map(item => CodeGeneratorResponse.File.fromObject(item))
         });
@@ -342,12 +351,12 @@ export class CodeGeneratorResponse extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_error && this.error.length)
+        if (this.has_error && this.error!.length)
             writer.writeString(1, this.error);
         if (this.has_supported_features)
             writer.writeUint64(2, this.supported_features);
         if (this.file.length)
-            writer.writeRepeatedMessage(15, this.file, (item: CodeGeneratorResponse.File) => item.serialize(writer));
+            writer.writeRepeatedMessage(15, this.file, (item: CodeGeneratorResponse.File) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -383,6 +392,11 @@ export namespace CodeGeneratorResponse {
         error: string;
         supported_features: number;
         file: CodeGeneratorResponse.File.AsObject[];
+    };
+    export type AsObjectPartial = {
+        error?: string;
+        supported_features?: number;
+        file: CodeGeneratorResponse.File.AsObjectPartial[];
     };
     export enum Feature {
         FEATURE_NONE = 0,
@@ -441,15 +455,15 @@ export namespace CodeGeneratorResponse {
             return pb_1.Message.getField(this, 15) != null;
         }
         get generated_code_info() {
-            return pb_1.Message.getWrapperField(this, dependency_1.GeneratedCodeInfo, 16) as dependency_1.GeneratedCodeInfo | undefined | null;
+            return pb_1.Message.getWrapperField(this, dependency_1.GeneratedCodeInfo, 16) as dependency_1.GeneratedCodeInfo | undefined;
         }
-        set generated_code_info(value: dependency_1.GeneratedCodeInfo | undefined | null) {
+        set generated_code_info(value: dependency_1.GeneratedCodeInfo | undefined) {
             pb_1.Message.setWrapperField(this, 16, value);
         }
         get has_generated_code_info() {
             return pb_1.Message.getField(this, 16) != null;
         }
-        static fromObject(data: RecursivePartial<File.AsObject>): File {
+        static fromObject(data: File.AsObjectPartial): File {
             const message = new File({});
             if (data.name != null) {
                 message.name = data.name;
@@ -480,14 +494,14 @@ export namespace CodeGeneratorResponse {
         serialize(w: pb_1.BinaryWriter): void;
         serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
             const writer = w || new pb_1.BinaryWriter();
-            if (this.has_name && this.name.length)
+            if (this.has_name && this.name!.length)
                 writer.writeString(1, this.name);
-            if (this.has_insertion_point && this.insertion_point.length)
+            if (this.has_insertion_point && this.insertion_point!.length)
                 writer.writeString(2, this.insertion_point);
-            if (this.has_content && this.content.length)
+            if (this.has_content && this.content!.length)
                 writer.writeString(15, this.content);
             if (this.has_generated_code_info)
-                writer.writeMessage(16, this.generated_code_info, () => this.generated_code_info.serialize(writer));
+                writer.writeMessage(16, this.generated_code_info, () => this.generated_code_info!.serialize(writer));
             if (!w)
                 return writer.getResultBuffer();
         }
@@ -527,6 +541,12 @@ export namespace CodeGeneratorResponse {
             insertion_point: string;
             content: string;
             generated_code_info?: dependency_1.GeneratedCodeInfo.AsObject;
+        };
+        export type AsObjectPartial = {
+            name?: string;
+            insertion_point?: string;
+            content?: string;
+            generated_code_info?: dependency_1.GeneratedCodeInfo.AsObjectPartial;
         };
     }
 }

--- a/src/compiler/plugin.ts
+++ b/src/compiler/plugin.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./descriptor";
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class Version extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -66,12 +69,7 @@ export class Version extends pb_1.Message {
     get has_suffix() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: {
-        major?: number;
-        minor?: number;
-        patch?: number;
-        suffix?: string;
-    }): Version {
+    static fromObject(data: RecursivePartial<Version.AsObject>): Version {
         const message = new Version({});
         if (data.major != null) {
             message.major = data.major;
@@ -88,12 +86,7 @@ export class Version extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            major: number;
-            minor: number;
-            patch: number;
-            suffix: string;
-        } = {
+        const data: Version.AsObject = {
             major: this.major,
             minor: this.minor,
             patch: this.patch,
@@ -146,6 +139,14 @@ export class Version extends pb_1.Message {
         return Version.deserialize(bytes);
     }
 }
+export namespace Version {
+    export type AsObject = {
+        major: number;
+        minor: number;
+        patch: number;
+        suffix: string;
+    };
+}
 export class CodeGeneratorRequest extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -197,12 +198,7 @@ export class CodeGeneratorRequest extends pb_1.Message {
     get has_compiler_version() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        file_to_generate?: string[];
-        parameter?: string;
-        proto_file?: Parameters<typeof dependency_1.FileDescriptorProto.fromObject>[0][];
-        compiler_version?: Parameters<typeof Version.fromObject>[0];
-    }): CodeGeneratorRequest {
+    static fromObject(data: RecursivePartial<CodeGeneratorRequest.AsObject>): CodeGeneratorRequest {
         const message = new CodeGeneratorRequest({
             file_to_generate: data.file_to_generate,
             proto_file: data.proto_file.map(item => dependency_1.FileDescriptorProto.fromObject(item))
@@ -216,12 +212,7 @@ export class CodeGeneratorRequest extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            file_to_generate: string[];
-            parameter: string;
-            proto_file: Parameters<typeof dependency_1.FileDescriptorProto.fromObject>[0][];
-            compiler_version?: Parameters<typeof Version.fromObject>[0];
-        } = {
+        const data: CodeGeneratorRequest.AsObject = {
             file_to_generate: this.file_to_generate,
             parameter: this.parameter,
             proto_file: this.proto_file.map((item: dependency_1.FileDescriptorProto) => item.toObject())
@@ -276,6 +267,14 @@ export class CodeGeneratorRequest extends pb_1.Message {
         return CodeGeneratorRequest.deserialize(bytes);
     }
 }
+export namespace CodeGeneratorRequest {
+    export type AsObject = {
+        file_to_generate: string[];
+        parameter: string;
+        proto_file: dependency_1.FileDescriptorProto.AsObject[];
+        compiler_version?: Version.AsObject;
+    };
+}
 export class CodeGeneratorResponse extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -319,11 +318,7 @@ export class CodeGeneratorResponse extends pb_1.Message {
     set file(value: CodeGeneratorResponse.File[]) {
         pb_1.Message.setRepeatedWrapperField(this, 15, value);
     }
-    static fromObject(data: {
-        error?: string;
-        supported_features?: number;
-        file?: Parameters<typeof CodeGeneratorResponse.File.fromObject>[0][];
-    }): CodeGeneratorResponse {
+    static fromObject(data: RecursivePartial<CodeGeneratorResponse.AsObject>): CodeGeneratorResponse {
         const message = new CodeGeneratorResponse({
             file: data.file.map(item => CodeGeneratorResponse.File.fromObject(item))
         });
@@ -336,11 +331,7 @@ export class CodeGeneratorResponse extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            error: string;
-            supported_features: number;
-            file: Parameters<typeof CodeGeneratorResponse.File.fromObject>[0][];
-        } = {
+        const data: CodeGeneratorResponse.AsObject = {
             error: this.error,
             supported_features: this.supported_features,
             file: this.file.map((item: CodeGeneratorResponse.File) => item.toObject())
@@ -388,6 +379,11 @@ export class CodeGeneratorResponse extends pb_1.Message {
     }
 }
 export namespace CodeGeneratorResponse {
+    export type AsObject = {
+        error: string;
+        supported_features: number;
+        file: CodeGeneratorResponse.File.AsObject[];
+    };
     export enum Feature {
         FEATURE_NONE = 0,
         FEATURE_PROTO3_OPTIONAL = 1
@@ -453,12 +449,7 @@ export namespace CodeGeneratorResponse {
         get has_generated_code_info() {
             return pb_1.Message.getField(this, 16) != null;
         }
-        static fromObject(data: {
-            name?: string;
-            insertion_point?: string;
-            content?: string;
-            generated_code_info?: Parameters<typeof dependency_1.GeneratedCodeInfo.fromObject>[0];
-        }): File {
+        static fromObject(data: RecursivePartial<File.AsObject>): File {
             const message = new File({});
             if (data.name != null) {
                 message.name = data.name;
@@ -475,12 +466,7 @@ export namespace CodeGeneratorResponse {
             return message;
         }
         toObject() {
-            const data: {
-                name: string;
-                insertion_point: string;
-                content: string;
-                generated_code_info?: Parameters<typeof dependency_1.GeneratedCodeInfo.fromObject>[0];
-            } = {
+            const data: File.AsObject = {
                 name: this.name,
                 insertion_point: this.insertion_point,
                 content: this.content
@@ -534,5 +520,13 @@ export namespace CodeGeneratorResponse {
         static deserializeBinary(bytes: Uint8Array): File {
             return File.deserialize(bytes);
         }
+    }
+    export namespace File {
+        export type AsObject = {
+            name: string;
+            insertion_point: string;
+            content: string;
+            generated_code_info?: dependency_1.GeneratedCodeInfo.AsObject;
+        };
     }
 }

--- a/src/compiler/plugin.ts
+++ b/src/compiler/plugin.ts
@@ -190,9 +190,9 @@ export class CodeGeneratorRequest extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 15, value);
     }
     get compiler_version() {
-        return pb_1.Message.getWrapperField(this, Version, 3) as Version;
+        return pb_1.Message.getWrapperField(this, Version, 3) as Version | undefined | null;
     }
-    set compiler_version(value: Version) {
+    set compiler_version(value: Version | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_compiler_version() {
@@ -441,9 +441,9 @@ export namespace CodeGeneratorResponse {
             return pb_1.Message.getField(this, 15) != null;
         }
         get generated_code_info() {
-            return pb_1.Message.getWrapperField(this, dependency_1.GeneratedCodeInfo, 16) as dependency_1.GeneratedCodeInfo;
+            return pb_1.Message.getWrapperField(this, dependency_1.GeneratedCodeInfo, 16) as dependency_1.GeneratedCodeInfo | undefined | null;
         }
-        set generated_code_info(value: dependency_1.GeneratedCodeInfo) {
+        set generated_code_info(value: dependency_1.GeneratedCodeInfo | undefined | null) {
             pb_1.Message.setWrapperField(this, 16, value);
         }
         get has_generated_code_info() {

--- a/src/compiler/plugin.ts
+++ b/src/compiler/plugin.ts
@@ -89,23 +89,16 @@ export class Version extends pb_1.Message {
     }
     toObject() {
         const data: {
-            major?: number;
-            minor?: number;
-            patch?: number;
-            suffix?: string;
-        } = {};
-        if (this.major != null) {
-            data.major = this.major;
-        }
-        if (this.minor != null) {
-            data.minor = this.minor;
-        }
-        if (this.patch != null) {
-            data.patch = this.patch;
-        }
-        if (this.suffix != null) {
-            data.suffix = this.suffix;
-        }
+            major: number;
+            minor: number;
+            patch: number;
+            suffix: string;
+        } = {
+            major: this.major,
+            minor: this.minor,
+            patch: this.patch,
+            suffix: this.suffix
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -205,10 +198,10 @@ export class CodeGeneratorRequest extends pb_1.Message {
         return pb_1.Message.getField(this, 3) != null;
     }
     static fromObject(data: {
-        file_to_generate: string[];
+        file_to_generate?: string[];
         parameter?: string;
-        proto_file?: ReturnType<typeof dependency_1.FileDescriptorProto.prototype.toObject>[];
-        compiler_version?: ReturnType<typeof Version.prototype.toObject>;
+        proto_file?: Parameters<typeof dependency_1.FileDescriptorProto.fromObject>[0][];
+        compiler_version?: Parameters<typeof Version.fromObject>[0];
     }): CodeGeneratorRequest {
         const message = new CodeGeneratorRequest({
             file_to_generate: data.file_to_generate,
@@ -225,18 +218,14 @@ export class CodeGeneratorRequest extends pb_1.Message {
     toObject() {
         const data: {
             file_to_generate: string[];
-            parameter?: string;
-            proto_file?: ReturnType<typeof dependency_1.FileDescriptorProto.prototype.toObject>[];
-            compiler_version?: ReturnType<typeof Version.prototype.toObject>;
+            parameter: string;
+            proto_file: Parameters<typeof dependency_1.FileDescriptorProto.fromObject>[0][];
+            compiler_version?: Parameters<typeof Version.fromObject>[0];
         } = {
-            file_to_generate: this.file_to_generate
+            file_to_generate: this.file_to_generate,
+            parameter: this.parameter,
+            proto_file: this.proto_file.map((item: dependency_1.FileDescriptorProto) => item.toObject())
         };
-        if (this.parameter != null) {
-            data.parameter = this.parameter;
-        }
-        if (this.proto_file != null) {
-            data.proto_file = this.proto_file.map((item: dependency_1.FileDescriptorProto) => item.toObject());
-        }
         if (this.compiler_version != null) {
             data.compiler_version = this.compiler_version.toObject();
         }
@@ -333,7 +322,7 @@ export class CodeGeneratorResponse extends pb_1.Message {
     static fromObject(data: {
         error?: string;
         supported_features?: number;
-        file?: ReturnType<typeof CodeGeneratorResponse.File.prototype.toObject>[];
+        file?: Parameters<typeof CodeGeneratorResponse.File.fromObject>[0][];
     }): CodeGeneratorResponse {
         const message = new CodeGeneratorResponse({
             file: data.file.map(item => CodeGeneratorResponse.File.fromObject(item))
@@ -348,19 +337,14 @@ export class CodeGeneratorResponse extends pb_1.Message {
     }
     toObject() {
         const data: {
-            error?: string;
-            supported_features?: number;
-            file?: ReturnType<typeof CodeGeneratorResponse.File.prototype.toObject>[];
-        } = {};
-        if (this.error != null) {
-            data.error = this.error;
-        }
-        if (this.supported_features != null) {
-            data.supported_features = this.supported_features;
-        }
-        if (this.file != null) {
-            data.file = this.file.map((item: CodeGeneratorResponse.File) => item.toObject());
-        }
+            error: string;
+            supported_features: number;
+            file: Parameters<typeof CodeGeneratorResponse.File.fromObject>[0][];
+        } = {
+            error: this.error,
+            supported_features: this.supported_features,
+            file: this.file.map((item: CodeGeneratorResponse.File) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -473,7 +457,7 @@ export namespace CodeGeneratorResponse {
             name?: string;
             insertion_point?: string;
             content?: string;
-            generated_code_info?: ReturnType<typeof dependency_1.GeneratedCodeInfo.prototype.toObject>;
+            generated_code_info?: Parameters<typeof dependency_1.GeneratedCodeInfo.fromObject>[0];
         }): File {
             const message = new File({});
             if (data.name != null) {
@@ -492,20 +476,15 @@ export namespace CodeGeneratorResponse {
         }
         toObject() {
             const data: {
-                name?: string;
-                insertion_point?: string;
-                content?: string;
-                generated_code_info?: ReturnType<typeof dependency_1.GeneratedCodeInfo.prototype.toObject>;
-            } = {};
-            if (this.name != null) {
-                data.name = this.name;
-            }
-            if (this.insertion_point != null) {
-                data.insertion_point = this.insertion_point;
-            }
-            if (this.content != null) {
-                data.content = this.content;
-            }
+                name: string;
+                insertion_point: string;
+                content: string;
+                generated_code_info?: Parameters<typeof dependency_1.GeneratedCodeInfo.fromObject>[0];
+            } = {
+                name: this.name,
+                insertion_point: this.insertion_point,
+                content: this.content
+            };
             if (this.generated_code_info != null) {
                 data.generated_code_info = this.generated_code_info.toObject();
             }

--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -914,10 +914,13 @@ function createGetter(
   pbIdentifier: ts.Identifier,
   parentName: string = '',
 ): ts.GetAccessorDeclaration {
-  const getterType = field.wrapRepeatedType(
+  let getterType = field.wrapRepeatedType(
     field.getType(fieldDescriptor, rootDescriptor) as ts.TypeNode,
     fieldDescriptor,
   );
+  if (!field.alwaysHasValue(rootDescriptor, fieldDescriptor)) {
+    getterType = field.wrapNullableType(getterType)
+  }
   let getterExpr: ts.Expression = createGetterCall(
     rootDescriptor,
     fieldDescriptor,
@@ -1148,10 +1151,13 @@ function createSetter(
   fieldDescriptor: descriptor.FieldDescriptorProto,
   pbIdentifier: ts.Identifier,
 ) {
-  const type = field.wrapRepeatedType(
+  let type = field.wrapRepeatedType(
     field.getType(fieldDescriptor, rootDescriptor),
     fieldDescriptor,
   );
+  if (!field.alwaysHasValue(rootDescriptor, fieldDescriptor)) {
+    type = field.wrapNullableType(type)
+  }
   const valueParameter = ts.factory.createIdentifier("value");
 
   let block: ts.Block;

--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -453,14 +453,6 @@ function createToObject(
         ts.factory.createNull(),
       );
 
-      if (field.isMap(fieldDescriptor)) {
-        condition = ts.factory.createBinaryExpression(
-          ts.factory.createPropertyAccessExpression(propertyAccessor, "size"),
-          ts.factory.createToken(ts.SyntaxKind.GreaterThanToken),
-          ts.factory.createNumericLiteral(0),
-        );
-      }
-
       statements.push(
         ts.factory.createIfStatement(
           condition,

--- a/src/field.ts
+++ b/src/field.ts
@@ -31,11 +31,13 @@ export function getMapType(rootDescriptor: descriptor.FileDescriptorProto, field
 /**
  * @param {descriptor.FieldDescriptorProto} fieldDescriptor
  * @param {descriptor.FileDescriptorProto} rootDescriptor
+ * @param asObject to return message AsObject representation reference
  * @returns {ts.TypeReferenceNode | ts.Identifier | ts.PropertyAccessExpression}
  */
 export function getType(
   fieldDescriptor: descriptor.FieldDescriptorProto,
   rootDescriptor: descriptor.FileDescriptorProto,
+  asObject = false,
 ): ts.TypeReferenceNode {
   if (isMap(fieldDescriptor)) {
     return getMapType(rootDescriptor, fieldDescriptor);
@@ -64,6 +66,11 @@ export function getType(
     case descriptor.FieldDescriptorProto.Type.TYPE_BYTES:
       return ts.factory.createTypeReferenceNode("Uint8Array");
     case descriptor.FieldDescriptorProto.Type.TYPE_MESSAGE:
+      return type.getTypeReference(
+        rootDescriptor,
+        fieldDescriptor.type_name,
+        asObject
+      );
     case descriptor.FieldDescriptorProto.Type.TYPE_ENUM:
       return type.getTypeReference(rootDescriptor, fieldDescriptor.type_name);
     default:

--- a/src/field.ts
+++ b/src/field.ts
@@ -15,6 +15,18 @@ export function wrapRepeatedType(type: any, fieldDescriptor: descriptor.FieldDes
 }
 
 /**
+ * Given the type T constructs T | undefined | null.
+ * @param type
+ */
+export function wrapNullableType(type: ts.TypeNode) {
+  return ts.factory.createUnionTypeNode([
+    type,
+    ts.factory.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+    ts.factory.createLiteralTypeNode(ts.factory.createNull()),
+  ])
+}
+
+/**
  * @param {descriptor.FileDescriptorProto} rootDescriptor
  * @param {descriptor.FieldDescriptorProto} fieldDescriptor
  */

--- a/src/field.ts
+++ b/src/field.ts
@@ -65,7 +65,7 @@ export function getType(
       return ts.factory.createTypeReferenceNode("Uint8Array");
     case descriptor.FieldDescriptorProto.Type.TYPE_MESSAGE:
     case descriptor.FieldDescriptorProto.Type.TYPE_ENUM:
-      return type.getTypeReference(rootDescriptor, fieldDescriptor.type_name)
+      return type.getTypeReference(rootDescriptor, fieldDescriptor.type_name);
     default:
       throw new Error("Unhandled type " + fieldDescriptor.type);
   }
@@ -191,6 +191,28 @@ export function isOptional(
     descriptor.FieldDescriptorProto.Label.LABEL_OPTIONAL
   );
 }
+
+/**
+ * Function is used to determine, whether the field must be non-null
+ * in the toObject() method or getter function return type.
+ * @param {descriptor.FileDescriptorProto} rootDescriptor
+ * @param {descriptor.FieldDescriptorProto} fieldDescriptor
+ */
+export function alwaysHasValue(
+  rootDescriptor: descriptor.FileDescriptorProto,
+  fieldDescriptor: descriptor.FieldDescriptorProto,
+) {
+  return (
+    isNumber(fieldDescriptor) ||
+    isEnum(fieldDescriptor) ||
+    isRepeated(fieldDescriptor) ||
+    isBytes(fieldDescriptor) ||
+    isString(fieldDescriptor) ||
+    isBoolean(fieldDescriptor) ||
+    isMap(fieldDescriptor)
+  ) && !isRequiredWithoutExplicitDefault(rootDescriptor, fieldDescriptor);
+}
+
 /**
  * @param {descriptor.FileDescriptorProto} rootDescriptor
  * @param {descriptor.FieldDescriptorProto} fieldDescriptor
@@ -218,7 +240,7 @@ export function isString(fieldDescriptor: descriptor.FieldDescriptorProto) {
 /**
  * @param {descriptor.FieldDescriptorProto} fieldDescriptor
  */
- export function isBytes(fieldDescriptor: descriptor.FieldDescriptorProto) {
+export function isBytes(fieldDescriptor: descriptor.FieldDescriptorProto) {
   return (
     fieldDescriptor.type == descriptor.FieldDescriptorProto.Type.TYPE_BYTES
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,13 @@ for (const fileDescriptor of request.proto_file) {
     ),
   ];
 
+
+  if (fileDescriptor.message_type.length > 0) {
+    statements.unshift(
+      type.recursivePartialDeclaration()
+    )
+  }
+
   if (statements.length) {
     importStatements.push(createImport(pbIdentifier, "google-protobuf"));
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,13 +87,6 @@ for (const fileDescriptor of request.proto_file) {
     ),
   ];
 
-
-  if (fileDescriptor.message_type.length > 0) {
-    statements.unshift(
-      type.recursivePartialDeclaration()
-    )
-  }
-
   if (statements.length) {
     importStatements.push(createImport(pbIdentifier, "google-protobuf"));
   }

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -308,9 +308,9 @@ function createUnaryRpcPromiseMethod(
   //   }
   // }
   const promiseBody = ts.factory.createCallExpression(
-    ts.factory.createPropertyAccessExpression(
+    ts.factory.createElementAccessExpression(
       ts.factory.createSuper(),
-      methodDescriptor.name,
+      ts.factory.createStringLiteral(methodDescriptor.name),
     ),
     undefined,
     [
@@ -794,9 +794,9 @@ function createUnaryRpcMethod(
           [
             ts.factory.createReturnStatement(
               ts.factory.createCallExpression(
-                ts.factory.createPropertyAccessExpression(
+                ts.factory.createElementAccessExpression(
                   ts.factory.createSuper(),
-                  methodDescriptor.name,
+                  ts.factory.createStringLiteral(methodDescriptor.name),
                 ),
                 undefined,
                 [
@@ -895,9 +895,9 @@ function createClientStreamingRpcMethod(
           [
             ts.factory.createReturnStatement(
               ts.factory.createCallExpression(
-                ts.factory.createPropertyAccessExpression(
+                ts.factory.createElementAccessExpression(
                   ts.factory.createSuper(),
-                  methodDescriptor.name,
+                  ts.factory.createStringLiteral(methodDescriptor.name),
                 ),
                 undefined,
                 [
@@ -976,9 +976,9 @@ function createServerStreamingRpcMethod(
           [
             ts.factory.createReturnStatement(
               ts.factory.createCallExpression(
-                ts.factory.createPropertyAccessExpression(
+                ts.factory.createElementAccessExpression(
                   ts.factory.createSuper(),
-                  methodDescriptor.name,
+                  ts.factory.createStringLiteral(methodDescriptor.name),
                 ),
                 undefined,
                 [
@@ -1057,9 +1057,9 @@ function createBidiStreamingRpcMethod(
           [
             ts.factory.createReturnStatement(
               ts.factory.createCallExpression(
-                ts.factory.createPropertyAccessExpression(
+                ts.factory.createElementAccessExpression(
                   ts.factory.createSuper(),
-                  methodDescriptor.name,
+                  ts.factory.createStringLiteral(methodDescriptor.name),
                 ),
                 undefined,
                 [

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -13,17 +13,24 @@ diff_and_update(
     checked = PROT_SOURCES,
 )
 
+# Allow any subpackages to reference the config
+exports_files(
+    [
+        "tsconfig.json",
+    ],
+    visibility = [":__subpackages__"],
+)
+
 
 ts_project(
     name = "tests",
     srcs = glob(["*.ts"]),
     tsconfig = {
         "compilerOptions": {
-            "target": "ES2020",
-            "module": "CommonJS",
             "noImplicitAny": True
         },
     },
+    extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -25,11 +25,7 @@ exports_files(
 ts_project(
     name = "tests",
     srcs = glob(["*.ts"]),
-    tsconfig = {
-        "compilerOptions": {
-            "noImplicitAny": True
-        },
-    },
+    tsconfig = {}, # no special options
     extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",

--- a/test/conformance.ts
+++ b/test/conformance.ts
@@ -138,7 +138,7 @@ export namespace main {
             super(address, credentials, options);
         }
         Method: GrpcUnaryServiceInterface<Message, MessageResult> = (message: Message, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<MessageResult>, options?: grpc_1.CallOptions | grpc_1.requestCallback<MessageResult>, callback?: grpc_1.requestCallback<MessageResult>): grpc_1.ClientUnaryCall => {
-            return super.Method(message, metadata, options, callback);
+            return super["Method"](message, metadata, options, callback);
         };
     }
 }

--- a/test/conformance.ts
+++ b/test/conformance.ts
@@ -6,9 +6,6 @@
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
 export namespace main {
-    type RecursivePartial<T> = {
-        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-    };
     export class Message extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {}) {
@@ -16,7 +13,7 @@ export namespace main {
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
             if (!Array.isArray(data) && typeof data == "object") { }
         }
-        static fromObject(data: RecursivePartial<Message.AsObject>): Message {
+        static fromObject(data: Message.AsObjectPartial): Message {
             const message = new Message({});
             return message;
         }
@@ -51,6 +48,7 @@ export namespace main {
     }
     export namespace Message {
         export type AsObject = {};
+        export type AsObjectPartial = {};
     }
     export class MessageResult extends pb_1.Message {
         #one_of_decls: number[][] = [];
@@ -59,7 +57,7 @@ export namespace main {
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
             if (!Array.isArray(data) && typeof data == "object") { }
         }
-        static fromObject(data: RecursivePartial<MessageResult.AsObject>): MessageResult {
+        static fromObject(data: MessageResult.AsObjectPartial): MessageResult {
             const message = new MessageResult({});
             return message;
         }
@@ -94,6 +92,7 @@ export namespace main {
     }
     export namespace MessageResult {
         export type AsObject = {};
+        export type AsObjectPartial = {};
     }
     interface GrpcUnaryServiceInterface<P, R> {
         (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/conformance.ts
+++ b/test/conformance.ts
@@ -6,6 +6,9 @@
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
 export namespace main {
+    type RecursivePartial<T> = {
+        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+    };
     export class Message extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {}) {
@@ -13,12 +16,12 @@ export namespace main {
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
             if (!Array.isArray(data) && typeof data == "object") { }
         }
-        static fromObject(data: {}): Message {
+        static fromObject(data: RecursivePartial<Message.AsObject>): Message {
             const message = new Message({});
             return message;
         }
         toObject() {
-            const data: {} = {};
+            const data: Message.AsObject = {};
             return data;
         }
         serialize(): Uint8Array;
@@ -46,6 +49,9 @@ export namespace main {
             return Message.deserialize(bytes);
         }
     }
+    export namespace Message {
+        export type AsObject = {};
+    }
     export class MessageResult extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {}) {
@@ -53,12 +59,12 @@ export namespace main {
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
             if (!Array.isArray(data) && typeof data == "object") { }
         }
-        static fromObject(data: {}): MessageResult {
+        static fromObject(data: RecursivePartial<MessageResult.AsObject>): MessageResult {
             const message = new MessageResult({});
             return message;
         }
         toObject() {
-            const data: {} = {};
+            const data: MessageResult.AsObject = {};
             return data;
         }
         serialize(): Uint8Array;
@@ -85,6 +91,9 @@ export namespace main {
         static deserializeBinary(bytes: Uint8Array): MessageResult {
             return MessageResult.deserialize(bytes);
         }
+    }
+    export namespace MessageResult {
+        export type AsObject = {};
     }
     interface GrpcUnaryServiceInterface<P, R> {
         (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/conformance/map/BUILD.bazel
+++ b/test/conformance/map/BUILD.bazel
@@ -29,11 +29,10 @@ ts_project(
     srcs = glob(["**/*.ts"]),
     tsconfig = {
         "compilerOptions": {
-            "target": "ES2020",
-            "module": "CommonJS",
             "noImplicitAny": True
         },
     },
+    extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/test/conformance/map/BUILD.bazel
+++ b/test/conformance/map/BUILD.bazel
@@ -27,11 +27,7 @@ diff_and_update(
 ts_project(
     name = "test_lib",
     srcs = glob(["**/*.ts"]),
-    tsconfig = {
-        "compilerOptions": {
-            "noImplicitAny": True
-        },
-    },
+    tsconfig = {}, # no special options
     extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",

--- a/test/conformance/map/proto/map_checked.ts
+++ b/test/conformance/map/proto/map_checked.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace maps {
+    type RecursivePartial<T> = {
+        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+    };
     export class Topic extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -24,9 +27,7 @@ export namespace maps {
         set link(value: string) {
             pb_1.Message.setField(this, 2, value);
         }
-        static fromObject(data: {
-            link?: string;
-        }): Topic {
+        static fromObject(data: RecursivePartial<Topic.AsObject>): Topic {
             const message = new Topic({});
             if (data.link != null) {
                 message.link = data.link;
@@ -34,9 +35,7 @@ export namespace maps {
             return message;
         }
         toObject() {
-            const data: {
-                link: string;
-            } = {
+            const data: Topic.AsObject = {
                 link: this.link
             };
             return data;
@@ -70,6 +69,11 @@ export namespace maps {
         static deserializeBinary(bytes: Uint8Array): Topic {
             return Topic.deserialize(bytes);
         }
+    }
+    export namespace Topic {
+        export type AsObject = {
+            link: string;
+        };
     }
     export class Tags extends pb_1.Message {
         #one_of_decls: number[][] = [];
@@ -126,18 +130,7 @@ export namespace maps {
         set topics_with_intkeys(value: Map<number, Topic>) {
             pb_1.Message.setField(this, 4, value as any);
         }
-        static fromObject(data: {
-            key?: string;
-            keys?: {
-                [key: string]: string;
-            };
-            topics?: {
-                [key: string]: Parameters<typeof Topic.fromObject>[0];
-            };
-            topics_with_intkeys?: {
-                [key: number]: Parameters<typeof Topic.fromObject>[0];
-            };
-        }): Tags {
+        static fromObject(data: RecursivePartial<Tags.AsObject>): Tags {
             const message = new Tags({});
             if (data.key != null) {
                 message.key = data.key;
@@ -154,18 +147,7 @@ export namespace maps {
             return message;
         }
         toObject() {
-            const data: {
-                key: string;
-                keys: {
-                    [key: string]: string;
-                };
-                topics: {
-                    [key: string]: Parameters<typeof Topic.fromObject>[0];
-                };
-                topics_with_intkeys: {
-                    [key: number]: Parameters<typeof Topic.fromObject>[0];
-                };
-            } = {
+            const data: Tags.AsObject = {
                 key: this.key,
                 keys: Object.fromEntries(this.keys),
                 topics: Object.fromEntries(Array.from(this.topics).map(([key, value]) => [key, value.toObject()])),
@@ -237,5 +219,19 @@ export namespace maps {
         static deserializeBinary(bytes: Uint8Array): Tags {
             return Tags.deserialize(bytes);
         }
+    }
+    export namespace Tags {
+        export type AsObject = {
+            key: string;
+            keys: {
+                [key: string]: string;
+            };
+            topics: {
+                [key: string]: Topic.AsObject;
+            };
+            topics_with_intkeys: {
+                [key: number]: Topic.AsObject;
+            };
+        };
     }
 }

--- a/test/conformance/map/proto/map_checked.ts
+++ b/test/conformance/map/proto/map_checked.ts
@@ -35,11 +35,10 @@ export namespace maps {
         }
         toObject() {
             const data: {
-                link?: string;
-            } = {};
-            if (this.link != null) {
-                data.link = this.link;
-            }
+                link: string;
+            } = {
+                link: this.link
+            };
             return data;
         }
         serialize(): Uint8Array;
@@ -133,10 +132,10 @@ export namespace maps {
                 [key: string]: string;
             };
             topics?: {
-                [key: string]: ReturnType<typeof Topic.prototype.toObject>;
+                [key: string]: Parameters<typeof Topic.fromObject>[0];
             };
             topics_with_intkeys?: {
-                [key: number]: ReturnType<typeof Topic.prototype.toObject>;
+                [key: number]: Parameters<typeof Topic.fromObject>[0];
             };
         }): Tags {
             const message = new Tags({});
@@ -156,29 +155,22 @@ export namespace maps {
         }
         toObject() {
             const data: {
-                key?: string;
-                keys?: {
+                key: string;
+                keys: {
                     [key: string]: string;
                 };
-                topics?: {
-                    [key: string]: ReturnType<typeof Topic.prototype.toObject>;
+                topics: {
+                    [key: string]: Parameters<typeof Topic.fromObject>[0];
                 };
-                topics_with_intkeys?: {
-                    [key: number]: ReturnType<typeof Topic.prototype.toObject>;
+                topics_with_intkeys: {
+                    [key: number]: Parameters<typeof Topic.fromObject>[0];
                 };
-            } = {};
-            if (this.key != null) {
-                data.key = this.key;
-            }
-            if (this.keys != null) {
-                data.keys = Object.fromEntries(this.keys);
-            }
-            if (this.topics != null) {
-                data.topics = Object.fromEntries(Array.from(this.topics).map(([key, value]) => [key, value.toObject()]));
-            }
-            if (this.topics_with_intkeys != null) {
-                data.topics_with_intkeys = Object.fromEntries(Array.from(this.topics_with_intkeys).map(([key, value]) => [key, value.toObject()]));
-            }
+            } = {
+                key: this.key,
+                keys: Object.fromEntries(this.keys),
+                topics: Object.fromEntries(Array.from(this.topics).map(([key, value]) => [key, value.toObject()])),
+                topics_with_intkeys: Object.fromEntries(Array.from(this.topics_with_intkeys).map(([key, value]) => [key, value.toObject()]))
+            };
             return data;
         }
         serialize(): Uint8Array;

--- a/test/conformance/map/proto/map_checked.ts
+++ b/test/conformance/map/proto/map_checked.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace maps {
-    type RecursivePartial<T> = {
-        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-    };
     export class Topic extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -27,7 +24,7 @@ export namespace maps {
         set link(value: string) {
             pb_1.Message.setField(this, 2, value);
         }
-        static fromObject(data: RecursivePartial<Topic.AsObject>): Topic {
+        static fromObject(data: Topic.AsObjectPartial): Topic {
             const message = new Topic({});
             if (data.link != null) {
                 message.link = data.link;
@@ -73,6 +70,9 @@ export namespace maps {
     export namespace Topic {
         export type AsObject = {
             link: string;
+        };
+        export type AsObjectPartial = {
+            link?: string;
         };
     }
     export class Tags extends pb_1.Message {
@@ -130,7 +130,7 @@ export namespace maps {
         set topics_with_intkeys(value: Map<number, Topic>) {
             pb_1.Message.setField(this, 4, value as any);
         }
-        static fromObject(data: RecursivePartial<Tags.AsObject>): Tags {
+        static fromObject(data: Tags.AsObjectPartial): Tags {
             const message = new Tags({});
             if (data.key != null) {
                 message.key = data.key;
@@ -170,13 +170,13 @@ export namespace maps {
             for (const [key, value] of this.topics) {
                 writer.writeMessage(3, this.topics, () => {
                     writer.writeString(1, key);
-                    writer.writeMessage(2, value, () => value.serialize(writer));
+                    writer.writeMessage(2, value, () => value!.serialize(writer));
                 });
             }
             for (const [key, value] of this.topics_with_intkeys) {
                 writer.writeMessage(4, this.topics_with_intkeys, () => {
                     writer.writeInt64(1, key);
-                    writer.writeMessage(2, value, () => value.serialize(writer));
+                    writer.writeMessage(2, value, () => value!.serialize(writer));
                 });
             }
             if (!w)
@@ -230,6 +230,18 @@ export namespace maps {
                 [key: string]: Topic.AsObject;
             };
             topics_with_intkeys: {
+                [key: number]: Topic.AsObject;
+            };
+        };
+        export type AsObjectPartial = {
+            key?: string;
+            keys?: {
+                [key: string]: string;
+            };
+            topics?: {
+                [key: string]: Topic.AsObject;
+            };
+            topics_with_intkeys?: {
                 [key: number]: Topic.AsObject;
             };
         };

--- a/test/conformance/map/proto/map_checked.ts
+++ b/test/conformance/map/proto/map_checked.ts
@@ -170,13 +170,13 @@ export namespace maps {
             if (this.key != null) {
                 data.key = this.key;
             }
-            if (this.keys.size > 0) {
+            if (this.keys != null) {
                 data.keys = Object.fromEntries(this.keys);
             }
-            if (this.topics.size > 0) {
+            if (this.topics != null) {
                 data.topics = Object.fromEntries(Array.from(this.topics).map(([key, value]) => [key, value.toObject()]));
             }
-            if (this.topics_with_intkeys.size > 0) {
+            if (this.topics_with_intkeys != null) {
                 data.topics_with_intkeys = Object.fromEntries(Array.from(this.topics_with_intkeys).map(([key, value]) => [key, value.toObject()]));
             }
             return data;

--- a/test/conformance/packedproto2/BUILD.bazel
+++ b/test/conformance/packedproto2/BUILD.bazel
@@ -27,11 +27,7 @@ diff_and_update(
 ts_project(
     name = "tests",
     srcs = glob(["*.ts"]),
-    tsconfig = {
-        "compilerOptions": {
-            "noImplicitAny": True
-        },
-    },
+    tsconfig = {}, # no special options
     extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",

--- a/test/conformance/packedproto2/BUILD.bazel
+++ b/test/conformance/packedproto2/BUILD.bazel
@@ -29,11 +29,10 @@ ts_project(
     srcs = glob(["*.ts"]),
     tsconfig = {
         "compilerOptions": {
-            "target": "ES2020",
-            "module": "CommonJS",
             "noImplicitAny": True
         },
     },
+    extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/test/conformance/packedproto2/packed_proto2.ts
+++ b/test/conformance/packedproto2/packed_proto2.ts
@@ -330,27 +330,27 @@ export class HydratedTemplateButton extends pb_1.Message {
         return pb_1.Message.getField(this, 4) != null;
     }
     get quickReplyButton() {
-        return pb_1.Message.getWrapperField(this, HydratedQuickReplyButton, 1) as HydratedQuickReplyButton;
+        return pb_1.Message.getWrapperField(this, HydratedQuickReplyButton, 1) as HydratedQuickReplyButton | undefined | null;
     }
-    set quickReplyButton(value: HydratedQuickReplyButton) {
+    set quickReplyButton(value: HydratedQuickReplyButton | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_quickReplyButton() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get urlButton() {
-        return pb_1.Message.getWrapperField(this, HydratedURLButton, 2) as HydratedURLButton;
+        return pb_1.Message.getWrapperField(this, HydratedURLButton, 2) as HydratedURLButton | undefined | null;
     }
-    set urlButton(value: HydratedURLButton) {
+    set urlButton(value: HydratedURLButton | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_urlButton() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get callButton() {
-        return pb_1.Message.getWrapperField(this, HydratedCallButton, 3) as HydratedCallButton;
+        return pb_1.Message.getWrapperField(this, HydratedCallButton, 3) as HydratedCallButton | undefined | null;
     }
-    set callButton(value: HydratedCallButton) {
+    set callButton(value: HydratedCallButton | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_callButton() {
@@ -469,9 +469,9 @@ export class QuickReplyButton extends pb_1.Message {
         }
     }
     get displayText() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined | null;
     }
-    set displayText(value: HighlyStructuredMessage) {
+    set displayText(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_displayText() {
@@ -564,18 +564,18 @@ export class URLButton extends pb_1.Message {
         }
     }
     get displayText() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined | null;
     }
-    set displayText(value: HighlyStructuredMessage) {
+    set displayText(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_displayText() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get url() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined | null;
     }
-    set url(value: HighlyStructuredMessage) {
+    set url(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_url() {
@@ -660,18 +660,18 @@ export class CallButton extends pb_1.Message {
         }
     }
     get displayText() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined | null;
     }
-    set displayText(value: HighlyStructuredMessage) {
+    set displayText(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_displayText() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get phoneNumber() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined | null;
     }
-    set phoneNumber(value: HighlyStructuredMessage) {
+    set phoneNumber(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_phoneNumber() {
@@ -782,27 +782,27 @@ export class TemplateButton extends pb_1.Message {
         return pb_1.Message.getField(this, 4) != null;
     }
     get quickReplyButton() {
-        return pb_1.Message.getWrapperField(this, QuickReplyButton, 1) as QuickReplyButton;
+        return pb_1.Message.getWrapperField(this, QuickReplyButton, 1) as QuickReplyButton | undefined | null;
     }
-    set quickReplyButton(value: QuickReplyButton) {
+    set quickReplyButton(value: QuickReplyButton | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_quickReplyButton() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get urlButton() {
-        return pb_1.Message.getWrapperField(this, URLButton, 2) as URLButton;
+        return pb_1.Message.getWrapperField(this, URLButton, 2) as URLButton | undefined | null;
     }
-    set urlButton(value: URLButton) {
+    set urlButton(value: URLButton | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_urlButton() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get callButton() {
-        return pb_1.Message.getWrapperField(this, CallButton, 3) as CallButton;
+        return pb_1.Message.getWrapperField(this, CallButton, 3) as CallButton | undefined | null;
     }
-    set callButton(value: CallButton) {
+    set callButton(value: CallButton | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_callButton() {
@@ -1181,9 +1181,9 @@ export class InteractiveAnnotation extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
     get location() {
-        return pb_1.Message.getWrapperField(this, Location, 2) as Location;
+        return pb_1.Message.getWrapperField(this, Location, 2) as Location | undefined | null;
     }
-    set location(value: Location) {
+    set location(value: Location | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_location() {
@@ -1487,9 +1487,9 @@ export class ContextInfo extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get quotedMessage() {
-        return pb_1.Message.getWrapperField(this, Message, 3) as Message;
+        return pb_1.Message.getWrapperField(this, Message, 3) as Message | undefined | null;
     }
-    set quotedMessage(value: Message) {
+    set quotedMessage(value: Message | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_quotedMessage() {
@@ -1556,18 +1556,18 @@ export class ContextInfo extends pb_1.Message {
         return pb_1.Message.getField(this, 22) != null;
     }
     get quotedAd() {
-        return pb_1.Message.getWrapperField(this, AdReplyInfo, 23) as AdReplyInfo;
+        return pb_1.Message.getWrapperField(this, AdReplyInfo, 23) as AdReplyInfo | undefined | null;
     }
-    set quotedAd(value: AdReplyInfo) {
+    set quotedAd(value: AdReplyInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 23, value);
     }
     get has_quotedAd() {
         return pb_1.Message.getField(this, 23) != null;
     }
     get placeholderKey() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 24) as MessageKey;
+        return pb_1.Message.getWrapperField(this, MessageKey, 24) as MessageKey | undefined | null;
     }
-    set placeholderKey(value: MessageKey) {
+    set placeholderKey(value: MessageKey | undefined | null) {
         pb_1.Message.setWrapperField(this, 24, value);
     }
     get has_placeholderKey() {
@@ -2090,9 +2090,9 @@ export class ImageMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -2445,9 +2445,9 @@ export class ContactMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -2680,9 +2680,9 @@ export class LocationMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -2996,9 +2996,9 @@ export class ExtendedTextMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -3355,9 +3355,9 @@ export class DocumentMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -3681,9 +3681,9 @@ export class AudioMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 10) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -4070,9 +4070,9 @@ export class VideoMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -4513,9 +4513,9 @@ export class ProtocolMessage extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
     }
-    set key(value: MessageKey) {
+    set key(value: MessageKey | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
@@ -4549,9 +4549,9 @@ export class ProtocolMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 5) != null;
     }
     get historySyncNotification() {
-        return pb_1.Message.getWrapperField(this, HistorySyncNotification, 6) as HistorySyncNotification;
+        return pb_1.Message.getWrapperField(this, HistorySyncNotification, 6) as HistorySyncNotification | undefined | null;
     }
-    set historySyncNotification(value: HistorySyncNotification) {
+    set historySyncNotification(value: HistorySyncNotification | undefined | null) {
         pb_1.Message.setWrapperField(this, 6, value);
     }
     get has_historySyncNotification() {
@@ -4928,9 +4928,9 @@ export class ContactsArrayMessage extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -5410,18 +5410,18 @@ export class HSMDateTime extends pb_1.Message {
         }
     }
     get component() {
-        return pb_1.Message.getWrapperField(this, HSMDateTimeComponent, 1) as HSMDateTimeComponent;
+        return pb_1.Message.getWrapperField(this, HSMDateTimeComponent, 1) as HSMDateTimeComponent | undefined | null;
     }
-    set component(value: HSMDateTimeComponent) {
+    set component(value: HSMDateTimeComponent | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_component() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get unixEpoch() {
-        return pb_1.Message.getWrapperField(this, HSMDateTimeUnixEpoch, 2) as HSMDateTimeUnixEpoch;
+        return pb_1.Message.getWrapperField(this, HSMDateTimeUnixEpoch, 2) as HSMDateTimeUnixEpoch | undefined | null;
     }
-    set unixEpoch(value: HSMDateTimeUnixEpoch) {
+    set unixEpoch(value: HSMDateTimeUnixEpoch | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_unixEpoch() {
@@ -5533,18 +5533,18 @@ export class HSMLocalizableParameter extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get currency() {
-        return pb_1.Message.getWrapperField(this, HSMCurrency, 2) as HSMCurrency;
+        return pb_1.Message.getWrapperField(this, HSMCurrency, 2) as HSMCurrency | undefined | null;
     }
-    set currency(value: HSMCurrency) {
+    set currency(value: HSMCurrency | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_currency() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get dateTime() {
-        return pb_1.Message.getWrapperField(this, HSMDateTime, 3) as HSMDateTime;
+        return pb_1.Message.getWrapperField(this, HSMDateTime, 3) as HSMDateTime | undefined | null;
     }
-    set dateTime(value: HSMDateTime) {
+    set dateTime(value: HSMDateTime | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_dateTime() {
@@ -5740,9 +5740,9 @@ export class HighlyStructuredMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 8) != null;
     }
     get hydratedHsm() {
-        return pb_1.Message.getWrapperField(this, TemplateMessage, 9) as TemplateMessage;
+        return pb_1.Message.getWrapperField(this, TemplateMessage, 9) as TemplateMessage | undefined | null;
     }
-    set hydratedHsm(value: TemplateMessage) {
+    set hydratedHsm(value: TemplateMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 9, value);
     }
     get has_hydratedHsm() {
@@ -5893,18 +5893,18 @@ export class SendPaymentMessage extends pb_1.Message {
         }
     }
     get noteMessage() {
-        return pb_1.Message.getWrapperField(this, Message, 2) as Message;
+        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined | null;
     }
-    set noteMessage(value: Message) {
+    set noteMessage(value: Message | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_noteMessage() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get requestMessageKey() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 3) as MessageKey;
+        return pb_1.Message.getWrapperField(this, MessageKey, 3) as MessageKey | undefined | null;
     }
-    set requestMessageKey(value: MessageKey) {
+    set requestMessageKey(value: MessageKey | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_requestMessageKey() {
@@ -6001,9 +6001,9 @@ export class RequestPaymentMessage extends pb_1.Message {
         }
     }
     get noteMessage() {
-        return pb_1.Message.getWrapperField(this, Message, 4) as Message;
+        return pb_1.Message.getWrapperField(this, Message, 4) as Message | undefined | null;
     }
-    set noteMessage(value: Message) {
+    set noteMessage(value: Message | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_noteMessage() {
@@ -6149,9 +6149,9 @@ export class DeclinePaymentRequestMessage extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
     }
-    set key(value: MessageKey) {
+    set key(value: MessageKey | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
@@ -6220,9 +6220,9 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
     }
-    set key(value: MessageKey) {
+    set key(value: MessageKey | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
@@ -6408,9 +6408,9 @@ export class LiveLocationMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -6752,9 +6752,9 @@ export class StickerMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -7015,18 +7015,18 @@ export class FourRowTemplate extends pb_1.Message {
         }
     }
     get content() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 6) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 6) as HighlyStructuredMessage | undefined | null;
     }
-    set content(value: HighlyStructuredMessage) {
+    set content(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 6, value);
     }
     get has_content() {
         return pb_1.Message.getField(this, 6) != null;
     }
     get footer() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 7) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 7) as HighlyStructuredMessage | undefined | null;
     }
-    set footer(value: HighlyStructuredMessage) {
+    set footer(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 7, value);
     }
     get has_footer() {
@@ -7039,45 +7039,45 @@ export class FourRowTemplate extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 8, value);
     }
     get documentMessage() {
-        return pb_1.Message.getWrapperField(this, DocumentMessage, 1) as DocumentMessage;
+        return pb_1.Message.getWrapperField(this, DocumentMessage, 1) as DocumentMessage | undefined | null;
     }
-    set documentMessage(value: DocumentMessage) {
+    set documentMessage(value: DocumentMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_documentMessage() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get highlyStructuredMessage() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined | null;
     }
-    set highlyStructuredMessage(value: HighlyStructuredMessage) {
+    set highlyStructuredMessage(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_highlyStructuredMessage() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get imageMessage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined | null;
     }
-    set imageMessage(value: ImageMessage) {
+    set imageMessage(value: ImageMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_imageMessage() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get videoMessage() {
-        return pb_1.Message.getWrapperField(this, VideoMessage, 4) as VideoMessage;
+        return pb_1.Message.getWrapperField(this, VideoMessage, 4) as VideoMessage | undefined | null;
     }
-    set videoMessage(value: VideoMessage) {
+    set videoMessage(value: VideoMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 4, this.#one_of_decls[0], value);
     }
     get has_videoMessage() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get locationMessage() {
-        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage;
+        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined | null;
     }
-    set locationMessage(value: LocationMessage) {
+    set locationMessage(value: LocationMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 5, this.#one_of_decls[0], value);
     }
     get has_locationMessage() {
@@ -7329,9 +7329,9 @@ export class HydratedFourRowTemplate extends pb_1.Message {
         return pb_1.Message.getField(this, 9) != null;
     }
     get documentMessage() {
-        return pb_1.Message.getWrapperField(this, DocumentMessage, 1) as DocumentMessage;
+        return pb_1.Message.getWrapperField(this, DocumentMessage, 1) as DocumentMessage | undefined | null;
     }
-    set documentMessage(value: DocumentMessage) {
+    set documentMessage(value: DocumentMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_documentMessage() {
@@ -7347,27 +7347,27 @@ export class HydratedFourRowTemplate extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get imageMessage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined | null;
     }
-    set imageMessage(value: ImageMessage) {
+    set imageMessage(value: ImageMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_imageMessage() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get videoMessage() {
-        return pb_1.Message.getWrapperField(this, VideoMessage, 4) as VideoMessage;
+        return pb_1.Message.getWrapperField(this, VideoMessage, 4) as VideoMessage | undefined | null;
     }
-    set videoMessage(value: VideoMessage) {
+    set videoMessage(value: VideoMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 4, this.#one_of_decls[0], value);
     }
     get has_videoMessage() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get locationMessage() {
-        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage;
+        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined | null;
     }
-    set locationMessage(value: LocationMessage) {
+    set locationMessage(value: LocationMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 5, this.#one_of_decls[0], value);
     }
     get has_locationMessage() {
@@ -7551,36 +7551,36 @@ export class TemplateMessage extends pb_1.Message {
         }
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 3) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 3) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get hydratedTemplate() {
-        return pb_1.Message.getWrapperField(this, HydratedFourRowTemplate, 4) as HydratedFourRowTemplate;
+        return pb_1.Message.getWrapperField(this, HydratedFourRowTemplate, 4) as HydratedFourRowTemplate | undefined | null;
     }
-    set hydratedTemplate(value: HydratedFourRowTemplate) {
+    set hydratedTemplate(value: HydratedFourRowTemplate | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_hydratedTemplate() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get fourRowTemplate() {
-        return pb_1.Message.getWrapperField(this, FourRowTemplate, 1) as FourRowTemplate;
+        return pb_1.Message.getWrapperField(this, FourRowTemplate, 1) as FourRowTemplate | undefined | null;
     }
-    set fourRowTemplate(value: FourRowTemplate) {
+    set fourRowTemplate(value: FourRowTemplate | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_fourRowTemplate() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get hydratedFourRowTemplate() {
-        return pb_1.Message.getWrapperField(this, HydratedFourRowTemplate, 2) as HydratedFourRowTemplate;
+        return pb_1.Message.getWrapperField(this, HydratedFourRowTemplate, 2) as HydratedFourRowTemplate | undefined | null;
     }
-    set hydratedFourRowTemplate(value: HydratedFourRowTemplate) {
+    set hydratedFourRowTemplate(value: HydratedFourRowTemplate | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_hydratedFourRowTemplate() {
@@ -7725,9 +7725,9 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 3) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 3) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_contextInfo() {
@@ -7844,9 +7844,9 @@ export class CatalogSnapshot extends pb_1.Message {
         }
     }
     get catalogImage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 1) as ImageMessage;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 1) as ImageMessage | undefined | null;
     }
-    set catalogImage(value: ImageMessage) {
+    set catalogImage(value: ImageMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_catalogImage() {
@@ -7990,9 +7990,9 @@ export class ProductSnapshot extends pb_1.Message {
         }
     }
     get productImage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 1) as ImageMessage;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 1) as ImageMessage | undefined | null;
     }
-    set productImage(value: ImageMessage) {
+    set productImage(value: ImageMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_productImage() {
@@ -8245,9 +8245,9 @@ export class ProductMessage extends pb_1.Message {
         }
     }
     get product() {
-        return pb_1.Message.getWrapperField(this, ProductSnapshot, 1) as ProductSnapshot;
+        return pb_1.Message.getWrapperField(this, ProductSnapshot, 1) as ProductSnapshot | undefined | null;
     }
-    set product(value: ProductSnapshot) {
+    set product(value: ProductSnapshot | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_product() {
@@ -8263,18 +8263,18 @@ export class ProductMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get catalog() {
-        return pb_1.Message.getWrapperField(this, CatalogSnapshot, 4) as CatalogSnapshot;
+        return pb_1.Message.getWrapperField(this, CatalogSnapshot, 4) as CatalogSnapshot | undefined | null;
     }
-    set catalog(value: CatalogSnapshot) {
+    set catalog(value: CatalogSnapshot | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_catalog() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -8456,9 +8456,9 @@ export class GroupInviteMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 6) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 7) as ContextInfo;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 7) as ContextInfo | undefined | null;
     }
-    set contextInfo(value: ContextInfo) {
+    set contextInfo(value: ContextInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 7, value);
     }
     get has_contextInfo() {
@@ -8605,9 +8605,9 @@ export class DeviceSentMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, Message, 2) as Message;
+        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined | null;
     }
-    set message(value: Message) {
+    set message(value: Message | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_message() {
@@ -8815,225 +8815,225 @@ export class Message extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get senderKeyDistributionMessage() {
-        return pb_1.Message.getWrapperField(this, SenderKeyDistributionMessage, 2) as SenderKeyDistributionMessage;
+        return pb_1.Message.getWrapperField(this, SenderKeyDistributionMessage, 2) as SenderKeyDistributionMessage | undefined | null;
     }
-    set senderKeyDistributionMessage(value: SenderKeyDistributionMessage) {
+    set senderKeyDistributionMessage(value: SenderKeyDistributionMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_senderKeyDistributionMessage() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get imageMessage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined | null;
     }
-    set imageMessage(value: ImageMessage) {
+    set imageMessage(value: ImageMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_imageMessage() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get contactMessage() {
-        return pb_1.Message.getWrapperField(this, ContactMessage, 4) as ContactMessage;
+        return pb_1.Message.getWrapperField(this, ContactMessage, 4) as ContactMessage | undefined | null;
     }
-    set contactMessage(value: ContactMessage) {
+    set contactMessage(value: ContactMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_contactMessage() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get locationMessage() {
-        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage;
+        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined | null;
     }
-    set locationMessage(value: LocationMessage) {
+    set locationMessage(value: LocationMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 5, value);
     }
     get has_locationMessage() {
         return pb_1.Message.getField(this, 5) != null;
     }
     get extendedTextMessage() {
-        return pb_1.Message.getWrapperField(this, ExtendedTextMessage, 6) as ExtendedTextMessage;
+        return pb_1.Message.getWrapperField(this, ExtendedTextMessage, 6) as ExtendedTextMessage | undefined | null;
     }
-    set extendedTextMessage(value: ExtendedTextMessage) {
+    set extendedTextMessage(value: ExtendedTextMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 6, value);
     }
     get has_extendedTextMessage() {
         return pb_1.Message.getField(this, 6) != null;
     }
     get documentMessage() {
-        return pb_1.Message.getWrapperField(this, DocumentMessage, 7) as DocumentMessage;
+        return pb_1.Message.getWrapperField(this, DocumentMessage, 7) as DocumentMessage | undefined | null;
     }
-    set documentMessage(value: DocumentMessage) {
+    set documentMessage(value: DocumentMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 7, value);
     }
     get has_documentMessage() {
         return pb_1.Message.getField(this, 7) != null;
     }
     get audioMessage() {
-        return pb_1.Message.getWrapperField(this, AudioMessage, 8) as AudioMessage;
+        return pb_1.Message.getWrapperField(this, AudioMessage, 8) as AudioMessage | undefined | null;
     }
-    set audioMessage(value: AudioMessage) {
+    set audioMessage(value: AudioMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 8, value);
     }
     get has_audioMessage() {
         return pb_1.Message.getField(this, 8) != null;
     }
     get videoMessage() {
-        return pb_1.Message.getWrapperField(this, VideoMessage, 9) as VideoMessage;
+        return pb_1.Message.getWrapperField(this, VideoMessage, 9) as VideoMessage | undefined | null;
     }
-    set videoMessage(value: VideoMessage) {
+    set videoMessage(value: VideoMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 9, value);
     }
     get has_videoMessage() {
         return pb_1.Message.getField(this, 9) != null;
     }
     get call() {
-        return pb_1.Message.getWrapperField(this, Call, 10) as Call;
+        return pb_1.Message.getWrapperField(this, Call, 10) as Call | undefined | null;
     }
-    set call(value: Call) {
+    set call(value: Call | undefined | null) {
         pb_1.Message.setWrapperField(this, 10, value);
     }
     get has_call() {
         return pb_1.Message.getField(this, 10) != null;
     }
     get chat() {
-        return pb_1.Message.getWrapperField(this, Chat, 11) as Chat;
+        return pb_1.Message.getWrapperField(this, Chat, 11) as Chat | undefined | null;
     }
-    set chat(value: Chat) {
+    set chat(value: Chat | undefined | null) {
         pb_1.Message.setWrapperField(this, 11, value);
     }
     get has_chat() {
         return pb_1.Message.getField(this, 11) != null;
     }
     get protocolMessage() {
-        return pb_1.Message.getWrapperField(this, ProtocolMessage, 12) as ProtocolMessage;
+        return pb_1.Message.getWrapperField(this, ProtocolMessage, 12) as ProtocolMessage | undefined | null;
     }
-    set protocolMessage(value: ProtocolMessage) {
+    set protocolMessage(value: ProtocolMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 12, value);
     }
     get has_protocolMessage() {
         return pb_1.Message.getField(this, 12) != null;
     }
     get contactsArrayMessage() {
-        return pb_1.Message.getWrapperField(this, ContactsArrayMessage, 13) as ContactsArrayMessage;
+        return pb_1.Message.getWrapperField(this, ContactsArrayMessage, 13) as ContactsArrayMessage | undefined | null;
     }
-    set contactsArrayMessage(value: ContactsArrayMessage) {
+    set contactsArrayMessage(value: ContactsArrayMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 13, value);
     }
     get has_contactsArrayMessage() {
         return pb_1.Message.getField(this, 13) != null;
     }
     get highlyStructuredMessage() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 14) as HighlyStructuredMessage;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 14) as HighlyStructuredMessage | undefined | null;
     }
-    set highlyStructuredMessage(value: HighlyStructuredMessage) {
+    set highlyStructuredMessage(value: HighlyStructuredMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 14, value);
     }
     get has_highlyStructuredMessage() {
         return pb_1.Message.getField(this, 14) != null;
     }
     get fastRatchetKeySenderKeyDistributionMessage() {
-        return pb_1.Message.getWrapperField(this, SenderKeyDistributionMessage, 15) as SenderKeyDistributionMessage;
+        return pb_1.Message.getWrapperField(this, SenderKeyDistributionMessage, 15) as SenderKeyDistributionMessage | undefined | null;
     }
-    set fastRatchetKeySenderKeyDistributionMessage(value: SenderKeyDistributionMessage) {
+    set fastRatchetKeySenderKeyDistributionMessage(value: SenderKeyDistributionMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 15, value);
     }
     get has_fastRatchetKeySenderKeyDistributionMessage() {
         return pb_1.Message.getField(this, 15) != null;
     }
     get sendPaymentMessage() {
-        return pb_1.Message.getWrapperField(this, SendPaymentMessage, 16) as SendPaymentMessage;
+        return pb_1.Message.getWrapperField(this, SendPaymentMessage, 16) as SendPaymentMessage | undefined | null;
     }
-    set sendPaymentMessage(value: SendPaymentMessage) {
+    set sendPaymentMessage(value: SendPaymentMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 16, value);
     }
     get has_sendPaymentMessage() {
         return pb_1.Message.getField(this, 16) != null;
     }
     get liveLocationMessage() {
-        return pb_1.Message.getWrapperField(this, LiveLocationMessage, 18) as LiveLocationMessage;
+        return pb_1.Message.getWrapperField(this, LiveLocationMessage, 18) as LiveLocationMessage | undefined | null;
     }
-    set liveLocationMessage(value: LiveLocationMessage) {
+    set liveLocationMessage(value: LiveLocationMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 18, value);
     }
     get has_liveLocationMessage() {
         return pb_1.Message.getField(this, 18) != null;
     }
     get requestPaymentMessage() {
-        return pb_1.Message.getWrapperField(this, RequestPaymentMessage, 22) as RequestPaymentMessage;
+        return pb_1.Message.getWrapperField(this, RequestPaymentMessage, 22) as RequestPaymentMessage | undefined | null;
     }
-    set requestPaymentMessage(value: RequestPaymentMessage) {
+    set requestPaymentMessage(value: RequestPaymentMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 22, value);
     }
     get has_requestPaymentMessage() {
         return pb_1.Message.getField(this, 22) != null;
     }
     get declinePaymentRequestMessage() {
-        return pb_1.Message.getWrapperField(this, DeclinePaymentRequestMessage, 23) as DeclinePaymentRequestMessage;
+        return pb_1.Message.getWrapperField(this, DeclinePaymentRequestMessage, 23) as DeclinePaymentRequestMessage | undefined | null;
     }
-    set declinePaymentRequestMessage(value: DeclinePaymentRequestMessage) {
+    set declinePaymentRequestMessage(value: DeclinePaymentRequestMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 23, value);
     }
     get has_declinePaymentRequestMessage() {
         return pb_1.Message.getField(this, 23) != null;
     }
     get cancelPaymentRequestMessage() {
-        return pb_1.Message.getWrapperField(this, CancelPaymentRequestMessage, 24) as CancelPaymentRequestMessage;
+        return pb_1.Message.getWrapperField(this, CancelPaymentRequestMessage, 24) as CancelPaymentRequestMessage | undefined | null;
     }
-    set cancelPaymentRequestMessage(value: CancelPaymentRequestMessage) {
+    set cancelPaymentRequestMessage(value: CancelPaymentRequestMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 24, value);
     }
     get has_cancelPaymentRequestMessage() {
         return pb_1.Message.getField(this, 24) != null;
     }
     get templateMessage() {
-        return pb_1.Message.getWrapperField(this, TemplateMessage, 25) as TemplateMessage;
+        return pb_1.Message.getWrapperField(this, TemplateMessage, 25) as TemplateMessage | undefined | null;
     }
-    set templateMessage(value: TemplateMessage) {
+    set templateMessage(value: TemplateMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 25, value);
     }
     get has_templateMessage() {
         return pb_1.Message.getField(this, 25) != null;
     }
     get stickerMessage() {
-        return pb_1.Message.getWrapperField(this, StickerMessage, 26) as StickerMessage;
+        return pb_1.Message.getWrapperField(this, StickerMessage, 26) as StickerMessage | undefined | null;
     }
-    set stickerMessage(value: StickerMessage) {
+    set stickerMessage(value: StickerMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 26, value);
     }
     get has_stickerMessage() {
         return pb_1.Message.getField(this, 26) != null;
     }
     get groupInviteMessage() {
-        return pb_1.Message.getWrapperField(this, GroupInviteMessage, 28) as GroupInviteMessage;
+        return pb_1.Message.getWrapperField(this, GroupInviteMessage, 28) as GroupInviteMessage | undefined | null;
     }
-    set groupInviteMessage(value: GroupInviteMessage) {
+    set groupInviteMessage(value: GroupInviteMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 28, value);
     }
     get has_groupInviteMessage() {
         return pb_1.Message.getField(this, 28) != null;
     }
     get templateButtonReplyMessage() {
-        return pb_1.Message.getWrapperField(this, TemplateButtonReplyMessage, 29) as TemplateButtonReplyMessage;
+        return pb_1.Message.getWrapperField(this, TemplateButtonReplyMessage, 29) as TemplateButtonReplyMessage | undefined | null;
     }
-    set templateButtonReplyMessage(value: TemplateButtonReplyMessage) {
+    set templateButtonReplyMessage(value: TemplateButtonReplyMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 29, value);
     }
     get has_templateButtonReplyMessage() {
         return pb_1.Message.getField(this, 29) != null;
     }
     get productMessage() {
-        return pb_1.Message.getWrapperField(this, ProductMessage, 30) as ProductMessage;
+        return pb_1.Message.getWrapperField(this, ProductMessage, 30) as ProductMessage | undefined | null;
     }
-    set productMessage(value: ProductMessage) {
+    set productMessage(value: ProductMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 30, value);
     }
     get has_productMessage() {
         return pb_1.Message.getField(this, 30) != null;
     }
     get deviceSentMessage() {
-        return pb_1.Message.getWrapperField(this, DeviceSentMessage, 31) as DeviceSentMessage;
+        return pb_1.Message.getWrapperField(this, DeviceSentMessage, 31) as DeviceSentMessage | undefined | null;
     }
-    set deviceSentMessage(value: DeviceSentMessage) {
+    set deviceSentMessage(value: DeviceSentMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 31, value);
     }
     get has_deviceSentMessage() {
@@ -10497,18 +10497,18 @@ export class NotificationMessageInfo extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
     }
-    set key(value: MessageKey) {
+    set key(value: MessageKey | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, Message, 2) as Message;
+        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined | null;
     }
-    set message(value: Message) {
+    set message(value: Message | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_message() {
@@ -10842,9 +10842,9 @@ export class PaymentInfo extends pb_1.Message {
         return pb_1.Message.getField(this, 5) != null;
     }
     get requestMessageKey() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 6) as MessageKey;
+        return pb_1.Message.getWrapperField(this, MessageKey, 6) as MessageKey | undefined | null;
     }
-    set requestMessageKey(value: MessageKey) {
+    set requestMessageKey(value: MessageKey | undefined | null) {
         pb_1.Message.setWrapperField(this, 6, value);
     }
     get has_requestMessageKey() {
@@ -11174,18 +11174,18 @@ export class WebMessageInfo extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
     }
-    set key(value: MessageKey) {
+    set key(value: MessageKey | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, Message, 2) as Message;
+        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined | null;
     }
-    set message(value: Message) {
+    set message(value: Message | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_message() {
@@ -11330,27 +11330,27 @@ export class WebMessageInfo extends pb_1.Message {
         pb_1.Message.setField(this, 28, value);
     }
     get paymentInfo() {
-        return pb_1.Message.getWrapperField(this, PaymentInfo, 29) as PaymentInfo;
+        return pb_1.Message.getWrapperField(this, PaymentInfo, 29) as PaymentInfo | undefined | null;
     }
-    set paymentInfo(value: PaymentInfo) {
+    set paymentInfo(value: PaymentInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 29, value);
     }
     get has_paymentInfo() {
         return pb_1.Message.getField(this, 29) != null;
     }
     get finalLiveLocation() {
-        return pb_1.Message.getWrapperField(this, LiveLocationMessage, 30) as LiveLocationMessage;
+        return pb_1.Message.getWrapperField(this, LiveLocationMessage, 30) as LiveLocationMessage | undefined | null;
     }
-    set finalLiveLocation(value: LiveLocationMessage) {
+    set finalLiveLocation(value: LiveLocationMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 30, value);
     }
     get has_finalLiveLocation() {
         return pb_1.Message.getField(this, 30) != null;
     }
     get quotedPaymentInfo() {
-        return pb_1.Message.getWrapperField(this, PaymentInfo, 31) as PaymentInfo;
+        return pb_1.Message.getWrapperField(this, PaymentInfo, 31) as PaymentInfo | undefined | null;
     }
-    set quotedPaymentInfo(value: PaymentInfo) {
+    set quotedPaymentInfo(value: PaymentInfo | undefined | null) {
         pb_1.Message.setWrapperField(this, 31, value);
     }
     get has_quotedPaymentInfo() {

--- a/test/conformance/packedproto2/packed_proto2.ts
+++ b/test/conformance/packedproto2/packed_proto2.ts
@@ -4,9 +4,6 @@
  * source: test/conformance/packedproto2/packedproto2.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class HydratedQuickReplyButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -42,7 +39,7 @@ export class HydratedQuickReplyButton extends pb_1.Message {
     get has_id() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<HydratedQuickReplyButton.AsObject>): HydratedQuickReplyButton {
+    static fromObject(data: HydratedQuickReplyButton.AsObjectPartial): HydratedQuickReplyButton {
         const message = new HydratedQuickReplyButton({});
         if (data.displayText != null) {
             message.displayText = data.displayText;
@@ -63,9 +60,9 @@ export class HydratedQuickReplyButton extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_displayText && this.displayText.length)
+        if (this.has_displayText && this.displayText!.length)
             writer.writeString(1, this.displayText);
-        if (this.has_id && this.id.length)
+        if (this.has_id && this.id!.length)
             writer.writeString(2, this.id);
         if (!w)
             return writer.getResultBuffer();
@@ -98,6 +95,10 @@ export namespace HydratedQuickReplyButton {
     export type AsObject = {
         displayText: string;
         id: string;
+    };
+    export type AsObjectPartial = {
+        displayText?: string;
+        id?: string;
     };
 }
 export class HydratedURLButton extends pb_1.Message {
@@ -135,7 +136,7 @@ export class HydratedURLButton extends pb_1.Message {
     get has_url() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<HydratedURLButton.AsObject>): HydratedURLButton {
+    static fromObject(data: HydratedURLButton.AsObjectPartial): HydratedURLButton {
         const message = new HydratedURLButton({});
         if (data.displayText != null) {
             message.displayText = data.displayText;
@@ -156,9 +157,9 @@ export class HydratedURLButton extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_displayText && this.displayText.length)
+        if (this.has_displayText && this.displayText!.length)
             writer.writeString(1, this.displayText);
-        if (this.has_url && this.url.length)
+        if (this.has_url && this.url!.length)
             writer.writeString(2, this.url);
         if (!w)
             return writer.getResultBuffer();
@@ -191,6 +192,10 @@ export namespace HydratedURLButton {
     export type AsObject = {
         displayText: string;
         url: string;
+    };
+    export type AsObjectPartial = {
+        displayText?: string;
+        url?: string;
     };
 }
 export class HydratedCallButton extends pb_1.Message {
@@ -228,7 +233,7 @@ export class HydratedCallButton extends pb_1.Message {
     get has_phoneNumber() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<HydratedCallButton.AsObject>): HydratedCallButton {
+    static fromObject(data: HydratedCallButton.AsObjectPartial): HydratedCallButton {
         const message = new HydratedCallButton({});
         if (data.displayText != null) {
             message.displayText = data.displayText;
@@ -249,9 +254,9 @@ export class HydratedCallButton extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_displayText && this.displayText.length)
+        if (this.has_displayText && this.displayText!.length)
             writer.writeString(1, this.displayText);
-        if (this.has_phoneNumber && this.phoneNumber.length)
+        if (this.has_phoneNumber && this.phoneNumber!.length)
             writer.writeString(2, this.phoneNumber);
         if (!w)
             return writer.getResultBuffer();
@@ -284,6 +289,10 @@ export namespace HydratedCallButton {
     export type AsObject = {
         displayText: string;
         phoneNumber: string;
+    };
+    export type AsObjectPartial = {
+        displayText?: string;
+        phoneNumber?: string;
     };
 }
 export class HydratedTemplateButton extends pb_1.Message {
@@ -330,27 +339,27 @@ export class HydratedTemplateButton extends pb_1.Message {
         return pb_1.Message.getField(this, 4) != null;
     }
     get quickReplyButton() {
-        return pb_1.Message.getWrapperField(this, HydratedQuickReplyButton, 1) as HydratedQuickReplyButton | undefined | null;
+        return pb_1.Message.getWrapperField(this, HydratedQuickReplyButton, 1) as HydratedQuickReplyButton | undefined;
     }
-    set quickReplyButton(value: HydratedQuickReplyButton | undefined | null) {
+    set quickReplyButton(value: HydratedQuickReplyButton | undefined) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_quickReplyButton() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get urlButton() {
-        return pb_1.Message.getWrapperField(this, HydratedURLButton, 2) as HydratedURLButton | undefined | null;
+        return pb_1.Message.getWrapperField(this, HydratedURLButton, 2) as HydratedURLButton | undefined;
     }
-    set urlButton(value: HydratedURLButton | undefined | null) {
+    set urlButton(value: HydratedURLButton | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_urlButton() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get callButton() {
-        return pb_1.Message.getWrapperField(this, HydratedCallButton, 3) as HydratedCallButton | undefined | null;
+        return pb_1.Message.getWrapperField(this, HydratedCallButton, 3) as HydratedCallButton | undefined;
     }
-    set callButton(value: HydratedCallButton | undefined | null) {
+    set callButton(value: HydratedCallButton | undefined) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_callButton() {
@@ -367,7 +376,7 @@ export class HydratedTemplateButton extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3])];
     }
-    static fromObject(data: RecursivePartial<HydratedTemplateButton.AsObject>): HydratedTemplateButton {
+    static fromObject(data: HydratedTemplateButton.AsObjectPartial): HydratedTemplateButton {
         const message = new HydratedTemplateButton({});
         if (data.index != null) {
             message.index = data.index;
@@ -405,11 +414,11 @@ export class HydratedTemplateButton extends pb_1.Message {
         if (this.has_index)
             writer.writeUint32(4, this.index);
         if (this.has_quickReplyButton)
-            writer.writeMessage(1, this.quickReplyButton, () => this.quickReplyButton.serialize(writer));
+            writer.writeMessage(1, this.quickReplyButton, () => this.quickReplyButton!.serialize(writer));
         if (this.has_urlButton)
-            writer.writeMessage(2, this.urlButton, () => this.urlButton.serialize(writer));
+            writer.writeMessage(2, this.urlButton, () => this.urlButton!.serialize(writer));
         if (this.has_callButton)
-            writer.writeMessage(3, this.callButton, () => this.callButton.serialize(writer));
+            writer.writeMessage(3, this.callButton, () => this.callButton!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -450,6 +459,12 @@ export namespace HydratedTemplateButton {
         urlButton?: HydratedURLButton.AsObject;
         callButton?: HydratedCallButton.AsObject;
     };
+    export type AsObjectPartial = {
+        index?: number;
+        quickReplyButton?: HydratedQuickReplyButton.AsObjectPartial;
+        urlButton?: HydratedURLButton.AsObjectPartial;
+        callButton?: HydratedCallButton.AsObjectPartial;
+    };
 }
 export class QuickReplyButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -469,9 +484,9 @@ export class QuickReplyButton extends pb_1.Message {
         }
     }
     get displayText() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined;
     }
-    set displayText(value: HighlyStructuredMessage | undefined | null) {
+    set displayText(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_displayText() {
@@ -486,7 +501,7 @@ export class QuickReplyButton extends pb_1.Message {
     get has_id() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<QuickReplyButton.AsObject>): QuickReplyButton {
+    static fromObject(data: QuickReplyButton.AsObjectPartial): QuickReplyButton {
         const message = new QuickReplyButton({});
         if (data.displayText != null) {
             message.displayText = HighlyStructuredMessage.fromObject(data.displayText);
@@ -510,8 +525,8 @@ export class QuickReplyButton extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_displayText)
-            writer.writeMessage(1, this.displayText, () => this.displayText.serialize(writer));
-        if (this.has_id && this.id.length)
+            writer.writeMessage(1, this.displayText, () => this.displayText!.serialize(writer));
+        if (this.has_id && this.id!.length)
             writer.writeString(2, this.id);
         if (!w)
             return writer.getResultBuffer();
@@ -545,6 +560,10 @@ export namespace QuickReplyButton {
         displayText?: HighlyStructuredMessage.AsObject;
         id: string;
     };
+    export type AsObjectPartial = {
+        displayText?: HighlyStructuredMessage.AsObjectPartial;
+        id?: string;
+    };
 }
 export class URLButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -564,24 +583,24 @@ export class URLButton extends pb_1.Message {
         }
     }
     get displayText() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined;
     }
-    set displayText(value: HighlyStructuredMessage | undefined | null) {
+    set displayText(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_displayText() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get url() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined;
     }
-    set url(value: HighlyStructuredMessage | undefined | null) {
+    set url(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_url() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<URLButton.AsObject>): URLButton {
+    static fromObject(data: URLButton.AsObjectPartial): URLButton {
         const message = new URLButton({});
         if (data.displayText != null) {
             message.displayText = HighlyStructuredMessage.fromObject(data.displayText);
@@ -606,9 +625,9 @@ export class URLButton extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_displayText)
-            writer.writeMessage(1, this.displayText, () => this.displayText.serialize(writer));
+            writer.writeMessage(1, this.displayText, () => this.displayText!.serialize(writer));
         if (this.has_url)
-            writer.writeMessage(2, this.url, () => this.url.serialize(writer));
+            writer.writeMessage(2, this.url, () => this.url!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -641,6 +660,10 @@ export namespace URLButton {
         displayText?: HighlyStructuredMessage.AsObject;
         url?: HighlyStructuredMessage.AsObject;
     };
+    export type AsObjectPartial = {
+        displayText?: HighlyStructuredMessage.AsObjectPartial;
+        url?: HighlyStructuredMessage.AsObjectPartial;
+    };
 }
 export class CallButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -660,24 +683,24 @@ export class CallButton extends pb_1.Message {
         }
     }
     get displayText() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 1) as HighlyStructuredMessage | undefined;
     }
-    set displayText(value: HighlyStructuredMessage | undefined | null) {
+    set displayText(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_displayText() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get phoneNumber() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined;
     }
-    set phoneNumber(value: HighlyStructuredMessage | undefined | null) {
+    set phoneNumber(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_phoneNumber() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<CallButton.AsObject>): CallButton {
+    static fromObject(data: CallButton.AsObjectPartial): CallButton {
         const message = new CallButton({});
         if (data.displayText != null) {
             message.displayText = HighlyStructuredMessage.fromObject(data.displayText);
@@ -702,9 +725,9 @@ export class CallButton extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_displayText)
-            writer.writeMessage(1, this.displayText, () => this.displayText.serialize(writer));
+            writer.writeMessage(1, this.displayText, () => this.displayText!.serialize(writer));
         if (this.has_phoneNumber)
-            writer.writeMessage(2, this.phoneNumber, () => this.phoneNumber.serialize(writer));
+            writer.writeMessage(2, this.phoneNumber, () => this.phoneNumber!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -736,6 +759,10 @@ export namespace CallButton {
     export type AsObject = {
         displayText?: HighlyStructuredMessage.AsObject;
         phoneNumber?: HighlyStructuredMessage.AsObject;
+    };
+    export type AsObjectPartial = {
+        displayText?: HighlyStructuredMessage.AsObjectPartial;
+        phoneNumber?: HighlyStructuredMessage.AsObjectPartial;
     };
 }
 export class TemplateButton extends pb_1.Message {
@@ -782,27 +809,27 @@ export class TemplateButton extends pb_1.Message {
         return pb_1.Message.getField(this, 4) != null;
     }
     get quickReplyButton() {
-        return pb_1.Message.getWrapperField(this, QuickReplyButton, 1) as QuickReplyButton | undefined | null;
+        return pb_1.Message.getWrapperField(this, QuickReplyButton, 1) as QuickReplyButton | undefined;
     }
-    set quickReplyButton(value: QuickReplyButton | undefined | null) {
+    set quickReplyButton(value: QuickReplyButton | undefined) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_quickReplyButton() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get urlButton() {
-        return pb_1.Message.getWrapperField(this, URLButton, 2) as URLButton | undefined | null;
+        return pb_1.Message.getWrapperField(this, URLButton, 2) as URLButton | undefined;
     }
-    set urlButton(value: URLButton | undefined | null) {
+    set urlButton(value: URLButton | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_urlButton() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get callButton() {
-        return pb_1.Message.getWrapperField(this, CallButton, 3) as CallButton | undefined | null;
+        return pb_1.Message.getWrapperField(this, CallButton, 3) as CallButton | undefined;
     }
-    set callButton(value: CallButton | undefined | null) {
+    set callButton(value: CallButton | undefined) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_callButton() {
@@ -819,7 +846,7 @@ export class TemplateButton extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3])];
     }
-    static fromObject(data: RecursivePartial<TemplateButton.AsObject>): TemplateButton {
+    static fromObject(data: TemplateButton.AsObjectPartial): TemplateButton {
         const message = new TemplateButton({});
         if (data.index != null) {
             message.index = data.index;
@@ -857,11 +884,11 @@ export class TemplateButton extends pb_1.Message {
         if (this.has_index)
             writer.writeUint32(4, this.index);
         if (this.has_quickReplyButton)
-            writer.writeMessage(1, this.quickReplyButton, () => this.quickReplyButton.serialize(writer));
+            writer.writeMessage(1, this.quickReplyButton, () => this.quickReplyButton!.serialize(writer));
         if (this.has_urlButton)
-            writer.writeMessage(2, this.urlButton, () => this.urlButton.serialize(writer));
+            writer.writeMessage(2, this.urlButton, () => this.urlButton!.serialize(writer));
         if (this.has_callButton)
-            writer.writeMessage(3, this.callButton, () => this.callButton.serialize(writer));
+            writer.writeMessage(3, this.callButton, () => this.callButton!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -901,6 +928,12 @@ export namespace TemplateButton {
         quickReplyButton?: QuickReplyButton.AsObject;
         urlButton?: URLButton.AsObject;
         callButton?: CallButton.AsObject;
+    };
+    export type AsObjectPartial = {
+        index?: number;
+        quickReplyButton?: QuickReplyButton.AsObjectPartial;
+        urlButton?: URLButton.AsObjectPartial;
+        callButton?: CallButton.AsObjectPartial;
     };
 }
 export class Location extends pb_1.Message {
@@ -951,7 +984,7 @@ export class Location extends pb_1.Message {
     get has_name() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<Location.AsObject>): Location {
+    static fromObject(data: Location.AsObjectPartial): Location {
         const message = new Location({});
         if (data.degreesLatitude != null) {
             message.degreesLatitude = data.degreesLatitude;
@@ -980,7 +1013,7 @@ export class Location extends pb_1.Message {
             writer.writeDouble(1, this.degreesLatitude);
         if (this.has_degreesLongitude)
             writer.writeDouble(2, this.degreesLongitude);
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(3, this.name);
         if (!w)
             return writer.getResultBuffer();
@@ -1017,6 +1050,11 @@ export namespace Location {
         degreesLatitude: number;
         degreesLongitude: number;
         name: string;
+    };
+    export type AsObjectPartial = {
+        degreesLatitude?: number;
+        degreesLongitude?: number;
+        name?: string;
     };
 }
 export class Point extends pb_1.Message {
@@ -1080,7 +1118,7 @@ export class Point extends pb_1.Message {
     get has_y() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: RecursivePartial<Point.AsObject>): Point {
+    static fromObject(data: Point.AsObjectPartial): Point {
         const message = new Point({});
         if (data.xDeprecated != null) {
             message.xDeprecated = data.xDeprecated;
@@ -1157,6 +1195,12 @@ export namespace Point {
         x: number;
         y: number;
     };
+    export type AsObjectPartial = {
+        xDeprecated?: number;
+        yDeprecated?: number;
+        x?: number;
+        y?: number;
+    };
 }
 export class InteractiveAnnotation extends pb_1.Message {
     #one_of_decls: number[][] = [[2]];
@@ -1181,9 +1225,9 @@ export class InteractiveAnnotation extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 1, value);
     }
     get location() {
-        return pb_1.Message.getWrapperField(this, Location, 2) as Location | undefined | null;
+        return pb_1.Message.getWrapperField(this, Location, 2) as Location | undefined;
     }
-    set location(value: Location | undefined | null) {
+    set location(value: Location | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_location() {
@@ -1198,7 +1242,7 @@ export class InteractiveAnnotation extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [2])];
     }
-    static fromObject(data: RecursivePartial<InteractiveAnnotation.AsObject>): InteractiveAnnotation {
+    static fromObject(data: InteractiveAnnotation.AsObjectPartial): InteractiveAnnotation {
         const message = new InteractiveAnnotation({
             polygonVertices: data.polygonVertices.map(item => Point.fromObject(item))
         });
@@ -1221,9 +1265,9 @@ export class InteractiveAnnotation extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.polygonVertices.length)
-            writer.writeRepeatedMessage(1, this.polygonVertices, (item: Point) => item.serialize(writer));
+            writer.writeRepeatedMessage(1, this.polygonVertices, (item: Point) => item!.serialize(writer));
         if (this.has_location)
-            writer.writeMessage(2, this.location, () => this.location.serialize(writer));
+            writer.writeMessage(2, this.location, () => this.location!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -1255,6 +1299,10 @@ export namespace InteractiveAnnotation {
     export type AsObject = {
         polygonVertices: Point.AsObject[];
         location?: Location.AsObject;
+    };
+    export type AsObjectPartial = {
+        polygonVertices: Point.AsObjectPartial[];
+        location?: Location.AsObjectPartial;
     };
 }
 export class AdReplyInfo extends pb_1.Message {
@@ -1318,7 +1366,7 @@ export class AdReplyInfo extends pb_1.Message {
     get has_caption() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<AdReplyInfo.AsObject>): AdReplyInfo {
+    static fromObject(data: AdReplyInfo.AsObjectPartial): AdReplyInfo {
         const message = new AdReplyInfo({});
         if (data.advertiserName != null) {
             message.advertiserName = data.advertiserName;
@@ -1347,13 +1395,13 @@ export class AdReplyInfo extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_advertiserName && this.advertiserName.length)
+        if (this.has_advertiserName && this.advertiserName!.length)
             writer.writeString(1, this.advertiserName);
         if (this.has_mediaType)
             writer.writeEnum(2, this.mediaType);
-        if (this.has_jpegThumbnail && this.jpegThumbnail.length)
+        if (this.has_jpegThumbnail && this.jpegThumbnail!.length)
             writer.writeBytes(16, this.jpegThumbnail);
-        if (this.has_caption && this.caption.length)
+        if (this.has_caption && this.caption!.length)
             writer.writeString(17, this.caption);
         if (!w)
             return writer.getResultBuffer();
@@ -1394,6 +1442,12 @@ export namespace AdReplyInfo {
         mediaType: AdReplyInfo.AD_REPLY_INFO_MEDIATYPE;
         jpegThumbnail: Uint8Array;
         caption: string;
+    };
+    export type AsObjectPartial = {
+        advertiserName?: string;
+        mediaType?: AdReplyInfo.AD_REPLY_INFO_MEDIATYPE;
+        jpegThumbnail?: Uint8Array;
+        caption?: string;
     };
     export enum AD_REPLY_INFO_MEDIATYPE {
         NONE = 0,
@@ -1487,9 +1541,9 @@ export class ContextInfo extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get quotedMessage() {
-        return pb_1.Message.getWrapperField(this, Message, 3) as Message | undefined | null;
+        return pb_1.Message.getWrapperField(this, Message, 3) as Message | undefined;
     }
-    set quotedMessage(value: Message | undefined | null) {
+    set quotedMessage(value: Message | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_quotedMessage() {
@@ -1556,18 +1610,18 @@ export class ContextInfo extends pb_1.Message {
         return pb_1.Message.getField(this, 22) != null;
     }
     get quotedAd() {
-        return pb_1.Message.getWrapperField(this, AdReplyInfo, 23) as AdReplyInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, AdReplyInfo, 23) as AdReplyInfo | undefined;
     }
-    set quotedAd(value: AdReplyInfo | undefined | null) {
+    set quotedAd(value: AdReplyInfo | undefined) {
         pb_1.Message.setWrapperField(this, 23, value);
     }
     get has_quotedAd() {
         return pb_1.Message.getField(this, 23) != null;
     }
     get placeholderKey() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 24) as MessageKey | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageKey, 24) as MessageKey | undefined;
     }
-    set placeholderKey(value: MessageKey | undefined | null) {
+    set placeholderKey(value: MessageKey | undefined) {
         pb_1.Message.setWrapperField(this, 24, value);
     }
     get has_placeholderKey() {
@@ -1600,7 +1654,7 @@ export class ContextInfo extends pb_1.Message {
     get has_ephemeralSharedSecret() {
         return pb_1.Message.getField(this, 27) != null;
     }
-    static fromObject(data: RecursivePartial<ContextInfo.AsObject>): ContextInfo {
+    static fromObject(data: ContextInfo.AsObjectPartial): ContextInfo {
         const message = new ContextInfo({
             mentionedJid: data.mentionedJid
         });
@@ -1678,19 +1732,19 @@ export class ContextInfo extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_stanzaId && this.stanzaId.length)
+        if (this.has_stanzaId && this.stanzaId!.length)
             writer.writeString(1, this.stanzaId);
-        if (this.has_participant && this.participant.length)
+        if (this.has_participant && this.participant!.length)
             writer.writeString(2, this.participant);
         if (this.has_quotedMessage)
-            writer.writeMessage(3, this.quotedMessage, () => this.quotedMessage.serialize(writer));
-        if (this.has_remoteJid && this.remoteJid.length)
+            writer.writeMessage(3, this.quotedMessage, () => this.quotedMessage!.serialize(writer));
+        if (this.has_remoteJid && this.remoteJid!.length)
             writer.writeString(4, this.remoteJid);
         if (this.mentionedJid.length)
             writer.writeRepeatedString(15, this.mentionedJid);
-        if (this.has_conversionSource && this.conversionSource.length)
+        if (this.has_conversionSource && this.conversionSource!.length)
             writer.writeString(18, this.conversionSource);
-        if (this.has_conversionData && this.conversionData.length)
+        if (this.has_conversionData && this.conversionData!.length)
             writer.writeBytes(19, this.conversionData);
         if (this.has_conversionDelaySeconds)
             writer.writeUint32(20, this.conversionDelaySeconds);
@@ -1699,14 +1753,14 @@ export class ContextInfo extends pb_1.Message {
         if (this.has_isForwarded)
             writer.writeBool(22, this.isForwarded);
         if (this.has_quotedAd)
-            writer.writeMessage(23, this.quotedAd, () => this.quotedAd.serialize(writer));
+            writer.writeMessage(23, this.quotedAd, () => this.quotedAd!.serialize(writer));
         if (this.has_placeholderKey)
-            writer.writeMessage(24, this.placeholderKey, () => this.placeholderKey.serialize(writer));
+            writer.writeMessage(24, this.placeholderKey, () => this.placeholderKey!.serialize(writer));
         if (this.has_expiration)
             writer.writeUint32(25, this.expiration);
         if (this.has_ephemeralSettingTimestamp)
             writer.writeInt64(26, this.ephemeralSettingTimestamp);
-        if (this.has_ephemeralSharedSecret && this.ephemeralSharedSecret.length)
+        if (this.has_ephemeralSharedSecret && this.ephemeralSharedSecret!.length)
             writer.writeBytes(27, this.ephemeralSharedSecret);
         if (!w)
             return writer.getResultBuffer();
@@ -1792,6 +1846,23 @@ export namespace ContextInfo {
         ephemeralSettingTimestamp: number;
         ephemeralSharedSecret: Uint8Array;
     };
+    export type AsObjectPartial = {
+        stanzaId?: string;
+        participant?: string;
+        quotedMessage?: Message.AsObjectPartial;
+        remoteJid?: string;
+        mentionedJid: string[];
+        conversionSource?: string;
+        conversionData?: Uint8Array;
+        conversionDelaySeconds?: number;
+        forwardingScore?: number;
+        isForwarded?: boolean;
+        quotedAd?: AdReplyInfo.AsObjectPartial;
+        placeholderKey?: MessageKey.AsObjectPartial;
+        expiration?: number;
+        ephemeralSettingTimestamp?: number;
+        ephemeralSharedSecret?: Uint8Array;
+    };
 }
 export class SenderKeyDistributionMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -1828,7 +1899,7 @@ export class SenderKeyDistributionMessage extends pb_1.Message {
     get has_axolotlSenderKeyDistributionMessage() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<SenderKeyDistributionMessage.AsObject>): SenderKeyDistributionMessage {
+    static fromObject(data: SenderKeyDistributionMessage.AsObjectPartial): SenderKeyDistributionMessage {
         const message = new SenderKeyDistributionMessage({});
         if (data.groupId != null) {
             message.groupId = data.groupId;
@@ -1849,9 +1920,9 @@ export class SenderKeyDistributionMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_groupId && this.groupId.length)
+        if (this.has_groupId && this.groupId!.length)
             writer.writeString(1, this.groupId);
-        if (this.has_axolotlSenderKeyDistributionMessage && this.axolotlSenderKeyDistributionMessage.length)
+        if (this.has_axolotlSenderKeyDistributionMessage && this.axolotlSenderKeyDistributionMessage!.length)
             writer.writeBytes(2, this.axolotlSenderKeyDistributionMessage);
         if (!w)
             return writer.getResultBuffer();
@@ -1884,6 +1955,10 @@ export namespace SenderKeyDistributionMessage {
     export type AsObject = {
         groupId: string;
         axolotlSenderKeyDistributionMessage: Uint8Array;
+    };
+    export type AsObjectPartial = {
+        groupId?: string;
+        axolotlSenderKeyDistributionMessage?: Uint8Array;
     };
 }
 export class ImageMessage extends pb_1.Message {
@@ -2090,9 +2165,9 @@ export class ImageMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -2158,7 +2233,7 @@ export class ImageMessage extends pb_1.Message {
     get has_midQualityFileEncSha256() {
         return pb_1.Message.getField(this, 24) != null;
     }
-    static fromObject(data: RecursivePartial<ImageMessage.AsObject>): ImageMessage {
+    static fromObject(data: ImageMessage.AsObjectPartial): ImageMessage {
         const message = new ImageMessage({
             interactiveAnnotations: data.interactiveAnnotations.map(item => InteractiveAnnotation.fromObject(item)),
             scanLengths: data.scanLengths
@@ -2254,13 +2329,13 @@ export class ImageMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_url && this.url.length)
+        if (this.has_url && this.url!.length)
             writer.writeString(1, this.url);
-        if (this.has_mimetype && this.mimetype.length)
+        if (this.has_mimetype && this.mimetype!.length)
             writer.writeString(2, this.mimetype);
-        if (this.has_caption && this.caption.length)
+        if (this.has_caption && this.caption!.length)
             writer.writeString(3, this.caption);
-        if (this.has_fileSha256 && this.fileSha256.length)
+        if (this.has_fileSha256 && this.fileSha256!.length)
             writer.writeBytes(4, this.fileSha256);
         if (this.has_fileLength)
             writer.writeUint64(5, this.fileLength);
@@ -2268,33 +2343,33 @@ export class ImageMessage extends pb_1.Message {
             writer.writeUint32(6, this.height);
         if (this.has_width)
             writer.writeUint32(7, this.width);
-        if (this.has_mediaKey && this.mediaKey.length)
+        if (this.has_mediaKey && this.mediaKey!.length)
             writer.writeBytes(8, this.mediaKey);
-        if (this.has_fileEncSha256 && this.fileEncSha256.length)
+        if (this.has_fileEncSha256 && this.fileEncSha256!.length)
             writer.writeBytes(9, this.fileEncSha256);
         if (this.interactiveAnnotations.length)
-            writer.writeRepeatedMessage(10, this.interactiveAnnotations, (item: InteractiveAnnotation) => item.serialize(writer));
-        if (this.has_directPath && this.directPath.length)
+            writer.writeRepeatedMessage(10, this.interactiveAnnotations, (item: InteractiveAnnotation) => item!.serialize(writer));
+        if (this.has_directPath && this.directPath!.length)
             writer.writeString(11, this.directPath);
         if (this.has_mediaKeyTimestamp)
             writer.writeInt64(12, this.mediaKeyTimestamp);
-        if (this.has_jpegThumbnail && this.jpegThumbnail.length)
+        if (this.has_jpegThumbnail && this.jpegThumbnail!.length)
             writer.writeBytes(16, this.jpegThumbnail);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
-        if (this.has_firstScanSidecar && this.firstScanSidecar.length)
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
+        if (this.has_firstScanSidecar && this.firstScanSidecar!.length)
             writer.writeBytes(18, this.firstScanSidecar);
         if (this.has_firstScanLength)
             writer.writeUint32(19, this.firstScanLength);
         if (this.has_experimentGroupId)
             writer.writeUint32(20, this.experimentGroupId);
-        if (this.has_scansSidecar && this.scansSidecar.length)
+        if (this.has_scansSidecar && this.scansSidecar!.length)
             writer.writeBytes(21, this.scansSidecar);
         if (this.scanLengths.length)
             writer.writeRepeatedUint32(22, this.scanLengths);
-        if (this.has_midQualityFileSha256 && this.midQualityFileSha256.length)
+        if (this.has_midQualityFileSha256 && this.midQualityFileSha256!.length)
             writer.writeBytes(23, this.midQualityFileSha256);
-        if (this.has_midQualityFileEncSha256 && this.midQualityFileEncSha256.length)
+        if (this.has_midQualityFileEncSha256 && this.midQualityFileEncSha256!.length)
             writer.writeBytes(24, this.midQualityFileEncSha256);
         if (!w)
             return writer.getResultBuffer();
@@ -2404,6 +2479,29 @@ export namespace ImageMessage {
         midQualityFileSha256: Uint8Array;
         midQualityFileEncSha256: Uint8Array;
     };
+    export type AsObjectPartial = {
+        url?: string;
+        mimetype?: string;
+        caption?: string;
+        fileSha256?: Uint8Array;
+        fileLength?: number;
+        height?: number;
+        width?: number;
+        mediaKey?: Uint8Array;
+        fileEncSha256?: Uint8Array;
+        interactiveAnnotations: InteractiveAnnotation.AsObjectPartial[];
+        directPath?: string;
+        mediaKeyTimestamp?: number;
+        jpegThumbnail?: Uint8Array;
+        contextInfo?: ContextInfo.AsObjectPartial;
+        firstScanSidecar?: Uint8Array;
+        firstScanLength?: number;
+        experimentGroupId?: number;
+        scansSidecar?: Uint8Array;
+        scanLengths: number[];
+        midQualityFileSha256?: Uint8Array;
+        midQualityFileEncSha256?: Uint8Array;
+    };
 }
 export class ContactMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -2445,15 +2543,15 @@ export class ContactMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<ContactMessage.AsObject>): ContactMessage {
+    static fromObject(data: ContactMessage.AsObjectPartial): ContactMessage {
         const message = new ContactMessage({});
         if (data.displayName != null) {
             message.displayName = data.displayName;
@@ -2480,12 +2578,12 @@ export class ContactMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_displayName && this.displayName.length)
+        if (this.has_displayName && this.displayName!.length)
             writer.writeString(1, this.displayName);
-        if (this.has_vcard && this.vcard.length)
+        if (this.has_vcard && this.vcard!.length)
             writer.writeString(16, this.vcard);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -2521,6 +2619,11 @@ export namespace ContactMessage {
         displayName: string;
         vcard: string;
         contextInfo?: ContextInfo.AsObject;
+    };
+    export type AsObjectPartial = {
+        displayName?: string;
+        vcard?: string;
+        contextInfo?: ContextInfo.AsObjectPartial;
     };
 }
 export class LocationMessage extends pb_1.Message {
@@ -2680,15 +2783,15 @@ export class LocationMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<LocationMessage.AsObject>): LocationMessage {
+    static fromObject(data: LocationMessage.AsObjectPartial): LocationMessage {
         const message = new LocationMessage({});
         if (data.degreesLatitude != null) {
             message.degreesLatitude = data.degreesLatitude;
@@ -2755,11 +2858,11 @@ export class LocationMessage extends pb_1.Message {
             writer.writeDouble(1, this.degreesLatitude);
         if (this.has_degreesLongitude)
             writer.writeDouble(2, this.degreesLongitude);
-        if (this.has_name && this.name.length)
+        if (this.has_name && this.name!.length)
             writer.writeString(3, this.name);
-        if (this.has_address && this.address.length)
+        if (this.has_address && this.address!.length)
             writer.writeString(4, this.address);
-        if (this.has_url && this.url.length)
+        if (this.has_url && this.url!.length)
             writer.writeString(5, this.url);
         if (this.has_isLive)
             writer.writeBool(6, this.isLive);
@@ -2769,12 +2872,12 @@ export class LocationMessage extends pb_1.Message {
             writer.writeFloat(8, this.speedInMps);
         if (this.has_degreesClockwiseFromMagneticNorth)
             writer.writeUint32(9, this.degreesClockwiseFromMagneticNorth);
-        if (this.has_comment && this.comment.length)
+        if (this.has_comment && this.comment!.length)
             writer.writeString(11, this.comment);
-        if (this.has_jpegThumbnail && this.jpegThumbnail.length)
+        if (this.has_jpegThumbnail && this.jpegThumbnail!.length)
             writer.writeBytes(16, this.jpegThumbnail);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -2846,6 +2949,20 @@ export namespace LocationMessage {
         comment: string;
         jpegThumbnail: Uint8Array;
         contextInfo?: ContextInfo.AsObject;
+    };
+    export type AsObjectPartial = {
+        degreesLatitude?: number;
+        degreesLongitude?: number;
+        name?: string;
+        address?: string;
+        url?: string;
+        isLive?: boolean;
+        accuracyInMeters?: number;
+        speedInMps?: number;
+        degreesClockwiseFromMagneticNorth?: number;
+        comment?: string;
+        jpegThumbnail?: Uint8Array;
+        contextInfo?: ContextInfo.AsObjectPartial;
     };
 }
 export class ExtendedTextMessage extends pb_1.Message {
@@ -2996,9 +3113,9 @@ export class ExtendedTextMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -3013,7 +3130,7 @@ export class ExtendedTextMessage extends pb_1.Message {
     get has_doNotPlayInline() {
         return pb_1.Message.getField(this, 18) != null;
     }
-    static fromObject(data: RecursivePartial<ExtendedTextMessage.AsObject>): ExtendedTextMessage {
+    static fromObject(data: ExtendedTextMessage.AsObjectPartial): ExtendedTextMessage {
         const message = new ExtendedTextMessage({});
         if (data.text != null) {
             message.text = data.text;
@@ -3076,15 +3193,15 @@ export class ExtendedTextMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_text && this.text.length)
+        if (this.has_text && this.text!.length)
             writer.writeString(1, this.text);
-        if (this.has_matchedText && this.matchedText.length)
+        if (this.has_matchedText && this.matchedText!.length)
             writer.writeString(2, this.matchedText);
-        if (this.has_canonicalUrl && this.canonicalUrl.length)
+        if (this.has_canonicalUrl && this.canonicalUrl!.length)
             writer.writeString(4, this.canonicalUrl);
-        if (this.has_description && this.description.length)
+        if (this.has_description && this.description!.length)
             writer.writeString(5, this.description);
-        if (this.has_title && this.title.length)
+        if (this.has_title && this.title!.length)
             writer.writeString(6, this.title);
         if (this.has_textArgb)
             writer.writeFixed32(7, this.textArgb);
@@ -3094,10 +3211,10 @@ export class ExtendedTextMessage extends pb_1.Message {
             writer.writeEnum(9, this.font);
         if (this.has_previewType)
             writer.writeEnum(10, this.previewType);
-        if (this.has_jpegThumbnail && this.jpegThumbnail.length)
+        if (this.has_jpegThumbnail && this.jpegThumbnail!.length)
             writer.writeBytes(16, this.jpegThumbnail);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (this.has_doNotPlayInline)
             writer.writeBool(18, this.doNotPlayInline);
         if (!w)
@@ -3171,6 +3288,20 @@ export namespace ExtendedTextMessage {
         jpegThumbnail: Uint8Array;
         contextInfo?: ContextInfo.AsObject;
         doNotPlayInline: boolean;
+    };
+    export type AsObjectPartial = {
+        text?: string;
+        matchedText?: string;
+        canonicalUrl?: string;
+        description?: string;
+        title?: string;
+        textArgb?: number;
+        backgroundArgb?: number;
+        font?: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_FONTTYPE;
+        previewType?: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_PREVIEWTYPE;
+        jpegThumbnail?: Uint8Array;
+        contextInfo?: ContextInfo.AsObjectPartial;
+        doNotPlayInline?: boolean;
     };
     export enum EXTENDED_TEXT_MESSAGE_FONTTYPE {
         SANS_SERIF = 0,
@@ -3355,15 +3486,15 @@ export class DocumentMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<DocumentMessage.AsObject>): DocumentMessage {
+    static fromObject(data: DocumentMessage.AsObjectPartial): DocumentMessage {
         const message = new DocumentMessage({});
         if (data.url != null) {
             message.url = data.url;
@@ -3430,32 +3561,32 @@ export class DocumentMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_url && this.url.length)
+        if (this.has_url && this.url!.length)
             writer.writeString(1, this.url);
-        if (this.has_mimetype && this.mimetype.length)
+        if (this.has_mimetype && this.mimetype!.length)
             writer.writeString(2, this.mimetype);
-        if (this.has_title && this.title.length)
+        if (this.has_title && this.title!.length)
             writer.writeString(3, this.title);
-        if (this.has_fileSha256 && this.fileSha256.length)
+        if (this.has_fileSha256 && this.fileSha256!.length)
             writer.writeBytes(4, this.fileSha256);
         if (this.has_fileLength)
             writer.writeUint64(5, this.fileLength);
         if (this.has_pageCount)
             writer.writeUint32(6, this.pageCount);
-        if (this.has_mediaKey && this.mediaKey.length)
+        if (this.has_mediaKey && this.mediaKey!.length)
             writer.writeBytes(7, this.mediaKey);
-        if (this.has_fileName && this.fileName.length)
+        if (this.has_fileName && this.fileName!.length)
             writer.writeString(8, this.fileName);
-        if (this.has_fileEncSha256 && this.fileEncSha256.length)
+        if (this.has_fileEncSha256 && this.fileEncSha256!.length)
             writer.writeBytes(9, this.fileEncSha256);
-        if (this.has_directPath && this.directPath.length)
+        if (this.has_directPath && this.directPath!.length)
             writer.writeString(10, this.directPath);
         if (this.has_mediaKeyTimestamp)
             writer.writeInt64(11, this.mediaKeyTimestamp);
-        if (this.has_jpegThumbnail && this.jpegThumbnail.length)
+        if (this.has_jpegThumbnail && this.jpegThumbnail!.length)
             writer.writeBytes(16, this.jpegThumbnail);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -3531,6 +3662,21 @@ export namespace DocumentMessage {
         mediaKeyTimestamp: number;
         jpegThumbnail: Uint8Array;
         contextInfo?: ContextInfo.AsObject;
+    };
+    export type AsObjectPartial = {
+        url?: string;
+        mimetype?: string;
+        title?: string;
+        fileSha256?: Uint8Array;
+        fileLength?: number;
+        pageCount?: number;
+        mediaKey?: Uint8Array;
+        fileName?: string;
+        fileEncSha256?: Uint8Array;
+        directPath?: string;
+        mediaKeyTimestamp?: number;
+        jpegThumbnail?: Uint8Array;
+        contextInfo?: ContextInfo.AsObjectPartial;
     };
 }
 export class AudioMessage extends pb_1.Message {
@@ -3681,9 +3827,9 @@ export class AudioMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 10) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -3698,7 +3844,7 @@ export class AudioMessage extends pb_1.Message {
     get has_streamingSidecar() {
         return pb_1.Message.getField(this, 18) != null;
     }
-    static fromObject(data: RecursivePartial<AudioMessage.AsObject>): AudioMessage {
+    static fromObject(data: AudioMessage.AsObjectPartial): AudioMessage {
         const message = new AudioMessage({});
         if (data.url != null) {
             message.url = data.url;
@@ -3761,11 +3907,11 @@ export class AudioMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_url && this.url.length)
+        if (this.has_url && this.url!.length)
             writer.writeString(1, this.url);
-        if (this.has_mimetype && this.mimetype.length)
+        if (this.has_mimetype && this.mimetype!.length)
             writer.writeString(2, this.mimetype);
-        if (this.has_fileSha256 && this.fileSha256.length)
+        if (this.has_fileSha256 && this.fileSha256!.length)
             writer.writeBytes(3, this.fileSha256);
         if (this.has_fileLength)
             writer.writeUint64(4, this.fileLength);
@@ -3773,17 +3919,17 @@ export class AudioMessage extends pb_1.Message {
             writer.writeUint32(5, this.seconds);
         if (this.has_ptt)
             writer.writeBool(6, this.ptt);
-        if (this.has_mediaKey && this.mediaKey.length)
+        if (this.has_mediaKey && this.mediaKey!.length)
             writer.writeBytes(7, this.mediaKey);
-        if (this.has_fileEncSha256 && this.fileEncSha256.length)
+        if (this.has_fileEncSha256 && this.fileEncSha256!.length)
             writer.writeBytes(8, this.fileEncSha256);
-        if (this.has_directPath && this.directPath.length)
+        if (this.has_directPath && this.directPath!.length)
             writer.writeString(9, this.directPath);
         if (this.has_mediaKeyTimestamp)
             writer.writeInt64(10, this.mediaKeyTimestamp);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
-        if (this.has_streamingSidecar && this.streamingSidecar.length)
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
+        if (this.has_streamingSidecar && this.streamingSidecar!.length)
             writer.writeBytes(18, this.streamingSidecar);
         if (!w)
             return writer.getResultBuffer();
@@ -3856,6 +4002,20 @@ export namespace AudioMessage {
         mediaKeyTimestamp: number;
         contextInfo?: ContextInfo.AsObject;
         streamingSidecar: Uint8Array;
+    };
+    export type AsObjectPartial = {
+        url?: string;
+        mimetype?: string;
+        fileSha256?: Uint8Array;
+        fileLength?: number;
+        seconds?: number;
+        ptt?: boolean;
+        mediaKey?: Uint8Array;
+        fileEncSha256?: Uint8Array;
+        directPath?: string;
+        mediaKeyTimestamp?: number;
+        contextInfo?: ContextInfo.AsObjectPartial;
+        streamingSidecar?: Uint8Array;
     };
 }
 export class VideoMessage extends pb_1.Message {
@@ -4070,9 +4230,9 @@ export class VideoMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
@@ -4096,7 +4256,7 @@ export class VideoMessage extends pb_1.Message {
     get has_gifAttribution() {
         return pb_1.Message.getField(this, 19) != null;
     }
-    static fromObject(data: RecursivePartial<VideoMessage.AsObject>): VideoMessage {
+    static fromObject(data: VideoMessage.AsObjectPartial): VideoMessage {
         const message = new VideoMessage({
             interactiveAnnotations: data.interactiveAnnotations.map(item => InteractiveAnnotation.fromObject(item))
         });
@@ -4182,19 +4342,19 @@ export class VideoMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_url && this.url.length)
+        if (this.has_url && this.url!.length)
             writer.writeString(1, this.url);
-        if (this.has_mimetype && this.mimetype.length)
+        if (this.has_mimetype && this.mimetype!.length)
             writer.writeString(2, this.mimetype);
-        if (this.has_fileSha256 && this.fileSha256.length)
+        if (this.has_fileSha256 && this.fileSha256!.length)
             writer.writeBytes(3, this.fileSha256);
         if (this.has_fileLength)
             writer.writeUint64(4, this.fileLength);
         if (this.has_seconds)
             writer.writeUint32(5, this.seconds);
-        if (this.has_mediaKey && this.mediaKey.length)
+        if (this.has_mediaKey && this.mediaKey!.length)
             writer.writeBytes(6, this.mediaKey);
-        if (this.has_caption && this.caption.length)
+        if (this.has_caption && this.caption!.length)
             writer.writeString(7, this.caption);
         if (this.has_gifPlayback)
             writer.writeBool(8, this.gifPlayback);
@@ -4202,19 +4362,19 @@ export class VideoMessage extends pb_1.Message {
             writer.writeUint32(9, this.height);
         if (this.has_width)
             writer.writeUint32(10, this.width);
-        if (this.has_fileEncSha256 && this.fileEncSha256.length)
+        if (this.has_fileEncSha256 && this.fileEncSha256!.length)
             writer.writeBytes(11, this.fileEncSha256);
         if (this.interactiveAnnotations.length)
-            writer.writeRepeatedMessage(12, this.interactiveAnnotations, (item: InteractiveAnnotation) => item.serialize(writer));
-        if (this.has_directPath && this.directPath.length)
+            writer.writeRepeatedMessage(12, this.interactiveAnnotations, (item: InteractiveAnnotation) => item!.serialize(writer));
+        if (this.has_directPath && this.directPath!.length)
             writer.writeString(13, this.directPath);
         if (this.has_mediaKeyTimestamp)
             writer.writeInt64(14, this.mediaKeyTimestamp);
-        if (this.has_jpegThumbnail && this.jpegThumbnail.length)
+        if (this.has_jpegThumbnail && this.jpegThumbnail!.length)
             writer.writeBytes(16, this.jpegThumbnail);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
-        if (this.has_streamingSidecar && this.streamingSidecar.length)
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
+        if (this.has_streamingSidecar && this.streamingSidecar!.length)
             writer.writeBytes(18, this.streamingSidecar);
         if (this.has_gifAttribution)
             writer.writeEnum(19, this.gifAttribution);
@@ -4314,6 +4474,26 @@ export namespace VideoMessage {
         streamingSidecar: Uint8Array;
         gifAttribution: VideoMessage.VIDEO_MESSAGE_ATTRIBUTION;
     };
+    export type AsObjectPartial = {
+        url?: string;
+        mimetype?: string;
+        fileSha256?: Uint8Array;
+        fileLength?: number;
+        seconds?: number;
+        mediaKey?: Uint8Array;
+        caption?: string;
+        gifPlayback?: boolean;
+        height?: number;
+        width?: number;
+        fileEncSha256?: Uint8Array;
+        interactiveAnnotations: InteractiveAnnotation.AsObjectPartial[];
+        directPath?: string;
+        mediaKeyTimestamp?: number;
+        jpegThumbnail?: Uint8Array;
+        contextInfo?: ContextInfo.AsObjectPartial;
+        streamingSidecar?: Uint8Array;
+        gifAttribution?: VideoMessage.VIDEO_MESSAGE_ATTRIBUTION;
+    };
     export enum VIDEO_MESSAGE_ATTRIBUTION {
         NONE = 0,
         GIPHY = 1,
@@ -4342,7 +4522,7 @@ export class Call extends pb_1.Message {
     get has_callKey() {
         return pb_1.Message.getField(this, 1) != null;
     }
-    static fromObject(data: RecursivePartial<Call.AsObject>): Call {
+    static fromObject(data: Call.AsObjectPartial): Call {
         const message = new Call({});
         if (data.callKey != null) {
             message.callKey = data.callKey;
@@ -4359,7 +4539,7 @@ export class Call extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_callKey && this.callKey.length)
+        if (this.has_callKey && this.callKey!.length)
             writer.writeBytes(1, this.callKey);
         if (!w)
             return writer.getResultBuffer();
@@ -4388,6 +4568,9 @@ export class Call extends pb_1.Message {
 export namespace Call {
     export type AsObject = {
         callKey: Uint8Array;
+    };
+    export type AsObjectPartial = {
+        callKey?: Uint8Array;
     };
 }
 export class Chat extends pb_1.Message {
@@ -4425,7 +4608,7 @@ export class Chat extends pb_1.Message {
     get has_id() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<Chat.AsObject>): Chat {
+    static fromObject(data: Chat.AsObjectPartial): Chat {
         const message = new Chat({});
         if (data.displayName != null) {
             message.displayName = data.displayName;
@@ -4446,9 +4629,9 @@ export class Chat extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_displayName && this.displayName.length)
+        if (this.has_displayName && this.displayName!.length)
             writer.writeString(1, this.displayName);
-        if (this.has_id && this.id.length)
+        if (this.has_id && this.id!.length)
             writer.writeString(2, this.id);
         if (!w)
             return writer.getResultBuffer();
@@ -4482,6 +4665,10 @@ export namespace Chat {
         displayName: string;
         id: string;
     };
+    export type AsObjectPartial = {
+        displayName?: string;
+        id?: string;
+    };
 }
 export class ProtocolMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -4513,9 +4700,9 @@ export class ProtocolMessage extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined;
     }
-    set key(value: MessageKey | undefined | null) {
+    set key(value: MessageKey | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
@@ -4549,15 +4736,15 @@ export class ProtocolMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 5) != null;
     }
     get historySyncNotification() {
-        return pb_1.Message.getWrapperField(this, HistorySyncNotification, 6) as HistorySyncNotification | undefined | null;
+        return pb_1.Message.getWrapperField(this, HistorySyncNotification, 6) as HistorySyncNotification | undefined;
     }
-    set historySyncNotification(value: HistorySyncNotification | undefined | null) {
+    set historySyncNotification(value: HistorySyncNotification | undefined) {
         pb_1.Message.setWrapperField(this, 6, value);
     }
     get has_historySyncNotification() {
         return pb_1.Message.getField(this, 6) != null;
     }
-    static fromObject(data: RecursivePartial<ProtocolMessage.AsObject>): ProtocolMessage {
+    static fromObject(data: ProtocolMessage.AsObjectPartial): ProtocolMessage {
         const message = new ProtocolMessage({});
         if (data.key != null) {
             message.key = MessageKey.fromObject(data.key);
@@ -4595,7 +4782,7 @@ export class ProtocolMessage extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_key)
-            writer.writeMessage(1, this.key, () => this.key.serialize(writer));
+            writer.writeMessage(1, this.key, () => this.key!.serialize(writer));
         if (this.has_type)
             writer.writeEnum(2, this.type);
         if (this.has_ephemeralExpiration)
@@ -4603,7 +4790,7 @@ export class ProtocolMessage extends pb_1.Message {
         if (this.has_ephemeralSettingTimestamp)
             writer.writeInt64(5, this.ephemeralSettingTimestamp);
         if (this.has_historySyncNotification)
-            writer.writeMessage(6, this.historySyncNotification, () => this.historySyncNotification.serialize(writer));
+            writer.writeMessage(6, this.historySyncNotification, () => this.historySyncNotification!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -4647,6 +4834,13 @@ export namespace ProtocolMessage {
         ephemeralExpiration: number;
         ephemeralSettingTimestamp: number;
         historySyncNotification?: HistorySyncNotification.AsObject;
+    };
+    export type AsObjectPartial = {
+        key?: MessageKey.AsObjectPartial;
+        type?: ProtocolMessage.PROTOCOL_MESSAGE_TYPE;
+        ephemeralExpiration?: number;
+        ephemeralSettingTimestamp?: number;
+        historySyncNotification?: HistorySyncNotification.AsObjectPartial;
     };
     export enum PROTOCOL_MESSAGE_TYPE {
         REVOKE = 0,
@@ -4768,7 +4962,7 @@ export class HistorySyncNotification extends pb_1.Message {
     get has_originalMessageId() {
         return pb_1.Message.getField(this, 8) != null;
     }
-    static fromObject(data: RecursivePartial<HistorySyncNotification.AsObject>): HistorySyncNotification {
+    static fromObject(data: HistorySyncNotification.AsObjectPartial): HistorySyncNotification {
         const message = new HistorySyncNotification({});
         if (data.fileSha256 != null) {
             message.fileSha256 = data.fileSha256;
@@ -4813,21 +5007,21 @@ export class HistorySyncNotification extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_fileSha256 && this.fileSha256.length)
+        if (this.has_fileSha256 && this.fileSha256!.length)
             writer.writeBytes(1, this.fileSha256);
         if (this.has_fileLength)
             writer.writeUint64(2, this.fileLength);
-        if (this.has_mediaKey && this.mediaKey.length)
+        if (this.has_mediaKey && this.mediaKey!.length)
             writer.writeBytes(3, this.mediaKey);
-        if (this.has_fileEncSha256 && this.fileEncSha256.length)
+        if (this.has_fileEncSha256 && this.fileEncSha256!.length)
             writer.writeBytes(4, this.fileEncSha256);
-        if (this.has_directPath && this.directPath.length)
+        if (this.has_directPath && this.directPath!.length)
             writer.writeString(5, this.directPath);
         if (this.has_syncType)
             writer.writeEnum(6, this.syncType);
         if (this.has_chunkOrder)
             writer.writeUint32(7, this.chunkOrder);
-        if (this.has_originalMessageId && this.originalMessageId.length)
+        if (this.has_originalMessageId && this.originalMessageId!.length)
             writer.writeString(8, this.originalMessageId);
         if (!w)
             return writer.getResultBuffer();
@@ -4885,6 +5079,16 @@ export namespace HistorySyncNotification {
         chunkOrder: number;
         originalMessageId: string;
     };
+    export type AsObjectPartial = {
+        fileSha256?: Uint8Array;
+        fileLength?: number;
+        mediaKey?: Uint8Array;
+        fileEncSha256?: Uint8Array;
+        directPath?: string;
+        syncType?: HistorySyncNotification.HISTORY_SYNC_NOTIFICATION_HISTORYSYNCTYPE;
+        chunkOrder?: number;
+        originalMessageId?: string;
+    };
     export enum HISTORY_SYNC_NOTIFICATION_HISTORYSYNCTYPE {
         INITIAL_BOOTSTRAP = 0,
         INITIAL_STATUS_V3 = 1,
@@ -4928,15 +5132,15 @@ export class ContactsArrayMessage extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<ContactsArrayMessage.AsObject>): ContactsArrayMessage {
+    static fromObject(data: ContactsArrayMessage.AsObjectPartial): ContactsArrayMessage {
         const message = new ContactsArrayMessage({
             contacts: data.contacts.map(item => ContactMessage.fromObject(item))
         });
@@ -4962,12 +5166,12 @@ export class ContactsArrayMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_displayName && this.displayName.length)
+        if (this.has_displayName && this.displayName!.length)
             writer.writeString(1, this.displayName);
         if (this.contacts.length)
-            writer.writeRepeatedMessage(2, this.contacts, (item: ContactMessage) => item.serialize(writer));
+            writer.writeRepeatedMessage(2, this.contacts, (item: ContactMessage) => item!.serialize(writer));
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -5003,6 +5207,11 @@ export namespace ContactsArrayMessage {
         displayName: string;
         contacts: ContactMessage.AsObject[];
         contextInfo?: ContextInfo.AsObject;
+    };
+    export type AsObjectPartial = {
+        displayName?: string;
+        contacts: ContactMessage.AsObjectPartial[];
+        contextInfo?: ContextInfo.AsObjectPartial;
     };
 }
 export class HSMCurrency extends pb_1.Message {
@@ -5040,7 +5249,7 @@ export class HSMCurrency extends pb_1.Message {
     get has_amount1000() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<HSMCurrency.AsObject>): HSMCurrency {
+    static fromObject(data: HSMCurrency.AsObjectPartial): HSMCurrency {
         const message = new HSMCurrency({});
         if (data.currencyCode != null) {
             message.currencyCode = data.currencyCode;
@@ -5061,7 +5270,7 @@ export class HSMCurrency extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_currencyCode && this.currencyCode.length)
+        if (this.has_currencyCode && this.currencyCode!.length)
             writer.writeString(1, this.currencyCode);
         if (this.has_amount1000)
             writer.writeInt64(2, this.amount1000);
@@ -5096,6 +5305,10 @@ export namespace HSMCurrency {
     export type AsObject = {
         currencyCode: string;
         amount1000: number;
+    };
+    export type AsObjectPartial = {
+        currencyCode?: string;
+        amount1000?: number;
     };
 }
 export class HSMDateTimeComponent extends pb_1.Message {
@@ -5198,7 +5411,7 @@ export class HSMDateTimeComponent extends pb_1.Message {
     get has_calendar() {
         return pb_1.Message.getField(this, 7) != null;
     }
-    static fromObject(data: RecursivePartial<HSMDateTimeComponent.AsObject>): HSMDateTimeComponent {
+    static fromObject(data: HSMDateTimeComponent.AsObjectPartial): HSMDateTimeComponent {
         const message = new HSMDateTimeComponent({});
         if (data.dayOfWeek != null) {
             message.dayOfWeek = data.dayOfWeek;
@@ -5305,6 +5518,15 @@ export namespace HSMDateTimeComponent {
         minute: number;
         calendar: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_CALENDARTYPE;
     };
+    export type AsObjectPartial = {
+        dayOfWeek?: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_DAYOFWEEKTYPE;
+        year?: number;
+        month?: number;
+        dayOfMonth?: number;
+        hour?: number;
+        minute?: number;
+        calendar?: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_CALENDARTYPE;
+    };
     export enum HSM_DATE_TIME_COMPONENT_DAYOFWEEKTYPE {
         MONDAY = 1,
         TUESDAY = 2,
@@ -5341,7 +5563,7 @@ export class HSMDateTimeUnixEpoch extends pb_1.Message {
     get has_timestamp() {
         return pb_1.Message.getField(this, 1) != null;
     }
-    static fromObject(data: RecursivePartial<HSMDateTimeUnixEpoch.AsObject>): HSMDateTimeUnixEpoch {
+    static fromObject(data: HSMDateTimeUnixEpoch.AsObjectPartial): HSMDateTimeUnixEpoch {
         const message = new HSMDateTimeUnixEpoch({});
         if (data.timestamp != null) {
             message.timestamp = data.timestamp;
@@ -5388,6 +5610,9 @@ export namespace HSMDateTimeUnixEpoch {
     export type AsObject = {
         timestamp: number;
     };
+    export type AsObjectPartial = {
+        timestamp?: number;
+    };
 }
 export class HSMDateTime extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2]];
@@ -5410,18 +5635,18 @@ export class HSMDateTime extends pb_1.Message {
         }
     }
     get component() {
-        return pb_1.Message.getWrapperField(this, HSMDateTimeComponent, 1) as HSMDateTimeComponent | undefined | null;
+        return pb_1.Message.getWrapperField(this, HSMDateTimeComponent, 1) as HSMDateTimeComponent | undefined;
     }
-    set component(value: HSMDateTimeComponent | undefined | null) {
+    set component(value: HSMDateTimeComponent | undefined) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_component() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get unixEpoch() {
-        return pb_1.Message.getWrapperField(this, HSMDateTimeUnixEpoch, 2) as HSMDateTimeUnixEpoch | undefined | null;
+        return pb_1.Message.getWrapperField(this, HSMDateTimeUnixEpoch, 2) as HSMDateTimeUnixEpoch | undefined;
     }
-    set unixEpoch(value: HSMDateTimeUnixEpoch | undefined | null) {
+    set unixEpoch(value: HSMDateTimeUnixEpoch | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_unixEpoch() {
@@ -5437,7 +5662,7 @@ export class HSMDateTime extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2])];
     }
-    static fromObject(data: RecursivePartial<HSMDateTime.AsObject>): HSMDateTime {
+    static fromObject(data: HSMDateTime.AsObjectPartial): HSMDateTime {
         const message = new HSMDateTime({});
         if (data.component != null) {
             message.component = HSMDateTimeComponent.fromObject(data.component);
@@ -5462,9 +5687,9 @@ export class HSMDateTime extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_component)
-            writer.writeMessage(1, this.component, () => this.component.serialize(writer));
+            writer.writeMessage(1, this.component, () => this.component!.serialize(writer));
         if (this.has_unixEpoch)
-            writer.writeMessage(2, this.unixEpoch, () => this.unixEpoch.serialize(writer));
+            writer.writeMessage(2, this.unixEpoch, () => this.unixEpoch!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -5496,6 +5721,10 @@ export namespace HSMDateTime {
     export type AsObject = {
         component?: HSMDateTimeComponent.AsObject;
         unixEpoch?: HSMDateTimeUnixEpoch.AsObject;
+    };
+    export type AsObjectPartial = {
+        component?: HSMDateTimeComponent.AsObjectPartial;
+        unixEpoch?: HSMDateTimeUnixEpoch.AsObjectPartial;
     };
 }
 export class HSMLocalizableParameter extends pb_1.Message {
@@ -5533,18 +5762,18 @@ export class HSMLocalizableParameter extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get currency() {
-        return pb_1.Message.getWrapperField(this, HSMCurrency, 2) as HSMCurrency | undefined | null;
+        return pb_1.Message.getWrapperField(this, HSMCurrency, 2) as HSMCurrency | undefined;
     }
-    set currency(value: HSMCurrency | undefined | null) {
+    set currency(value: HSMCurrency | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_currency() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get dateTime() {
-        return pb_1.Message.getWrapperField(this, HSMDateTime, 3) as HSMDateTime | undefined | null;
+        return pb_1.Message.getWrapperField(this, HSMDateTime, 3) as HSMDateTime | undefined;
     }
-    set dateTime(value: HSMDateTime | undefined | null) {
+    set dateTime(value: HSMDateTime | undefined) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_dateTime() {
@@ -5560,7 +5789,7 @@ export class HSMLocalizableParameter extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [2, 3])];
     }
-    static fromObject(data: RecursivePartial<HSMLocalizableParameter.AsObject>): HSMLocalizableParameter {
+    static fromObject(data: HSMLocalizableParameter.AsObjectPartial): HSMLocalizableParameter {
         const message = new HSMLocalizableParameter({});
         if (data.default != null) {
             message.default = data.default;
@@ -5589,12 +5818,12 @@ export class HSMLocalizableParameter extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_default && this.default.length)
+        if (this.has_default && this.default!.length)
             writer.writeString(1, this.default);
         if (this.has_currency)
-            writer.writeMessage(2, this.currency, () => this.currency.serialize(writer));
+            writer.writeMessage(2, this.currency, () => this.currency!.serialize(writer));
         if (this.has_dateTime)
-            writer.writeMessage(3, this.dateTime, () => this.dateTime.serialize(writer));
+            writer.writeMessage(3, this.dateTime, () => this.dateTime!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -5630,6 +5859,11 @@ export namespace HSMLocalizableParameter {
         default: string;
         currency?: HSMCurrency.AsObject;
         dateTime?: HSMDateTime.AsObject;
+    };
+    export type AsObjectPartial = {
+        default?: string;
+        currency?: HSMCurrency.AsObjectPartial;
+        dateTime?: HSMDateTime.AsObjectPartial;
     };
 }
 export class HighlyStructuredMessage extends pb_1.Message {
@@ -5740,15 +5974,15 @@ export class HighlyStructuredMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 8) != null;
     }
     get hydratedHsm() {
-        return pb_1.Message.getWrapperField(this, TemplateMessage, 9) as TemplateMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, TemplateMessage, 9) as TemplateMessage | undefined;
     }
-    set hydratedHsm(value: TemplateMessage | undefined | null) {
+    set hydratedHsm(value: TemplateMessage | undefined) {
         pb_1.Message.setWrapperField(this, 9, value);
     }
     get has_hydratedHsm() {
         return pb_1.Message.getField(this, 9) != null;
     }
-    static fromObject(data: RecursivePartial<HighlyStructuredMessage.AsObject>): HighlyStructuredMessage {
+    static fromObject(data: HighlyStructuredMessage.AsObjectPartial): HighlyStructuredMessage {
         const message = new HighlyStructuredMessage({
             params: data.params,
             localizableParams: data.localizableParams.map(item => HSMLocalizableParameter.fromObject(item))
@@ -5796,24 +6030,24 @@ export class HighlyStructuredMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_namespace && this.namespace.length)
+        if (this.has_namespace && this.namespace!.length)
             writer.writeString(1, this.namespace);
-        if (this.has_elementName && this.elementName.length)
+        if (this.has_elementName && this.elementName!.length)
             writer.writeString(2, this.elementName);
         if (this.params.length)
             writer.writeRepeatedString(3, this.params);
-        if (this.has_fallbackLg && this.fallbackLg.length)
+        if (this.has_fallbackLg && this.fallbackLg!.length)
             writer.writeString(4, this.fallbackLg);
-        if (this.has_fallbackLc && this.fallbackLc.length)
+        if (this.has_fallbackLc && this.fallbackLc!.length)
             writer.writeString(5, this.fallbackLc);
         if (this.localizableParams.length)
-            writer.writeRepeatedMessage(6, this.localizableParams, (item: HSMLocalizableParameter) => item.serialize(writer));
-        if (this.has_deterministicLg && this.deterministicLg.length)
+            writer.writeRepeatedMessage(6, this.localizableParams, (item: HSMLocalizableParameter) => item!.serialize(writer));
+        if (this.has_deterministicLg && this.deterministicLg!.length)
             writer.writeString(7, this.deterministicLg);
-        if (this.has_deterministicLc && this.deterministicLc.length)
+        if (this.has_deterministicLc && this.deterministicLc!.length)
             writer.writeString(8, this.deterministicLc);
         if (this.has_hydratedHsm)
-            writer.writeMessage(9, this.hydratedHsm, () => this.hydratedHsm.serialize(writer));
+            writer.writeMessage(9, this.hydratedHsm, () => this.hydratedHsm!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -5874,6 +6108,17 @@ export namespace HighlyStructuredMessage {
         deterministicLc: string;
         hydratedHsm?: TemplateMessage.AsObject;
     };
+    export type AsObjectPartial = {
+        namespace?: string;
+        elementName?: string;
+        params: string[];
+        fallbackLg?: string;
+        fallbackLc?: string;
+        localizableParams: HSMLocalizableParameter.AsObjectPartial[];
+        deterministicLg?: string;
+        deterministicLc?: string;
+        hydratedHsm?: TemplateMessage.AsObjectPartial;
+    };
 }
 export class SendPaymentMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -5893,24 +6138,24 @@ export class SendPaymentMessage extends pb_1.Message {
         }
     }
     get noteMessage() {
-        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined | null;
+        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined;
     }
-    set noteMessage(value: Message | undefined | null) {
+    set noteMessage(value: Message | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_noteMessage() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get requestMessageKey() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 3) as MessageKey | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageKey, 3) as MessageKey | undefined;
     }
-    set requestMessageKey(value: MessageKey | undefined | null) {
+    set requestMessageKey(value: MessageKey | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_requestMessageKey() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<SendPaymentMessage.AsObject>): SendPaymentMessage {
+    static fromObject(data: SendPaymentMessage.AsObjectPartial): SendPaymentMessage {
         const message = new SendPaymentMessage({});
         if (data.noteMessage != null) {
             message.noteMessage = Message.fromObject(data.noteMessage);
@@ -5935,9 +6180,9 @@ export class SendPaymentMessage extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_noteMessage)
-            writer.writeMessage(2, this.noteMessage, () => this.noteMessage.serialize(writer));
+            writer.writeMessage(2, this.noteMessage, () => this.noteMessage!.serialize(writer));
         if (this.has_requestMessageKey)
-            writer.writeMessage(3, this.requestMessageKey, () => this.requestMessageKey.serialize(writer));
+            writer.writeMessage(3, this.requestMessageKey, () => this.requestMessageKey!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -5970,6 +6215,10 @@ export namespace SendPaymentMessage {
         noteMessage?: Message.AsObject;
         requestMessageKey?: MessageKey.AsObject;
     };
+    export type AsObjectPartial = {
+        noteMessage?: Message.AsObjectPartial;
+        requestMessageKey?: MessageKey.AsObjectPartial;
+    };
 }
 export class RequestPaymentMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -6001,9 +6250,9 @@ export class RequestPaymentMessage extends pb_1.Message {
         }
     }
     get noteMessage() {
-        return pb_1.Message.getWrapperField(this, Message, 4) as Message | undefined | null;
+        return pb_1.Message.getWrapperField(this, Message, 4) as Message | undefined;
     }
-    set noteMessage(value: Message | undefined | null) {
+    set noteMessage(value: Message | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_noteMessage() {
@@ -6045,7 +6294,7 @@ export class RequestPaymentMessage extends pb_1.Message {
     get has_expiryTimestamp() {
         return pb_1.Message.getField(this, 5) != null;
     }
-    static fromObject(data: RecursivePartial<RequestPaymentMessage.AsObject>): RequestPaymentMessage {
+    static fromObject(data: RequestPaymentMessage.AsObjectPartial): RequestPaymentMessage {
         const message = new RequestPaymentMessage({});
         if (data.noteMessage != null) {
             message.noteMessage = Message.fromObject(data.noteMessage);
@@ -6081,12 +6330,12 @@ export class RequestPaymentMessage extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_noteMessage)
-            writer.writeMessage(4, this.noteMessage, () => this.noteMessage.serialize(writer));
-        if (this.has_currencyCodeIso4217 && this.currencyCodeIso4217.length)
+            writer.writeMessage(4, this.noteMessage, () => this.noteMessage!.serialize(writer));
+        if (this.has_currencyCodeIso4217 && this.currencyCodeIso4217!.length)
             writer.writeString(1, this.currencyCodeIso4217);
         if (this.has_amount1000)
             writer.writeUint64(2, this.amount1000);
-        if (this.has_requestFrom && this.requestFrom.length)
+        if (this.has_requestFrom && this.requestFrom!.length)
             writer.writeString(3, this.requestFrom);
         if (this.has_expiryTimestamp)
             writer.writeInt64(5, this.expiryTimestamp);
@@ -6134,6 +6383,13 @@ export namespace RequestPaymentMessage {
         requestFrom: string;
         expiryTimestamp: number;
     };
+    export type AsObjectPartial = {
+        noteMessage?: Message.AsObjectPartial;
+        currencyCodeIso4217?: string;
+        amount1000?: number;
+        requestFrom?: string;
+        expiryTimestamp?: number;
+    };
 }
 export class DeclinePaymentRequestMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -6149,15 +6405,15 @@ export class DeclinePaymentRequestMessage extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined;
     }
-    set key(value: MessageKey | undefined | null) {
+    set key(value: MessageKey | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
         return pb_1.Message.getField(this, 1) != null;
     }
-    static fromObject(data: RecursivePartial<DeclinePaymentRequestMessage.AsObject>): DeclinePaymentRequestMessage {
+    static fromObject(data: DeclinePaymentRequestMessage.AsObjectPartial): DeclinePaymentRequestMessage {
         const message = new DeclinePaymentRequestMessage({});
         if (data.key != null) {
             message.key = MessageKey.fromObject(data.key);
@@ -6176,7 +6432,7 @@ export class DeclinePaymentRequestMessage extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_key)
-            writer.writeMessage(1, this.key, () => this.key.serialize(writer));
+            writer.writeMessage(1, this.key, () => this.key!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -6205,6 +6461,9 @@ export namespace DeclinePaymentRequestMessage {
     export type AsObject = {
         key?: MessageKey.AsObject;
     };
+    export type AsObjectPartial = {
+        key?: MessageKey.AsObjectPartial;
+    };
 }
 export class CancelPaymentRequestMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -6220,15 +6479,15 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined;
     }
-    set key(value: MessageKey | undefined | null) {
+    set key(value: MessageKey | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
         return pb_1.Message.getField(this, 1) != null;
     }
-    static fromObject(data: RecursivePartial<CancelPaymentRequestMessage.AsObject>): CancelPaymentRequestMessage {
+    static fromObject(data: CancelPaymentRequestMessage.AsObjectPartial): CancelPaymentRequestMessage {
         const message = new CancelPaymentRequestMessage({});
         if (data.key != null) {
             message.key = MessageKey.fromObject(data.key);
@@ -6247,7 +6506,7 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_key)
-            writer.writeMessage(1, this.key, () => this.key.serialize(writer));
+            writer.writeMessage(1, this.key, () => this.key!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -6275,6 +6534,9 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
 export namespace CancelPaymentRequestMessage {
     export type AsObject = {
         key?: MessageKey.AsObject;
+    };
+    export type AsObjectPartial = {
+        key?: MessageKey.AsObjectPartial;
     };
 }
 export class LiveLocationMessage extends pb_1.Message {
@@ -6408,15 +6670,15 @@ export class LiveLocationMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<LiveLocationMessage.AsObject>): LiveLocationMessage {
+    static fromObject(data: LiveLocationMessage.AsObjectPartial): LiveLocationMessage {
         const message = new LiveLocationMessage({});
         if (data.degreesLatitude != null) {
             message.degreesLatitude = data.degreesLatitude;
@@ -6481,16 +6743,16 @@ export class LiveLocationMessage extends pb_1.Message {
             writer.writeFloat(4, this.speedInMps);
         if (this.has_degreesClockwiseFromMagneticNorth)
             writer.writeUint32(5, this.degreesClockwiseFromMagneticNorth);
-        if (this.has_caption && this.caption.length)
+        if (this.has_caption && this.caption!.length)
             writer.writeString(6, this.caption);
         if (this.has_sequenceNumber)
             writer.writeInt64(7, this.sequenceNumber);
         if (this.has_timeOffset)
             writer.writeUint32(8, this.timeOffset);
-        if (this.has_jpegThumbnail && this.jpegThumbnail.length)
+        if (this.has_jpegThumbnail && this.jpegThumbnail!.length)
             writer.writeBytes(16, this.jpegThumbnail);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -6554,6 +6816,18 @@ export namespace LiveLocationMessage {
         timeOffset: number;
         jpegThumbnail: Uint8Array;
         contextInfo?: ContextInfo.AsObject;
+    };
+    export type AsObjectPartial = {
+        degreesLatitude?: number;
+        degreesLongitude?: number;
+        accuracyInMeters?: number;
+        speedInMps?: number;
+        degreesClockwiseFromMagneticNorth?: number;
+        caption?: string;
+        sequenceNumber?: number;
+        timeOffset?: number;
+        jpegThumbnail?: Uint8Array;
+        contextInfo?: ContextInfo.AsObjectPartial;
     };
 }
 export class StickerMessage extends pb_1.Message {
@@ -6752,15 +7026,15 @@ export class StickerMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 16) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<StickerMessage.AsObject>): StickerMessage {
+    static fromObject(data: StickerMessage.AsObjectPartial): StickerMessage {
         const message = new StickerMessage({});
         if (data.url != null) {
             message.url = data.url;
@@ -6835,21 +7109,21 @@ export class StickerMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_url && this.url.length)
+        if (this.has_url && this.url!.length)
             writer.writeString(1, this.url);
-        if (this.has_fileSha256 && this.fileSha256.length)
+        if (this.has_fileSha256 && this.fileSha256!.length)
             writer.writeBytes(2, this.fileSha256);
-        if (this.has_fileEncSha256 && this.fileEncSha256.length)
+        if (this.has_fileEncSha256 && this.fileEncSha256!.length)
             writer.writeBytes(3, this.fileEncSha256);
-        if (this.has_mediaKey && this.mediaKey.length)
+        if (this.has_mediaKey && this.mediaKey!.length)
             writer.writeBytes(4, this.mediaKey);
-        if (this.has_mimetype && this.mimetype.length)
+        if (this.has_mimetype && this.mimetype!.length)
             writer.writeString(5, this.mimetype);
         if (this.has_height)
             writer.writeUint32(6, this.height);
         if (this.has_width)
             writer.writeUint32(7, this.width);
-        if (this.has_directPath && this.directPath.length)
+        if (this.has_directPath && this.directPath!.length)
             writer.writeString(8, this.directPath);
         if (this.has_fileLength)
             writer.writeUint64(9, this.fileLength);
@@ -6857,14 +7131,14 @@ export class StickerMessage extends pb_1.Message {
             writer.writeInt64(10, this.mediaKeyTimestamp);
         if (this.has_firstFrameLength)
             writer.writeUint32(11, this.firstFrameLength);
-        if (this.has_firstFrameSidecar && this.firstFrameSidecar.length)
+        if (this.has_firstFrameSidecar && this.firstFrameSidecar!.length)
             writer.writeBytes(12, this.firstFrameSidecar);
         if (this.has_isAnimated)
             writer.writeBool(13, this.isAnimated);
-        if (this.has_pngThumbnail && this.pngThumbnail.length)
+        if (this.has_pngThumbnail && this.pngThumbnail!.length)
             writer.writeBytes(16, this.pngThumbnail);
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -6949,6 +7223,23 @@ export namespace StickerMessage {
         pngThumbnail: Uint8Array;
         contextInfo?: ContextInfo.AsObject;
     };
+    export type AsObjectPartial = {
+        url?: string;
+        fileSha256?: Uint8Array;
+        fileEncSha256?: Uint8Array;
+        mediaKey?: Uint8Array;
+        mimetype?: string;
+        height?: number;
+        width?: number;
+        directPath?: string;
+        fileLength?: number;
+        mediaKeyTimestamp?: number;
+        firstFrameLength?: number;
+        firstFrameSidecar?: Uint8Array;
+        isAnimated?: boolean;
+        pngThumbnail?: Uint8Array;
+        contextInfo?: ContextInfo.AsObjectPartial;
+    };
 }
 export class FourRowTemplate extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2, 3, 4, 5]];
@@ -7015,18 +7306,18 @@ export class FourRowTemplate extends pb_1.Message {
         }
     }
     get content() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 6) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 6) as HighlyStructuredMessage | undefined;
     }
-    set content(value: HighlyStructuredMessage | undefined | null) {
+    set content(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setWrapperField(this, 6, value);
     }
     get has_content() {
         return pb_1.Message.getField(this, 6) != null;
     }
     get footer() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 7) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 7) as HighlyStructuredMessage | undefined;
     }
-    set footer(value: HighlyStructuredMessage | undefined | null) {
+    set footer(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setWrapperField(this, 7, value);
     }
     get has_footer() {
@@ -7039,45 +7330,45 @@ export class FourRowTemplate extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 8, value);
     }
     get documentMessage() {
-        return pb_1.Message.getWrapperField(this, DocumentMessage, 1) as DocumentMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, DocumentMessage, 1) as DocumentMessage | undefined;
     }
-    set documentMessage(value: DocumentMessage | undefined | null) {
+    set documentMessage(value: DocumentMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_documentMessage() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get highlyStructuredMessage() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 2) as HighlyStructuredMessage | undefined;
     }
-    set highlyStructuredMessage(value: HighlyStructuredMessage | undefined | null) {
+    set highlyStructuredMessage(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_highlyStructuredMessage() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get imageMessage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined;
     }
-    set imageMessage(value: ImageMessage | undefined | null) {
+    set imageMessage(value: ImageMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_imageMessage() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get videoMessage() {
-        return pb_1.Message.getWrapperField(this, VideoMessage, 4) as VideoMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, VideoMessage, 4) as VideoMessage | undefined;
     }
-    set videoMessage(value: VideoMessage | undefined | null) {
+    set videoMessage(value: VideoMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 4, this.#one_of_decls[0], value);
     }
     get has_videoMessage() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get locationMessage() {
-        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined;
     }
-    set locationMessage(value: LocationMessage | undefined | null) {
+    set locationMessage(value: LocationMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 5, this.#one_of_decls[0], value);
     }
     get has_locationMessage() {
@@ -7096,7 +7387,7 @@ export class FourRowTemplate extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3, 4, 5])];
     }
-    static fromObject(data: RecursivePartial<FourRowTemplate.AsObject>): FourRowTemplate {
+    static fromObject(data: FourRowTemplate.AsObjectPartial): FourRowTemplate {
         const message = new FourRowTemplate({
             buttons: data.buttons.map(item => TemplateButton.fromObject(item))
         });
@@ -7155,21 +7446,21 @@ export class FourRowTemplate extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_content)
-            writer.writeMessage(6, this.content, () => this.content.serialize(writer));
+            writer.writeMessage(6, this.content, () => this.content!.serialize(writer));
         if (this.has_footer)
-            writer.writeMessage(7, this.footer, () => this.footer.serialize(writer));
+            writer.writeMessage(7, this.footer, () => this.footer!.serialize(writer));
         if (this.buttons.length)
-            writer.writeRepeatedMessage(8, this.buttons, (item: TemplateButton) => item.serialize(writer));
+            writer.writeRepeatedMessage(8, this.buttons, (item: TemplateButton) => item!.serialize(writer));
         if (this.has_documentMessage)
-            writer.writeMessage(1, this.documentMessage, () => this.documentMessage.serialize(writer));
+            writer.writeMessage(1, this.documentMessage, () => this.documentMessage!.serialize(writer));
         if (this.has_highlyStructuredMessage)
-            writer.writeMessage(2, this.highlyStructuredMessage, () => this.highlyStructuredMessage.serialize(writer));
+            writer.writeMessage(2, this.highlyStructuredMessage, () => this.highlyStructuredMessage!.serialize(writer));
         if (this.has_imageMessage)
-            writer.writeMessage(3, this.imageMessage, () => this.imageMessage.serialize(writer));
+            writer.writeMessage(3, this.imageMessage, () => this.imageMessage!.serialize(writer));
         if (this.has_videoMessage)
-            writer.writeMessage(4, this.videoMessage, () => this.videoMessage.serialize(writer));
+            writer.writeMessage(4, this.videoMessage, () => this.videoMessage!.serialize(writer));
         if (this.has_locationMessage)
-            writer.writeMessage(5, this.locationMessage, () => this.locationMessage.serialize(writer));
+            writer.writeMessage(5, this.locationMessage, () => this.locationMessage!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -7225,6 +7516,16 @@ export namespace FourRowTemplate {
         imageMessage?: ImageMessage.AsObject;
         videoMessage?: VideoMessage.AsObject;
         locationMessage?: LocationMessage.AsObject;
+    };
+    export type AsObjectPartial = {
+        content?: HighlyStructuredMessage.AsObjectPartial;
+        footer?: HighlyStructuredMessage.AsObjectPartial;
+        buttons: TemplateButton.AsObjectPartial[];
+        documentMessage?: DocumentMessage.AsObjectPartial;
+        highlyStructuredMessage?: HighlyStructuredMessage.AsObjectPartial;
+        imageMessage?: ImageMessage.AsObjectPartial;
+        videoMessage?: VideoMessage.AsObjectPartial;
+        locationMessage?: LocationMessage.AsObjectPartial;
     };
 }
 export class HydratedFourRowTemplate extends pb_1.Message {
@@ -7329,9 +7630,9 @@ export class HydratedFourRowTemplate extends pb_1.Message {
         return pb_1.Message.getField(this, 9) != null;
     }
     get documentMessage() {
-        return pb_1.Message.getWrapperField(this, DocumentMessage, 1) as DocumentMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, DocumentMessage, 1) as DocumentMessage | undefined;
     }
-    set documentMessage(value: DocumentMessage | undefined | null) {
+    set documentMessage(value: DocumentMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_documentMessage() {
@@ -7347,27 +7648,27 @@ export class HydratedFourRowTemplate extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get imageMessage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined;
     }
-    set imageMessage(value: ImageMessage | undefined | null) {
+    set imageMessage(value: ImageMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 3, this.#one_of_decls[0], value);
     }
     get has_imageMessage() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get videoMessage() {
-        return pb_1.Message.getWrapperField(this, VideoMessage, 4) as VideoMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, VideoMessage, 4) as VideoMessage | undefined;
     }
-    set videoMessage(value: VideoMessage | undefined | null) {
+    set videoMessage(value: VideoMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 4, this.#one_of_decls[0], value);
     }
     get has_videoMessage() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get locationMessage() {
-        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined;
     }
-    set locationMessage(value: LocationMessage | undefined | null) {
+    set locationMessage(value: LocationMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 5, this.#one_of_decls[0], value);
     }
     get has_locationMessage() {
@@ -7386,7 +7687,7 @@ export class HydratedFourRowTemplate extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3, 4, 5])];
     }
-    static fromObject(data: RecursivePartial<HydratedFourRowTemplate.AsObject>): HydratedFourRowTemplate {
+    static fromObject(data: HydratedFourRowTemplate.AsObjectPartial): HydratedFourRowTemplate {
         const message = new HydratedFourRowTemplate({
             hydratedButtons: data.hydratedButtons.map(item => HydratedTemplateButton.fromObject(item))
         });
@@ -7442,24 +7743,24 @@ export class HydratedFourRowTemplate extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_hydratedContentText && this.hydratedContentText.length)
+        if (this.has_hydratedContentText && this.hydratedContentText!.length)
             writer.writeString(6, this.hydratedContentText);
-        if (this.has_hydratedFooterText && this.hydratedFooterText.length)
+        if (this.has_hydratedFooterText && this.hydratedFooterText!.length)
             writer.writeString(7, this.hydratedFooterText);
         if (this.hydratedButtons.length)
-            writer.writeRepeatedMessage(8, this.hydratedButtons, (item: HydratedTemplateButton) => item.serialize(writer));
-        if (this.has_templateId && this.templateId.length)
+            writer.writeRepeatedMessage(8, this.hydratedButtons, (item: HydratedTemplateButton) => item!.serialize(writer));
+        if (this.has_templateId && this.templateId!.length)
             writer.writeString(9, this.templateId);
         if (this.has_documentMessage)
-            writer.writeMessage(1, this.documentMessage, () => this.documentMessage.serialize(writer));
+            writer.writeMessage(1, this.documentMessage, () => this.documentMessage!.serialize(writer));
         if (this.has_hydratedTitleText)
             writer.writeString(2, this.hydratedTitleText);
         if (this.has_imageMessage)
-            writer.writeMessage(3, this.imageMessage, () => this.imageMessage.serialize(writer));
+            writer.writeMessage(3, this.imageMessage, () => this.imageMessage!.serialize(writer));
         if (this.has_videoMessage)
-            writer.writeMessage(4, this.videoMessage, () => this.videoMessage.serialize(writer));
+            writer.writeMessage(4, this.videoMessage, () => this.videoMessage!.serialize(writer));
         if (this.has_locationMessage)
-            writer.writeMessage(5, this.locationMessage, () => this.locationMessage.serialize(writer));
+            writer.writeMessage(5, this.locationMessage, () => this.locationMessage!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -7520,6 +7821,17 @@ export namespace HydratedFourRowTemplate {
         videoMessage?: VideoMessage.AsObject;
         locationMessage?: LocationMessage.AsObject;
     };
+    export type AsObjectPartial = {
+        hydratedContentText?: string;
+        hydratedFooterText?: string;
+        hydratedButtons: HydratedTemplateButton.AsObjectPartial[];
+        templateId?: string;
+        documentMessage?: DocumentMessage.AsObjectPartial;
+        hydratedTitleText?: string;
+        imageMessage?: ImageMessage.AsObjectPartial;
+        videoMessage?: VideoMessage.AsObjectPartial;
+        locationMessage?: LocationMessage.AsObjectPartial;
+    };
 }
 export class TemplateMessage extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2]];
@@ -7551,36 +7863,36 @@ export class TemplateMessage extends pb_1.Message {
         }
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 3) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 3) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get hydratedTemplate() {
-        return pb_1.Message.getWrapperField(this, HydratedFourRowTemplate, 4) as HydratedFourRowTemplate | undefined | null;
+        return pb_1.Message.getWrapperField(this, HydratedFourRowTemplate, 4) as HydratedFourRowTemplate | undefined;
     }
-    set hydratedTemplate(value: HydratedFourRowTemplate | undefined | null) {
+    set hydratedTemplate(value: HydratedFourRowTemplate | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_hydratedTemplate() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get fourRowTemplate() {
-        return pb_1.Message.getWrapperField(this, FourRowTemplate, 1) as FourRowTemplate | undefined | null;
+        return pb_1.Message.getWrapperField(this, FourRowTemplate, 1) as FourRowTemplate | undefined;
     }
-    set fourRowTemplate(value: FourRowTemplate | undefined | null) {
+    set fourRowTemplate(value: FourRowTemplate | undefined) {
         pb_1.Message.setOneofWrapperField(this, 1, this.#one_of_decls[0], value);
     }
     get has_fourRowTemplate() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get hydratedFourRowTemplate() {
-        return pb_1.Message.getWrapperField(this, HydratedFourRowTemplate, 2) as HydratedFourRowTemplate | undefined | null;
+        return pb_1.Message.getWrapperField(this, HydratedFourRowTemplate, 2) as HydratedFourRowTemplate | undefined;
     }
-    set hydratedFourRowTemplate(value: HydratedFourRowTemplate | undefined | null) {
+    set hydratedFourRowTemplate(value: HydratedFourRowTemplate | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_hydratedFourRowTemplate() {
@@ -7596,7 +7908,7 @@ export class TemplateMessage extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2])];
     }
-    static fromObject(data: RecursivePartial<TemplateMessage.AsObject>): TemplateMessage {
+    static fromObject(data: TemplateMessage.AsObjectPartial): TemplateMessage {
         const message = new TemplateMessage({});
         if (data.contextInfo != null) {
             message.contextInfo = ContextInfo.fromObject(data.contextInfo);
@@ -7633,13 +7945,13 @@ export class TemplateMessage extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_contextInfo)
-            writer.writeMessage(3, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(3, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (this.has_hydratedTemplate)
-            writer.writeMessage(4, this.hydratedTemplate, () => this.hydratedTemplate.serialize(writer));
+            writer.writeMessage(4, this.hydratedTemplate, () => this.hydratedTemplate!.serialize(writer));
         if (this.has_fourRowTemplate)
-            writer.writeMessage(1, this.fourRowTemplate, () => this.fourRowTemplate.serialize(writer));
+            writer.writeMessage(1, this.fourRowTemplate, () => this.fourRowTemplate!.serialize(writer));
         if (this.has_hydratedFourRowTemplate)
-            writer.writeMessage(2, this.hydratedFourRowTemplate, () => this.hydratedFourRowTemplate.serialize(writer));
+            writer.writeMessage(2, this.hydratedFourRowTemplate, () => this.hydratedFourRowTemplate!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -7679,6 +7991,12 @@ export namespace TemplateMessage {
         hydratedTemplate?: HydratedFourRowTemplate.AsObject;
         fourRowTemplate?: FourRowTemplate.AsObject;
         hydratedFourRowTemplate?: HydratedFourRowTemplate.AsObject;
+    };
+    export type AsObjectPartial = {
+        contextInfo?: ContextInfo.AsObjectPartial;
+        hydratedTemplate?: HydratedFourRowTemplate.AsObjectPartial;
+        fourRowTemplate?: FourRowTemplate.AsObjectPartial;
+        hydratedFourRowTemplate?: HydratedFourRowTemplate.AsObjectPartial;
     };
 }
 export class TemplateButtonReplyMessage extends pb_1.Message {
@@ -7725,9 +8043,9 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 3) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 3) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_contextInfo() {
@@ -7742,7 +8060,7 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
     get has_selectedIndex() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: RecursivePartial<TemplateButtonReplyMessage.AsObject>): TemplateButtonReplyMessage {
+    static fromObject(data: TemplateButtonReplyMessage.AsObjectPartial): TemplateButtonReplyMessage {
         const message = new TemplateButtonReplyMessage({});
         if (data.selectedId != null) {
             message.selectedId = data.selectedId;
@@ -7773,12 +8091,12 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_selectedId && this.selectedId.length)
+        if (this.has_selectedId && this.selectedId!.length)
             writer.writeString(1, this.selectedId);
-        if (this.has_selectedDisplayText && this.selectedDisplayText.length)
+        if (this.has_selectedDisplayText && this.selectedDisplayText!.length)
             writer.writeString(2, this.selectedDisplayText);
         if (this.has_contextInfo)
-            writer.writeMessage(3, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(3, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (this.has_selectedIndex)
             writer.writeUint32(4, this.selectedIndex);
         if (!w)
@@ -7821,6 +8139,12 @@ export namespace TemplateButtonReplyMessage {
         contextInfo?: ContextInfo.AsObject;
         selectedIndex: number;
     };
+    export type AsObjectPartial = {
+        selectedId?: string;
+        selectedDisplayText?: string;
+        contextInfo?: ContextInfo.AsObjectPartial;
+        selectedIndex?: number;
+    };
 }
 export class CatalogSnapshot extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -7844,9 +8168,9 @@ export class CatalogSnapshot extends pb_1.Message {
         }
     }
     get catalogImage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 1) as ImageMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 1) as ImageMessage | undefined;
     }
-    set catalogImage(value: ImageMessage | undefined | null) {
+    set catalogImage(value: ImageMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_catalogImage() {
@@ -7870,7 +8194,7 @@ export class CatalogSnapshot extends pb_1.Message {
     get has_description() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<CatalogSnapshot.AsObject>): CatalogSnapshot {
+    static fromObject(data: CatalogSnapshot.AsObjectPartial): CatalogSnapshot {
         const message = new CatalogSnapshot({});
         if (data.catalogImage != null) {
             message.catalogImage = ImageMessage.fromObject(data.catalogImage);
@@ -7898,10 +8222,10 @@ export class CatalogSnapshot extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_catalogImage)
-            writer.writeMessage(1, this.catalogImage, () => this.catalogImage.serialize(writer));
-        if (this.has_title && this.title.length)
+            writer.writeMessage(1, this.catalogImage, () => this.catalogImage!.serialize(writer));
+        if (this.has_title && this.title!.length)
             writer.writeString(2, this.title);
-        if (this.has_description && this.description.length)
+        if (this.has_description && this.description!.length)
             writer.writeString(3, this.description);
         if (!w)
             return writer.getResultBuffer();
@@ -7938,6 +8262,11 @@ export namespace CatalogSnapshot {
         catalogImage?: ImageMessage.AsObject;
         title: string;
         description: string;
+    };
+    export type AsObjectPartial = {
+        catalogImage?: ImageMessage.AsObjectPartial;
+        title?: string;
+        description?: string;
     };
 }
 export class ProductSnapshot extends pb_1.Message {
@@ -7990,9 +8319,9 @@ export class ProductSnapshot extends pb_1.Message {
         }
     }
     get productImage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 1) as ImageMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 1) as ImageMessage | undefined;
     }
-    set productImage(value: ImageMessage | undefined | null) {
+    set productImage(value: ImageMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_productImage() {
@@ -8079,7 +8408,7 @@ export class ProductSnapshot extends pb_1.Message {
     get has_firstImageId() {
         return pb_1.Message.getField(this, 11) != null;
     }
-    static fromObject(data: RecursivePartial<ProductSnapshot.AsObject>): ProductSnapshot {
+    static fromObject(data: ProductSnapshot.AsObjectPartial): ProductSnapshot {
         const message = new ProductSnapshot({});
         if (data.productImage != null) {
             message.productImage = ImageMessage.fromObject(data.productImage);
@@ -8135,24 +8464,24 @@ export class ProductSnapshot extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_productImage)
-            writer.writeMessage(1, this.productImage, () => this.productImage.serialize(writer));
-        if (this.has_productId && this.productId.length)
+            writer.writeMessage(1, this.productImage, () => this.productImage!.serialize(writer));
+        if (this.has_productId && this.productId!.length)
             writer.writeString(2, this.productId);
-        if (this.has_title && this.title.length)
+        if (this.has_title && this.title!.length)
             writer.writeString(3, this.title);
-        if (this.has_description && this.description.length)
+        if (this.has_description && this.description!.length)
             writer.writeString(4, this.description);
-        if (this.has_currencyCode && this.currencyCode.length)
+        if (this.has_currencyCode && this.currencyCode!.length)
             writer.writeString(5, this.currencyCode);
         if (this.has_priceAmount1000)
             writer.writeInt64(6, this.priceAmount1000);
-        if (this.has_retailerId && this.retailerId.length)
+        if (this.has_retailerId && this.retailerId!.length)
             writer.writeString(7, this.retailerId);
-        if (this.has_url && this.url.length)
+        if (this.has_url && this.url!.length)
             writer.writeString(8, this.url);
         if (this.has_productImageCount)
             writer.writeUint32(9, this.productImageCount);
-        if (this.has_firstImageId && this.firstImageId.length)
+        if (this.has_firstImageId && this.firstImageId!.length)
             writer.writeString(11, this.firstImageId);
         if (!w)
             return writer.getResultBuffer();
@@ -8218,6 +8547,18 @@ export namespace ProductSnapshot {
         productImageCount: number;
         firstImageId: string;
     };
+    export type AsObjectPartial = {
+        productImage?: ImageMessage.AsObjectPartial;
+        productId?: string;
+        title?: string;
+        description?: string;
+        currencyCode?: string;
+        priceAmount1000?: number;
+        retailerId?: string;
+        url?: string;
+        productImageCount?: number;
+        firstImageId?: string;
+    };
 }
 export class ProductMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -8245,9 +8586,9 @@ export class ProductMessage extends pb_1.Message {
         }
     }
     get product() {
-        return pb_1.Message.getWrapperField(this, ProductSnapshot, 1) as ProductSnapshot | undefined | null;
+        return pb_1.Message.getWrapperField(this, ProductSnapshot, 1) as ProductSnapshot | undefined;
     }
-    set product(value: ProductSnapshot | undefined | null) {
+    set product(value: ProductSnapshot | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_product() {
@@ -8263,24 +8604,24 @@ export class ProductMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     get catalog() {
-        return pb_1.Message.getWrapperField(this, CatalogSnapshot, 4) as CatalogSnapshot | undefined | null;
+        return pb_1.Message.getWrapperField(this, CatalogSnapshot, 4) as CatalogSnapshot | undefined;
     }
-    set catalog(value: CatalogSnapshot | undefined | null) {
+    set catalog(value: CatalogSnapshot | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_catalog() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 17) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 17, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: RecursivePartial<ProductMessage.AsObject>): ProductMessage {
+    static fromObject(data: ProductMessage.AsObjectPartial): ProductMessage {
         const message = new ProductMessage({});
         if (data.product != null) {
             message.product = ProductSnapshot.fromObject(data.product);
@@ -8316,13 +8657,13 @@ export class ProductMessage extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_product)
-            writer.writeMessage(1, this.product, () => this.product.serialize(writer));
-        if (this.has_businessOwnerJid && this.businessOwnerJid.length)
+            writer.writeMessage(1, this.product, () => this.product!.serialize(writer));
+        if (this.has_businessOwnerJid && this.businessOwnerJid!.length)
             writer.writeString(2, this.businessOwnerJid);
         if (this.has_catalog)
-            writer.writeMessage(4, this.catalog, () => this.catalog.serialize(writer));
+            writer.writeMessage(4, this.catalog, () => this.catalog!.serialize(writer));
         if (this.has_contextInfo)
-            writer.writeMessage(17, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(17, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -8362,6 +8703,12 @@ export namespace ProductMessage {
         businessOwnerJid: string;
         catalog?: CatalogSnapshot.AsObject;
         contextInfo?: ContextInfo.AsObject;
+    };
+    export type AsObjectPartial = {
+        product?: ProductSnapshot.AsObjectPartial;
+        businessOwnerJid?: string;
+        catalog?: CatalogSnapshot.AsObjectPartial;
+        contextInfo?: ContextInfo.AsObjectPartial;
     };
 }
 export class GroupInviteMessage extends pb_1.Message {
@@ -8456,15 +8803,15 @@ export class GroupInviteMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 6) != null;
     }
     get contextInfo() {
-        return pb_1.Message.getWrapperField(this, ContextInfo, 7) as ContextInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContextInfo, 7) as ContextInfo | undefined;
     }
-    set contextInfo(value: ContextInfo | undefined | null) {
+    set contextInfo(value: ContextInfo | undefined) {
         pb_1.Message.setWrapperField(this, 7, value);
     }
     get has_contextInfo() {
         return pb_1.Message.getField(this, 7) != null;
     }
-    static fromObject(data: RecursivePartial<GroupInviteMessage.AsObject>): GroupInviteMessage {
+    static fromObject(data: GroupInviteMessage.AsObjectPartial): GroupInviteMessage {
         const message = new GroupInviteMessage({});
         if (data.groupJid != null) {
             message.groupJid = data.groupJid;
@@ -8507,20 +8854,20 @@ export class GroupInviteMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_groupJid && this.groupJid.length)
+        if (this.has_groupJid && this.groupJid!.length)
             writer.writeString(1, this.groupJid);
-        if (this.has_inviteCode && this.inviteCode.length)
+        if (this.has_inviteCode && this.inviteCode!.length)
             writer.writeString(2, this.inviteCode);
         if (this.has_inviteExpiration)
             writer.writeInt64(3, this.inviteExpiration);
-        if (this.has_groupName && this.groupName.length)
+        if (this.has_groupName && this.groupName!.length)
             writer.writeString(4, this.groupName);
-        if (this.has_jpegThumbnail && this.jpegThumbnail.length)
+        if (this.has_jpegThumbnail && this.jpegThumbnail!.length)
             writer.writeBytes(5, this.jpegThumbnail);
-        if (this.has_caption && this.caption.length)
+        if (this.has_caption && this.caption!.length)
             writer.writeString(6, this.caption);
         if (this.has_contextInfo)
-            writer.writeMessage(7, this.contextInfo, () => this.contextInfo.serialize(writer));
+            writer.writeMessage(7, this.contextInfo, () => this.contextInfo!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -8573,6 +8920,15 @@ export namespace GroupInviteMessage {
         caption: string;
         contextInfo?: ContextInfo.AsObject;
     };
+    export type AsObjectPartial = {
+        groupJid?: string;
+        inviteCode?: string;
+        inviteExpiration?: number;
+        groupName?: string;
+        jpegThumbnail?: Uint8Array;
+        caption?: string;
+        contextInfo?: ContextInfo.AsObjectPartial;
+    };
 }
 export class DeviceSentMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -8605,9 +8961,9 @@ export class DeviceSentMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined | null;
+        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined;
     }
-    set message(value: Message | undefined | null) {
+    set message(value: Message | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_message() {
@@ -8622,7 +8978,7 @@ export class DeviceSentMessage extends pb_1.Message {
     get has_phash() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<DeviceSentMessage.AsObject>): DeviceSentMessage {
+    static fromObject(data: DeviceSentMessage.AsObjectPartial): DeviceSentMessage {
         const message = new DeviceSentMessage({});
         if (data.destinationJid != null) {
             message.destinationJid = data.destinationJid;
@@ -8649,11 +9005,11 @@ export class DeviceSentMessage extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_destinationJid && this.destinationJid.length)
+        if (this.has_destinationJid && this.destinationJid!.length)
             writer.writeString(1, this.destinationJid);
         if (this.has_message)
-            writer.writeMessage(2, this.message, () => this.message.serialize(writer));
-        if (this.has_phash && this.phash.length)
+            writer.writeMessage(2, this.message, () => this.message!.serialize(writer));
+        if (this.has_phash && this.phash!.length)
             writer.writeString(3, this.phash);
         if (!w)
             return writer.getResultBuffer();
@@ -8690,6 +9046,11 @@ export namespace DeviceSentMessage {
         destinationJid: string;
         message?: Message.AsObject;
         phash: string;
+    };
+    export type AsObjectPartial = {
+        destinationJid?: string;
+        message?: Message.AsObjectPartial;
+        phash?: string;
     };
 }
 export class Message extends pb_1.Message {
@@ -8815,231 +9176,231 @@ export class Message extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get senderKeyDistributionMessage() {
-        return pb_1.Message.getWrapperField(this, SenderKeyDistributionMessage, 2) as SenderKeyDistributionMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, SenderKeyDistributionMessage, 2) as SenderKeyDistributionMessage | undefined;
     }
-    set senderKeyDistributionMessage(value: SenderKeyDistributionMessage | undefined | null) {
+    set senderKeyDistributionMessage(value: SenderKeyDistributionMessage | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_senderKeyDistributionMessage() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get imageMessage() {
-        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ImageMessage, 3) as ImageMessage | undefined;
     }
-    set imageMessage(value: ImageMessage | undefined | null) {
+    set imageMessage(value: ImageMessage | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_imageMessage() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get contactMessage() {
-        return pb_1.Message.getWrapperField(this, ContactMessage, 4) as ContactMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContactMessage, 4) as ContactMessage | undefined;
     }
-    set contactMessage(value: ContactMessage | undefined | null) {
+    set contactMessage(value: ContactMessage | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_contactMessage() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get locationMessage() {
-        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, LocationMessage, 5) as LocationMessage | undefined;
     }
-    set locationMessage(value: LocationMessage | undefined | null) {
+    set locationMessage(value: LocationMessage | undefined) {
         pb_1.Message.setWrapperField(this, 5, value);
     }
     get has_locationMessage() {
         return pb_1.Message.getField(this, 5) != null;
     }
     get extendedTextMessage() {
-        return pb_1.Message.getWrapperField(this, ExtendedTextMessage, 6) as ExtendedTextMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ExtendedTextMessage, 6) as ExtendedTextMessage | undefined;
     }
-    set extendedTextMessage(value: ExtendedTextMessage | undefined | null) {
+    set extendedTextMessage(value: ExtendedTextMessage | undefined) {
         pb_1.Message.setWrapperField(this, 6, value);
     }
     get has_extendedTextMessage() {
         return pb_1.Message.getField(this, 6) != null;
     }
     get documentMessage() {
-        return pb_1.Message.getWrapperField(this, DocumentMessage, 7) as DocumentMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, DocumentMessage, 7) as DocumentMessage | undefined;
     }
-    set documentMessage(value: DocumentMessage | undefined | null) {
+    set documentMessage(value: DocumentMessage | undefined) {
         pb_1.Message.setWrapperField(this, 7, value);
     }
     get has_documentMessage() {
         return pb_1.Message.getField(this, 7) != null;
     }
     get audioMessage() {
-        return pb_1.Message.getWrapperField(this, AudioMessage, 8) as AudioMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, AudioMessage, 8) as AudioMessage | undefined;
     }
-    set audioMessage(value: AudioMessage | undefined | null) {
+    set audioMessage(value: AudioMessage | undefined) {
         pb_1.Message.setWrapperField(this, 8, value);
     }
     get has_audioMessage() {
         return pb_1.Message.getField(this, 8) != null;
     }
     get videoMessage() {
-        return pb_1.Message.getWrapperField(this, VideoMessage, 9) as VideoMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, VideoMessage, 9) as VideoMessage | undefined;
     }
-    set videoMessage(value: VideoMessage | undefined | null) {
+    set videoMessage(value: VideoMessage | undefined) {
         pb_1.Message.setWrapperField(this, 9, value);
     }
     get has_videoMessage() {
         return pb_1.Message.getField(this, 9) != null;
     }
     get call() {
-        return pb_1.Message.getWrapperField(this, Call, 10) as Call | undefined | null;
+        return pb_1.Message.getWrapperField(this, Call, 10) as Call | undefined;
     }
-    set call(value: Call | undefined | null) {
+    set call(value: Call | undefined) {
         pb_1.Message.setWrapperField(this, 10, value);
     }
     get has_call() {
         return pb_1.Message.getField(this, 10) != null;
     }
     get chat() {
-        return pb_1.Message.getWrapperField(this, Chat, 11) as Chat | undefined | null;
+        return pb_1.Message.getWrapperField(this, Chat, 11) as Chat | undefined;
     }
-    set chat(value: Chat | undefined | null) {
+    set chat(value: Chat | undefined) {
         pb_1.Message.setWrapperField(this, 11, value);
     }
     get has_chat() {
         return pb_1.Message.getField(this, 11) != null;
     }
     get protocolMessage() {
-        return pb_1.Message.getWrapperField(this, ProtocolMessage, 12) as ProtocolMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ProtocolMessage, 12) as ProtocolMessage | undefined;
     }
-    set protocolMessage(value: ProtocolMessage | undefined | null) {
+    set protocolMessage(value: ProtocolMessage | undefined) {
         pb_1.Message.setWrapperField(this, 12, value);
     }
     get has_protocolMessage() {
         return pb_1.Message.getField(this, 12) != null;
     }
     get contactsArrayMessage() {
-        return pb_1.Message.getWrapperField(this, ContactsArrayMessage, 13) as ContactsArrayMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ContactsArrayMessage, 13) as ContactsArrayMessage | undefined;
     }
-    set contactsArrayMessage(value: ContactsArrayMessage | undefined | null) {
+    set contactsArrayMessage(value: ContactsArrayMessage | undefined) {
         pb_1.Message.setWrapperField(this, 13, value);
     }
     get has_contactsArrayMessage() {
         return pb_1.Message.getField(this, 13) != null;
     }
     get highlyStructuredMessage() {
-        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 14) as HighlyStructuredMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, HighlyStructuredMessage, 14) as HighlyStructuredMessage | undefined;
     }
-    set highlyStructuredMessage(value: HighlyStructuredMessage | undefined | null) {
+    set highlyStructuredMessage(value: HighlyStructuredMessage | undefined) {
         pb_1.Message.setWrapperField(this, 14, value);
     }
     get has_highlyStructuredMessage() {
         return pb_1.Message.getField(this, 14) != null;
     }
     get fastRatchetKeySenderKeyDistributionMessage() {
-        return pb_1.Message.getWrapperField(this, SenderKeyDistributionMessage, 15) as SenderKeyDistributionMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, SenderKeyDistributionMessage, 15) as SenderKeyDistributionMessage | undefined;
     }
-    set fastRatchetKeySenderKeyDistributionMessage(value: SenderKeyDistributionMessage | undefined | null) {
+    set fastRatchetKeySenderKeyDistributionMessage(value: SenderKeyDistributionMessage | undefined) {
         pb_1.Message.setWrapperField(this, 15, value);
     }
     get has_fastRatchetKeySenderKeyDistributionMessage() {
         return pb_1.Message.getField(this, 15) != null;
     }
     get sendPaymentMessage() {
-        return pb_1.Message.getWrapperField(this, SendPaymentMessage, 16) as SendPaymentMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, SendPaymentMessage, 16) as SendPaymentMessage | undefined;
     }
-    set sendPaymentMessage(value: SendPaymentMessage | undefined | null) {
+    set sendPaymentMessage(value: SendPaymentMessage | undefined) {
         pb_1.Message.setWrapperField(this, 16, value);
     }
     get has_sendPaymentMessage() {
         return pb_1.Message.getField(this, 16) != null;
     }
     get liveLocationMessage() {
-        return pb_1.Message.getWrapperField(this, LiveLocationMessage, 18) as LiveLocationMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, LiveLocationMessage, 18) as LiveLocationMessage | undefined;
     }
-    set liveLocationMessage(value: LiveLocationMessage | undefined | null) {
+    set liveLocationMessage(value: LiveLocationMessage | undefined) {
         pb_1.Message.setWrapperField(this, 18, value);
     }
     get has_liveLocationMessage() {
         return pb_1.Message.getField(this, 18) != null;
     }
     get requestPaymentMessage() {
-        return pb_1.Message.getWrapperField(this, RequestPaymentMessage, 22) as RequestPaymentMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, RequestPaymentMessage, 22) as RequestPaymentMessage | undefined;
     }
-    set requestPaymentMessage(value: RequestPaymentMessage | undefined | null) {
+    set requestPaymentMessage(value: RequestPaymentMessage | undefined) {
         pb_1.Message.setWrapperField(this, 22, value);
     }
     get has_requestPaymentMessage() {
         return pb_1.Message.getField(this, 22) != null;
     }
     get declinePaymentRequestMessage() {
-        return pb_1.Message.getWrapperField(this, DeclinePaymentRequestMessage, 23) as DeclinePaymentRequestMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, DeclinePaymentRequestMessage, 23) as DeclinePaymentRequestMessage | undefined;
     }
-    set declinePaymentRequestMessage(value: DeclinePaymentRequestMessage | undefined | null) {
+    set declinePaymentRequestMessage(value: DeclinePaymentRequestMessage | undefined) {
         pb_1.Message.setWrapperField(this, 23, value);
     }
     get has_declinePaymentRequestMessage() {
         return pb_1.Message.getField(this, 23) != null;
     }
     get cancelPaymentRequestMessage() {
-        return pb_1.Message.getWrapperField(this, CancelPaymentRequestMessage, 24) as CancelPaymentRequestMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, CancelPaymentRequestMessage, 24) as CancelPaymentRequestMessage | undefined;
     }
-    set cancelPaymentRequestMessage(value: CancelPaymentRequestMessage | undefined | null) {
+    set cancelPaymentRequestMessage(value: CancelPaymentRequestMessage | undefined) {
         pb_1.Message.setWrapperField(this, 24, value);
     }
     get has_cancelPaymentRequestMessage() {
         return pb_1.Message.getField(this, 24) != null;
     }
     get templateMessage() {
-        return pb_1.Message.getWrapperField(this, TemplateMessage, 25) as TemplateMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, TemplateMessage, 25) as TemplateMessage | undefined;
     }
-    set templateMessage(value: TemplateMessage | undefined | null) {
+    set templateMessage(value: TemplateMessage | undefined) {
         pb_1.Message.setWrapperField(this, 25, value);
     }
     get has_templateMessage() {
         return pb_1.Message.getField(this, 25) != null;
     }
     get stickerMessage() {
-        return pb_1.Message.getWrapperField(this, StickerMessage, 26) as StickerMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, StickerMessage, 26) as StickerMessage | undefined;
     }
-    set stickerMessage(value: StickerMessage | undefined | null) {
+    set stickerMessage(value: StickerMessage | undefined) {
         pb_1.Message.setWrapperField(this, 26, value);
     }
     get has_stickerMessage() {
         return pb_1.Message.getField(this, 26) != null;
     }
     get groupInviteMessage() {
-        return pb_1.Message.getWrapperField(this, GroupInviteMessage, 28) as GroupInviteMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, GroupInviteMessage, 28) as GroupInviteMessage | undefined;
     }
-    set groupInviteMessage(value: GroupInviteMessage | undefined | null) {
+    set groupInviteMessage(value: GroupInviteMessage | undefined) {
         pb_1.Message.setWrapperField(this, 28, value);
     }
     get has_groupInviteMessage() {
         return pb_1.Message.getField(this, 28) != null;
     }
     get templateButtonReplyMessage() {
-        return pb_1.Message.getWrapperField(this, TemplateButtonReplyMessage, 29) as TemplateButtonReplyMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, TemplateButtonReplyMessage, 29) as TemplateButtonReplyMessage | undefined;
     }
-    set templateButtonReplyMessage(value: TemplateButtonReplyMessage | undefined | null) {
+    set templateButtonReplyMessage(value: TemplateButtonReplyMessage | undefined) {
         pb_1.Message.setWrapperField(this, 29, value);
     }
     get has_templateButtonReplyMessage() {
         return pb_1.Message.getField(this, 29) != null;
     }
     get productMessage() {
-        return pb_1.Message.getWrapperField(this, ProductMessage, 30) as ProductMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, ProductMessage, 30) as ProductMessage | undefined;
     }
-    set productMessage(value: ProductMessage | undefined | null) {
+    set productMessage(value: ProductMessage | undefined) {
         pb_1.Message.setWrapperField(this, 30, value);
     }
     get has_productMessage() {
         return pb_1.Message.getField(this, 30) != null;
     }
     get deviceSentMessage() {
-        return pb_1.Message.getWrapperField(this, DeviceSentMessage, 31) as DeviceSentMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, DeviceSentMessage, 31) as DeviceSentMessage | undefined;
     }
-    set deviceSentMessage(value: DeviceSentMessage | undefined | null) {
+    set deviceSentMessage(value: DeviceSentMessage | undefined) {
         pb_1.Message.setWrapperField(this, 31, value);
     }
     get has_deviceSentMessage() {
         return pb_1.Message.getField(this, 31) != null;
     }
-    static fromObject(data: RecursivePartial<Message.AsObject>): Message {
+    static fromObject(data: Message.AsObjectPartial): Message {
         const message = new Message({});
         if (data.conversation != null) {
             message.conversation = data.conversation;
@@ -9206,58 +9567,58 @@ export class Message extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_conversation && this.conversation.length)
+        if (this.has_conversation && this.conversation!.length)
             writer.writeString(1, this.conversation);
         if (this.has_senderKeyDistributionMessage)
-            writer.writeMessage(2, this.senderKeyDistributionMessage, () => this.senderKeyDistributionMessage.serialize(writer));
+            writer.writeMessage(2, this.senderKeyDistributionMessage, () => this.senderKeyDistributionMessage!.serialize(writer));
         if (this.has_imageMessage)
-            writer.writeMessage(3, this.imageMessage, () => this.imageMessage.serialize(writer));
+            writer.writeMessage(3, this.imageMessage, () => this.imageMessage!.serialize(writer));
         if (this.has_contactMessage)
-            writer.writeMessage(4, this.contactMessage, () => this.contactMessage.serialize(writer));
+            writer.writeMessage(4, this.contactMessage, () => this.contactMessage!.serialize(writer));
         if (this.has_locationMessage)
-            writer.writeMessage(5, this.locationMessage, () => this.locationMessage.serialize(writer));
+            writer.writeMessage(5, this.locationMessage, () => this.locationMessage!.serialize(writer));
         if (this.has_extendedTextMessage)
-            writer.writeMessage(6, this.extendedTextMessage, () => this.extendedTextMessage.serialize(writer));
+            writer.writeMessage(6, this.extendedTextMessage, () => this.extendedTextMessage!.serialize(writer));
         if (this.has_documentMessage)
-            writer.writeMessage(7, this.documentMessage, () => this.documentMessage.serialize(writer));
+            writer.writeMessage(7, this.documentMessage, () => this.documentMessage!.serialize(writer));
         if (this.has_audioMessage)
-            writer.writeMessage(8, this.audioMessage, () => this.audioMessage.serialize(writer));
+            writer.writeMessage(8, this.audioMessage, () => this.audioMessage!.serialize(writer));
         if (this.has_videoMessage)
-            writer.writeMessage(9, this.videoMessage, () => this.videoMessage.serialize(writer));
+            writer.writeMessage(9, this.videoMessage, () => this.videoMessage!.serialize(writer));
         if (this.has_call)
-            writer.writeMessage(10, this.call, () => this.call.serialize(writer));
+            writer.writeMessage(10, this.call, () => this.call!.serialize(writer));
         if (this.has_chat)
-            writer.writeMessage(11, this.chat, () => this.chat.serialize(writer));
+            writer.writeMessage(11, this.chat, () => this.chat!.serialize(writer));
         if (this.has_protocolMessage)
-            writer.writeMessage(12, this.protocolMessage, () => this.protocolMessage.serialize(writer));
+            writer.writeMessage(12, this.protocolMessage, () => this.protocolMessage!.serialize(writer));
         if (this.has_contactsArrayMessage)
-            writer.writeMessage(13, this.contactsArrayMessage, () => this.contactsArrayMessage.serialize(writer));
+            writer.writeMessage(13, this.contactsArrayMessage, () => this.contactsArrayMessage!.serialize(writer));
         if (this.has_highlyStructuredMessage)
-            writer.writeMessage(14, this.highlyStructuredMessage, () => this.highlyStructuredMessage.serialize(writer));
+            writer.writeMessage(14, this.highlyStructuredMessage, () => this.highlyStructuredMessage!.serialize(writer));
         if (this.has_fastRatchetKeySenderKeyDistributionMessage)
-            writer.writeMessage(15, this.fastRatchetKeySenderKeyDistributionMessage, () => this.fastRatchetKeySenderKeyDistributionMessage.serialize(writer));
+            writer.writeMessage(15, this.fastRatchetKeySenderKeyDistributionMessage, () => this.fastRatchetKeySenderKeyDistributionMessage!.serialize(writer));
         if (this.has_sendPaymentMessage)
-            writer.writeMessage(16, this.sendPaymentMessage, () => this.sendPaymentMessage.serialize(writer));
+            writer.writeMessage(16, this.sendPaymentMessage, () => this.sendPaymentMessage!.serialize(writer));
         if (this.has_liveLocationMessage)
-            writer.writeMessage(18, this.liveLocationMessage, () => this.liveLocationMessage.serialize(writer));
+            writer.writeMessage(18, this.liveLocationMessage, () => this.liveLocationMessage!.serialize(writer));
         if (this.has_requestPaymentMessage)
-            writer.writeMessage(22, this.requestPaymentMessage, () => this.requestPaymentMessage.serialize(writer));
+            writer.writeMessage(22, this.requestPaymentMessage, () => this.requestPaymentMessage!.serialize(writer));
         if (this.has_declinePaymentRequestMessage)
-            writer.writeMessage(23, this.declinePaymentRequestMessage, () => this.declinePaymentRequestMessage.serialize(writer));
+            writer.writeMessage(23, this.declinePaymentRequestMessage, () => this.declinePaymentRequestMessage!.serialize(writer));
         if (this.has_cancelPaymentRequestMessage)
-            writer.writeMessage(24, this.cancelPaymentRequestMessage, () => this.cancelPaymentRequestMessage.serialize(writer));
+            writer.writeMessage(24, this.cancelPaymentRequestMessage, () => this.cancelPaymentRequestMessage!.serialize(writer));
         if (this.has_templateMessage)
-            writer.writeMessage(25, this.templateMessage, () => this.templateMessage.serialize(writer));
+            writer.writeMessage(25, this.templateMessage, () => this.templateMessage!.serialize(writer));
         if (this.has_stickerMessage)
-            writer.writeMessage(26, this.stickerMessage, () => this.stickerMessage.serialize(writer));
+            writer.writeMessage(26, this.stickerMessage, () => this.stickerMessage!.serialize(writer));
         if (this.has_groupInviteMessage)
-            writer.writeMessage(28, this.groupInviteMessage, () => this.groupInviteMessage.serialize(writer));
+            writer.writeMessage(28, this.groupInviteMessage, () => this.groupInviteMessage!.serialize(writer));
         if (this.has_templateButtonReplyMessage)
-            writer.writeMessage(29, this.templateButtonReplyMessage, () => this.templateButtonReplyMessage.serialize(writer));
+            writer.writeMessage(29, this.templateButtonReplyMessage, () => this.templateButtonReplyMessage!.serialize(writer));
         if (this.has_productMessage)
-            writer.writeMessage(30, this.productMessage, () => this.productMessage.serialize(writer));
+            writer.writeMessage(30, this.productMessage, () => this.productMessage!.serialize(writer));
         if (this.has_deviceSentMessage)
-            writer.writeMessage(31, this.deviceSentMessage, () => this.deviceSentMessage.serialize(writer));
+            writer.writeMessage(31, this.deviceSentMessage, () => this.deviceSentMessage!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -9386,6 +9747,34 @@ export namespace Message {
         productMessage?: ProductMessage.AsObject;
         deviceSentMessage?: DeviceSentMessage.AsObject;
     };
+    export type AsObjectPartial = {
+        conversation?: string;
+        senderKeyDistributionMessage?: SenderKeyDistributionMessage.AsObjectPartial;
+        imageMessage?: ImageMessage.AsObjectPartial;
+        contactMessage?: ContactMessage.AsObjectPartial;
+        locationMessage?: LocationMessage.AsObjectPartial;
+        extendedTextMessage?: ExtendedTextMessage.AsObjectPartial;
+        documentMessage?: DocumentMessage.AsObjectPartial;
+        audioMessage?: AudioMessage.AsObjectPartial;
+        videoMessage?: VideoMessage.AsObjectPartial;
+        call?: Call.AsObjectPartial;
+        chat?: Chat.AsObjectPartial;
+        protocolMessage?: ProtocolMessage.AsObjectPartial;
+        contactsArrayMessage?: ContactsArrayMessage.AsObjectPartial;
+        highlyStructuredMessage?: HighlyStructuredMessage.AsObjectPartial;
+        fastRatchetKeySenderKeyDistributionMessage?: SenderKeyDistributionMessage.AsObjectPartial;
+        sendPaymentMessage?: SendPaymentMessage.AsObjectPartial;
+        liveLocationMessage?: LiveLocationMessage.AsObjectPartial;
+        requestPaymentMessage?: RequestPaymentMessage.AsObjectPartial;
+        declinePaymentRequestMessage?: DeclinePaymentRequestMessage.AsObjectPartial;
+        cancelPaymentRequestMessage?: CancelPaymentRequestMessage.AsObjectPartial;
+        templateMessage?: TemplateMessage.AsObjectPartial;
+        stickerMessage?: StickerMessage.AsObjectPartial;
+        groupInviteMessage?: GroupInviteMessage.AsObjectPartial;
+        templateButtonReplyMessage?: TemplateButtonReplyMessage.AsObjectPartial;
+        productMessage?: ProductMessage.AsObjectPartial;
+        deviceSentMessage?: DeviceSentMessage.AsObjectPartial;
+    };
 }
 export class MessageKey extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -9448,7 +9837,7 @@ export class MessageKey extends pb_1.Message {
     get has_participant() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: RecursivePartial<MessageKey.AsObject>): MessageKey {
+    static fromObject(data: MessageKey.AsObjectPartial): MessageKey {
         const message = new MessageKey({});
         if (data.remoteJid != null) {
             message.remoteJid = data.remoteJid;
@@ -9477,13 +9866,13 @@ export class MessageKey extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_remoteJid && this.remoteJid.length)
+        if (this.has_remoteJid && this.remoteJid!.length)
             writer.writeString(1, this.remoteJid);
         if (this.has_fromMe)
             writer.writeBool(2, this.fromMe);
-        if (this.has_id && this.id.length)
+        if (this.has_id && this.id!.length)
             writer.writeString(3, this.id);
-        if (this.has_participant && this.participant.length)
+        if (this.has_participant && this.participant!.length)
             writer.writeString(4, this.participant);
         if (!w)
             return writer.getResultBuffer();
@@ -9524,6 +9913,12 @@ export namespace MessageKey {
         fromMe: boolean;
         id: string;
         participant: string;
+    };
+    export type AsObjectPartial = {
+        remoteJid?: string;
+        fromMe?: boolean;
+        id?: string;
+        participant?: string;
     };
 }
 export class WebFeatures extends pb_1.Message {
@@ -9964,7 +10359,7 @@ export class WebFeatures extends pb_1.Message {
     get has_syncdRelease1() {
         return pb_1.Message.getField(this, 35) != null;
     }
-    static fromObject(data: RecursivePartial<WebFeatures.AsObject>): WebFeatures {
+    static fromObject(data: WebFeatures.AsObjectPartial): WebFeatures {
         const message = new WebFeatures({});
         if (data.labelsDisplay != null) {
             message.labelsDisplay = data.labelsDisplay;
@@ -10331,6 +10726,41 @@ export namespace WebFeatures {
         recentStickersV2: WebFeatures.WEB_FEATURES_FLAG;
         syncdRelease1: WebFeatures.WEB_FEATURES_FLAG;
     };
+    export type AsObjectPartial = {
+        labelsDisplay?: WebFeatures.WEB_FEATURES_FLAG;
+        voipIndividualOutgoing?: WebFeatures.WEB_FEATURES_FLAG;
+        groupsV3?: WebFeatures.WEB_FEATURES_FLAG;
+        groupsV3Create?: WebFeatures.WEB_FEATURES_FLAG;
+        changeNumberV2?: WebFeatures.WEB_FEATURES_FLAG;
+        queryStatusV3Thumbnail?: WebFeatures.WEB_FEATURES_FLAG;
+        liveLocations?: WebFeatures.WEB_FEATURES_FLAG;
+        queryVname?: WebFeatures.WEB_FEATURES_FLAG;
+        voipIndividualIncoming?: WebFeatures.WEB_FEATURES_FLAG;
+        quickRepliesQuery?: WebFeatures.WEB_FEATURES_FLAG;
+        payments?: WebFeatures.WEB_FEATURES_FLAG;
+        stickerPackQuery?: WebFeatures.WEB_FEATURES_FLAG;
+        liveLocationsFinal?: WebFeatures.WEB_FEATURES_FLAG;
+        labelsEdit?: WebFeatures.WEB_FEATURES_FLAG;
+        mediaUpload?: WebFeatures.WEB_FEATURES_FLAG;
+        mediaUploadRichQuickReplies?: WebFeatures.WEB_FEATURES_FLAG;
+        vnameV2?: WebFeatures.WEB_FEATURES_FLAG;
+        videoPlaybackUrl?: WebFeatures.WEB_FEATURES_FLAG;
+        statusRanking?: WebFeatures.WEB_FEATURES_FLAG;
+        voipIndividualVideo?: WebFeatures.WEB_FEATURES_FLAG;
+        thirdPartyStickers?: WebFeatures.WEB_FEATURES_FLAG;
+        frequentlyForwardedSetting?: WebFeatures.WEB_FEATURES_FLAG;
+        groupsV4JoinPermission?: WebFeatures.WEB_FEATURES_FLAG;
+        recentStickers?: WebFeatures.WEB_FEATURES_FLAG;
+        catalog?: WebFeatures.WEB_FEATURES_FLAG;
+        starredStickers?: WebFeatures.WEB_FEATURES_FLAG;
+        voipGroupCall?: WebFeatures.WEB_FEATURES_FLAG;
+        templateMessage?: WebFeatures.WEB_FEATURES_FLAG;
+        templateMessageInteractivity?: WebFeatures.WEB_FEATURES_FLAG;
+        ephemeralMessages?: WebFeatures.WEB_FEATURES_FLAG;
+        e2ENotificationSync?: WebFeatures.WEB_FEATURES_FLAG;
+        recentStickersV2?: WebFeatures.WEB_FEATURES_FLAG;
+        syncdRelease1?: WebFeatures.WEB_FEATURES_FLAG;
+    };
     export enum WEB_FEATURES_FLAG {
         NOT_STARTED = 0,
         FORCE_UPGRADE = 1,
@@ -10394,7 +10824,7 @@ export class TabletNotificationsInfo extends pb_1.Message {
     set notifyMessage(value: NotificationMessageInfo[]) {
         pb_1.Message.setRepeatedWrapperField(this, 5, value);
     }
-    static fromObject(data: RecursivePartial<TabletNotificationsInfo.AsObject>): TabletNotificationsInfo {
+    static fromObject(data: TabletNotificationsInfo.AsObjectPartial): TabletNotificationsInfo {
         const message = new TabletNotificationsInfo({
             notifyMessage: data.notifyMessage.map(item => NotificationMessageInfo.fromObject(item))
         });
@@ -10429,7 +10859,7 @@ export class TabletNotificationsInfo extends pb_1.Message {
         if (this.has_notifyMessageCount)
             writer.writeUint32(4, this.notifyMessageCount);
         if (this.notifyMessage.length)
-            writer.writeRepeatedMessage(5, this.notifyMessage, (item: NotificationMessageInfo) => item.serialize(writer));
+            writer.writeRepeatedMessage(5, this.notifyMessage, (item: NotificationMessageInfo) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -10470,6 +10900,12 @@ export namespace TabletNotificationsInfo {
         notifyMessageCount: number;
         notifyMessage: NotificationMessageInfo.AsObject[];
     };
+    export type AsObjectPartial = {
+        timestamp?: number;
+        unreadChats?: number;
+        notifyMessageCount?: number;
+        notifyMessage: NotificationMessageInfo.AsObjectPartial[];
+    };
 }
 export class NotificationMessageInfo extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -10497,18 +10933,18 @@ export class NotificationMessageInfo extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined;
     }
-    set key(value: MessageKey | undefined | null) {
+    set key(value: MessageKey | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined | null;
+        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined;
     }
-    set message(value: Message | undefined | null) {
+    set message(value: Message | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_message() {
@@ -10532,7 +10968,7 @@ export class NotificationMessageInfo extends pb_1.Message {
     get has_participant() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: RecursivePartial<NotificationMessageInfo.AsObject>): NotificationMessageInfo {
+    static fromObject(data: NotificationMessageInfo.AsObjectPartial): NotificationMessageInfo {
         const message = new NotificationMessageInfo({});
         if (data.key != null) {
             message.key = MessageKey.fromObject(data.key);
@@ -10566,12 +11002,12 @@ export class NotificationMessageInfo extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_key)
-            writer.writeMessage(1, this.key, () => this.key.serialize(writer));
+            writer.writeMessage(1, this.key, () => this.key!.serialize(writer));
         if (this.has_message)
-            writer.writeMessage(2, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(2, this.message, () => this.message!.serialize(writer));
         if (this.has_messageTimestamp)
             writer.writeUint64(3, this.messageTimestamp);
-        if (this.has_participant && this.participant.length)
+        if (this.has_participant && this.participant!.length)
             writer.writeString(4, this.participant);
         if (!w)
             return writer.getResultBuffer();
@@ -10612,6 +11048,12 @@ export namespace NotificationMessageInfo {
         message?: Message.AsObject;
         messageTimestamp: number;
         participant: string;
+    };
+    export type AsObjectPartial = {
+        key?: MessageKey.AsObjectPartial;
+        message?: Message.AsObjectPartial;
+        messageTimestamp?: number;
+        participant?: string;
     };
 }
 export class WebNotificationsInfo extends pb_1.Message {
@@ -10670,7 +11112,7 @@ export class WebNotificationsInfo extends pb_1.Message {
     set notifyMessages(value: WebMessageInfo[]) {
         pb_1.Message.setRepeatedWrapperField(this, 5, value);
     }
-    static fromObject(data: RecursivePartial<WebNotificationsInfo.AsObject>): WebNotificationsInfo {
+    static fromObject(data: WebNotificationsInfo.AsObjectPartial): WebNotificationsInfo {
         const message = new WebNotificationsInfo({
             notifyMessages: data.notifyMessages.map(item => WebMessageInfo.fromObject(item))
         });
@@ -10705,7 +11147,7 @@ export class WebNotificationsInfo extends pb_1.Message {
         if (this.has_notifyMessageCount)
             writer.writeUint32(4, this.notifyMessageCount);
         if (this.notifyMessages.length)
-            writer.writeRepeatedMessage(5, this.notifyMessages, (item: WebMessageInfo) => item.serialize(writer));
+            writer.writeRepeatedMessage(5, this.notifyMessages, (item: WebMessageInfo) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -10745,6 +11187,12 @@ export namespace WebNotificationsInfo {
         unreadChats: number;
         notifyMessageCount: number;
         notifyMessages: WebMessageInfo.AsObject[];
+    };
+    export type AsObjectPartial = {
+        timestamp?: number;
+        unreadChats?: number;
+        notifyMessageCount?: number;
+        notifyMessages: WebMessageInfo.AsObjectPartial[];
     };
 }
 export class PaymentInfo extends pb_1.Message {
@@ -10842,9 +11290,9 @@ export class PaymentInfo extends pb_1.Message {
         return pb_1.Message.getField(this, 5) != null;
     }
     get requestMessageKey() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 6) as MessageKey | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageKey, 6) as MessageKey | undefined;
     }
-    set requestMessageKey(value: MessageKey | undefined | null) {
+    set requestMessageKey(value: MessageKey | undefined) {
         pb_1.Message.setWrapperField(this, 6, value);
     }
     get has_requestMessageKey() {
@@ -10886,7 +11334,7 @@ export class PaymentInfo extends pb_1.Message {
     get has_txnStatus() {
         return pb_1.Message.getField(this, 10) != null;
     }
-    static fromObject(data: RecursivePartial<PaymentInfo.AsObject>): PaymentInfo {
+    static fromObject(data: PaymentInfo.AsObjectPartial): PaymentInfo {
         const message = new PaymentInfo({});
         if (data.currencyDeprecated != null) {
             message.currencyDeprecated = data.currencyDeprecated;
@@ -10945,19 +11393,19 @@ export class PaymentInfo extends pb_1.Message {
             writer.writeEnum(1, this.currencyDeprecated);
         if (this.has_amount1000)
             writer.writeUint64(2, this.amount1000);
-        if (this.has_receiverJid && this.receiverJid.length)
+        if (this.has_receiverJid && this.receiverJid!.length)
             writer.writeString(3, this.receiverJid);
         if (this.has_status)
             writer.writeEnum(4, this.status);
         if (this.has_transactionTimestamp)
             writer.writeUint64(5, this.transactionTimestamp);
         if (this.has_requestMessageKey)
-            writer.writeMessage(6, this.requestMessageKey, () => this.requestMessageKey.serialize(writer));
+            writer.writeMessage(6, this.requestMessageKey, () => this.requestMessageKey!.serialize(writer));
         if (this.has_expiryTimestamp)
             writer.writeUint64(7, this.expiryTimestamp);
         if (this.has_futureproofed)
             writer.writeBool(8, this.futureproofed);
-        if (this.has_currency && this.currency.length)
+        if (this.has_currency && this.currency!.length)
             writer.writeString(9, this.currency);
         if (this.has_txnStatus)
             writer.writeEnum(10, this.txnStatus);
@@ -11024,6 +11472,18 @@ export namespace PaymentInfo {
         futureproofed: boolean;
         currency: string;
         txnStatus: PaymentInfo.PAYMENT_INFO_TXNSTATUS;
+    };
+    export type AsObjectPartial = {
+        currencyDeprecated?: PaymentInfo.PAYMENT_INFO_CURRENCY;
+        amount1000?: number;
+        receiverJid?: string;
+        status?: PaymentInfo.PAYMENT_INFO_STATUS;
+        transactionTimestamp?: number;
+        requestMessageKey?: MessageKey.AsObjectPartial;
+        expiryTimestamp?: number;
+        futureproofed?: boolean;
+        currency?: string;
+        txnStatus?: PaymentInfo.PAYMENT_INFO_TXNSTATUS;
     };
     export enum PAYMENT_INFO_CURRENCY {
         UNKNOWN_CURRENCY = 0,
@@ -11174,18 +11634,18 @@ export class WebMessageInfo extends pb_1.Message {
         }
     }
     get key() {
-        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined | null;
+        return pb_1.Message.getWrapperField(this, MessageKey, 1) as MessageKey | undefined;
     }
-    set key(value: MessageKey | undefined | null) {
+    set key(value: MessageKey | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_key() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined | null;
+        return pb_1.Message.getWrapperField(this, Message, 2) as Message | undefined;
     }
-    set message(value: Message | undefined | null) {
+    set message(value: Message | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_message() {
@@ -11330,27 +11790,27 @@ export class WebMessageInfo extends pb_1.Message {
         pb_1.Message.setField(this, 28, value);
     }
     get paymentInfo() {
-        return pb_1.Message.getWrapperField(this, PaymentInfo, 29) as PaymentInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, PaymentInfo, 29) as PaymentInfo | undefined;
     }
-    set paymentInfo(value: PaymentInfo | undefined | null) {
+    set paymentInfo(value: PaymentInfo | undefined) {
         pb_1.Message.setWrapperField(this, 29, value);
     }
     get has_paymentInfo() {
         return pb_1.Message.getField(this, 29) != null;
     }
     get finalLiveLocation() {
-        return pb_1.Message.getWrapperField(this, LiveLocationMessage, 30) as LiveLocationMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, LiveLocationMessage, 30) as LiveLocationMessage | undefined;
     }
-    set finalLiveLocation(value: LiveLocationMessage | undefined | null) {
+    set finalLiveLocation(value: LiveLocationMessage | undefined) {
         pb_1.Message.setWrapperField(this, 30, value);
     }
     get has_finalLiveLocation() {
         return pb_1.Message.getField(this, 30) != null;
     }
     get quotedPaymentInfo() {
-        return pb_1.Message.getWrapperField(this, PaymentInfo, 31) as PaymentInfo | undefined | null;
+        return pb_1.Message.getWrapperField(this, PaymentInfo, 31) as PaymentInfo | undefined;
     }
-    set quotedPaymentInfo(value: PaymentInfo | undefined | null) {
+    set quotedPaymentInfo(value: PaymentInfo | undefined) {
         pb_1.Message.setWrapperField(this, 31, value);
     }
     get has_quotedPaymentInfo() {
@@ -11383,7 +11843,7 @@ export class WebMessageInfo extends pb_1.Message {
     get has_ephemeralOffToOn() {
         return pb_1.Message.getField(this, 34) != null;
     }
-    static fromObject(data: RecursivePartial<WebMessageInfo.AsObject>): WebMessageInfo {
+    static fromObject(data: WebMessageInfo.AsObjectPartial): WebMessageInfo {
         const message = new WebMessageInfo({
             key: MessageKey.fromObject(data.key),
             messageStubParameters: data.messageStubParameters,
@@ -11498,14 +11958,14 @@ export class WebMessageInfo extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_key)
-            writer.writeMessage(1, this.key, () => this.key.serialize(writer));
+            writer.writeMessage(1, this.key, () => this.key!.serialize(writer));
         if (this.has_message)
-            writer.writeMessage(2, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(2, this.message, () => this.message!.serialize(writer));
         if (this.has_messageTimestamp)
             writer.writeUint64(3, this.messageTimestamp);
         if (this.has_status)
             writer.writeEnum(4, this.status);
-        if (this.has_participant && this.participant.length)
+        if (this.has_participant && this.participant!.length)
             writer.writeString(5, this.participant);
         if (this.has_ignore)
             writer.writeBool(16, this.ignore);
@@ -11513,9 +11973,9 @@ export class WebMessageInfo extends pb_1.Message {
             writer.writeBool(17, this.starred);
         if (this.has_broadcast)
             writer.writeBool(18, this.broadcast);
-        if (this.has_pushName && this.pushName.length)
+        if (this.has_pushName && this.pushName!.length)
             writer.writeString(19, this.pushName);
-        if (this.has_mediaCiphertextSha256 && this.mediaCiphertextSha256.length)
+        if (this.has_mediaCiphertextSha256 && this.mediaCiphertextSha256!.length)
             writer.writeBytes(20, this.mediaCiphertextSha256);
         if (this.has_multicast)
             writer.writeBool(21, this.multicast);
@@ -11534,11 +11994,11 @@ export class WebMessageInfo extends pb_1.Message {
         if (this.labels.length)
             writer.writeRepeatedString(28, this.labels);
         if (this.has_paymentInfo)
-            writer.writeMessage(29, this.paymentInfo, () => this.paymentInfo.serialize(writer));
+            writer.writeMessage(29, this.paymentInfo, () => this.paymentInfo!.serialize(writer));
         if (this.has_finalLiveLocation)
-            writer.writeMessage(30, this.finalLiveLocation, () => this.finalLiveLocation.serialize(writer));
+            writer.writeMessage(30, this.finalLiveLocation, () => this.finalLiveLocation!.serialize(writer));
         if (this.has_quotedPaymentInfo)
-            writer.writeMessage(31, this.quotedPaymentInfo, () => this.quotedPaymentInfo.serialize(writer));
+            writer.writeMessage(31, this.quotedPaymentInfo, () => this.quotedPaymentInfo!.serialize(writer));
         if (this.has_ephemeralStartTimestamp)
             writer.writeUint64(32, this.ephemeralStartTimestamp);
         if (this.has_ephemeralDuration)
@@ -11664,6 +12124,32 @@ export namespace WebMessageInfo {
         ephemeralStartTimestamp: number;
         ephemeralDuration: number;
         ephemeralOffToOn: boolean;
+    };
+    export type AsObjectPartial = {
+        key: MessageKey.AsObjectPartial;
+        message?: Message.AsObjectPartial;
+        messageTimestamp?: number;
+        status?: WebMessageInfo.WEB_MESSAGE_INFO_STATUS;
+        participant?: string;
+        ignore?: boolean;
+        starred?: boolean;
+        broadcast?: boolean;
+        pushName?: string;
+        mediaCiphertextSha256?: Uint8Array;
+        multicast?: boolean;
+        urlText?: boolean;
+        urlNumber?: boolean;
+        messageStubType?: WebMessageInfo.WEB_MESSAGE_INFO_STUBTYPE;
+        clearMedia?: boolean;
+        messageStubParameters: string[];
+        duration?: number;
+        labels: string[];
+        paymentInfo?: PaymentInfo.AsObjectPartial;
+        finalLiveLocation?: LiveLocationMessage.AsObjectPartial;
+        quotedPaymentInfo?: PaymentInfo.AsObjectPartial;
+        ephemeralStartTimestamp?: number;
+        ephemeralDuration?: number;
+        ephemeralOffToOn?: boolean;
     };
     export enum WEB_MESSAGE_INFO_STATUS {
         ERROR = 0,

--- a/test/conformance/packedproto2/packed_proto2.ts
+++ b/test/conformance/packedproto2/packed_proto2.ts
@@ -4,6 +4,9 @@
  * source: test/conformance/packedproto2/packedproto2.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class HydratedQuickReplyButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -39,10 +42,7 @@ export class HydratedQuickReplyButton extends pb_1.Message {
     get has_id() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        displayText?: string;
-        id?: string;
-    }): HydratedQuickReplyButton {
+    static fromObject(data: RecursivePartial<HydratedQuickReplyButton.AsObject>): HydratedQuickReplyButton {
         const message = new HydratedQuickReplyButton({});
         if (data.displayText != null) {
             message.displayText = data.displayText;
@@ -53,10 +53,7 @@ export class HydratedQuickReplyButton extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayText: string;
-            id: string;
-        } = {
+        const data: HydratedQuickReplyButton.AsObject = {
             displayText: this.displayText,
             id: this.id
         };
@@ -97,6 +94,12 @@ export class HydratedQuickReplyButton extends pb_1.Message {
         return HydratedQuickReplyButton.deserialize(bytes);
     }
 }
+export namespace HydratedQuickReplyButton {
+    export type AsObject = {
+        displayText: string;
+        id: string;
+    };
+}
 export class HydratedURLButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -132,10 +135,7 @@ export class HydratedURLButton extends pb_1.Message {
     get has_url() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        displayText?: string;
-        url?: string;
-    }): HydratedURLButton {
+    static fromObject(data: RecursivePartial<HydratedURLButton.AsObject>): HydratedURLButton {
         const message = new HydratedURLButton({});
         if (data.displayText != null) {
             message.displayText = data.displayText;
@@ -146,10 +146,7 @@ export class HydratedURLButton extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayText: string;
-            url: string;
-        } = {
+        const data: HydratedURLButton.AsObject = {
             displayText: this.displayText,
             url: this.url
         };
@@ -190,6 +187,12 @@ export class HydratedURLButton extends pb_1.Message {
         return HydratedURLButton.deserialize(bytes);
     }
 }
+export namespace HydratedURLButton {
+    export type AsObject = {
+        displayText: string;
+        url: string;
+    };
+}
 export class HydratedCallButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -225,10 +228,7 @@ export class HydratedCallButton extends pb_1.Message {
     get has_phoneNumber() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        displayText?: string;
-        phoneNumber?: string;
-    }): HydratedCallButton {
+    static fromObject(data: RecursivePartial<HydratedCallButton.AsObject>): HydratedCallButton {
         const message = new HydratedCallButton({});
         if (data.displayText != null) {
             message.displayText = data.displayText;
@@ -239,10 +239,7 @@ export class HydratedCallButton extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayText: string;
-            phoneNumber: string;
-        } = {
+        const data: HydratedCallButton.AsObject = {
             displayText: this.displayText,
             phoneNumber: this.phoneNumber
         };
@@ -282,6 +279,12 @@ export class HydratedCallButton extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): HydratedCallButton {
         return HydratedCallButton.deserialize(bytes);
     }
+}
+export namespace HydratedCallButton {
+    export type AsObject = {
+        displayText: string;
+        phoneNumber: string;
+    };
 }
 export class HydratedTemplateButton extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2, 3]];
@@ -364,12 +367,7 @@ export class HydratedTemplateButton extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3])];
     }
-    static fromObject(data: {
-        index?: number;
-        quickReplyButton?: Parameters<typeof HydratedQuickReplyButton.fromObject>[0];
-        urlButton?: Parameters<typeof HydratedURLButton.fromObject>[0];
-        callButton?: Parameters<typeof HydratedCallButton.fromObject>[0];
-    }): HydratedTemplateButton {
+    static fromObject(data: RecursivePartial<HydratedTemplateButton.AsObject>): HydratedTemplateButton {
         const message = new HydratedTemplateButton({});
         if (data.index != null) {
             message.index = data.index;
@@ -386,12 +384,7 @@ export class HydratedTemplateButton extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            index: number;
-            quickReplyButton?: Parameters<typeof HydratedQuickReplyButton.fromObject>[0];
-            urlButton?: Parameters<typeof HydratedURLButton.fromObject>[0];
-            callButton?: Parameters<typeof HydratedCallButton.fromObject>[0];
-        } = {
+        const data: HydratedTemplateButton.AsObject = {
             index: this.index
         };
         if (this.quickReplyButton != null) {
@@ -450,6 +443,14 @@ export class HydratedTemplateButton extends pb_1.Message {
         return HydratedTemplateButton.deserialize(bytes);
     }
 }
+export namespace HydratedTemplateButton {
+    export type AsObject = {
+        index: number;
+        quickReplyButton?: HydratedQuickReplyButton.AsObject;
+        urlButton?: HydratedURLButton.AsObject;
+        callButton?: HydratedCallButton.AsObject;
+    };
+}
 export class QuickReplyButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -485,10 +486,7 @@ export class QuickReplyButton extends pb_1.Message {
     get has_id() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        id?: string;
-    }): QuickReplyButton {
+    static fromObject(data: RecursivePartial<QuickReplyButton.AsObject>): QuickReplyButton {
         const message = new QuickReplyButton({});
         if (data.displayText != null) {
             message.displayText = HighlyStructuredMessage.fromObject(data.displayText);
@@ -499,10 +497,7 @@ export class QuickReplyButton extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-            id: string;
-        } = {
+        const data: QuickReplyButton.AsObject = {
             id: this.id
         };
         if (this.displayText != null) {
@@ -545,6 +540,12 @@ export class QuickReplyButton extends pb_1.Message {
         return QuickReplyButton.deserialize(bytes);
     }
 }
+export namespace QuickReplyButton {
+    export type AsObject = {
+        displayText?: HighlyStructuredMessage.AsObject;
+        id: string;
+    };
+}
 export class URLButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -580,10 +581,7 @@ export class URLButton extends pb_1.Message {
     get has_url() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        url?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-    }): URLButton {
+    static fromObject(data: RecursivePartial<URLButton.AsObject>): URLButton {
         const message = new URLButton({});
         if (data.displayText != null) {
             message.displayText = HighlyStructuredMessage.fromObject(data.displayText);
@@ -594,10 +592,7 @@ export class URLButton extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-            url?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        } = {};
+        const data: URLButton.AsObject = {};
         if (this.displayText != null) {
             data.displayText = this.displayText.toObject();
         }
@@ -641,6 +636,12 @@ export class URLButton extends pb_1.Message {
         return URLButton.deserialize(bytes);
     }
 }
+export namespace URLButton {
+    export type AsObject = {
+        displayText?: HighlyStructuredMessage.AsObject;
+        url?: HighlyStructuredMessage.AsObject;
+    };
+}
 export class CallButton extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -676,10 +677,7 @@ export class CallButton extends pb_1.Message {
     get has_phoneNumber() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        phoneNumber?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-    }): CallButton {
+    static fromObject(data: RecursivePartial<CallButton.AsObject>): CallButton {
         const message = new CallButton({});
         if (data.displayText != null) {
             message.displayText = HighlyStructuredMessage.fromObject(data.displayText);
@@ -690,10 +688,7 @@ export class CallButton extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-            phoneNumber?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        } = {};
+        const data: CallButton.AsObject = {};
         if (this.displayText != null) {
             data.displayText = this.displayText.toObject();
         }
@@ -736,6 +731,12 @@ export class CallButton extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): CallButton {
         return CallButton.deserialize(bytes);
     }
+}
+export namespace CallButton {
+    export type AsObject = {
+        displayText?: HighlyStructuredMessage.AsObject;
+        phoneNumber?: HighlyStructuredMessage.AsObject;
+    };
 }
 export class TemplateButton extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2, 3]];
@@ -818,12 +819,7 @@ export class TemplateButton extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3])];
     }
-    static fromObject(data: {
-        index?: number;
-        quickReplyButton?: Parameters<typeof QuickReplyButton.fromObject>[0];
-        urlButton?: Parameters<typeof URLButton.fromObject>[0];
-        callButton?: Parameters<typeof CallButton.fromObject>[0];
-    }): TemplateButton {
+    static fromObject(data: RecursivePartial<TemplateButton.AsObject>): TemplateButton {
         const message = new TemplateButton({});
         if (data.index != null) {
             message.index = data.index;
@@ -840,12 +836,7 @@ export class TemplateButton extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            index: number;
-            quickReplyButton?: Parameters<typeof QuickReplyButton.fromObject>[0];
-            urlButton?: Parameters<typeof URLButton.fromObject>[0];
-            callButton?: Parameters<typeof CallButton.fromObject>[0];
-        } = {
+        const data: TemplateButton.AsObject = {
             index: this.index
         };
         if (this.quickReplyButton != null) {
@@ -904,6 +895,14 @@ export class TemplateButton extends pb_1.Message {
         return TemplateButton.deserialize(bytes);
     }
 }
+export namespace TemplateButton {
+    export type AsObject = {
+        index: number;
+        quickReplyButton?: QuickReplyButton.AsObject;
+        urlButton?: URLButton.AsObject;
+        callButton?: CallButton.AsObject;
+    };
+}
 export class Location extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -952,11 +951,7 @@ export class Location extends pb_1.Message {
     get has_name() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        degreesLatitude?: number;
-        degreesLongitude?: number;
-        name?: string;
-    }): Location {
+    static fromObject(data: RecursivePartial<Location.AsObject>): Location {
         const message = new Location({});
         if (data.degreesLatitude != null) {
             message.degreesLatitude = data.degreesLatitude;
@@ -970,11 +965,7 @@ export class Location extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            degreesLatitude: number;
-            degreesLongitude: number;
-            name: string;
-        } = {
+        const data: Location.AsObject = {
             degreesLatitude: this.degreesLatitude,
             degreesLongitude: this.degreesLongitude,
             name: this.name
@@ -1020,6 +1011,13 @@ export class Location extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Location {
         return Location.deserialize(bytes);
     }
+}
+export namespace Location {
+    export type AsObject = {
+        degreesLatitude: number;
+        degreesLongitude: number;
+        name: string;
+    };
 }
 export class Point extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -1082,12 +1080,7 @@ export class Point extends pb_1.Message {
     get has_y() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: {
-        xDeprecated?: number;
-        yDeprecated?: number;
-        x?: number;
-        y?: number;
-    }): Point {
+    static fromObject(data: RecursivePartial<Point.AsObject>): Point {
         const message = new Point({});
         if (data.xDeprecated != null) {
             message.xDeprecated = data.xDeprecated;
@@ -1104,12 +1097,7 @@ export class Point extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            xDeprecated: number;
-            yDeprecated: number;
-            x: number;
-            y: number;
-        } = {
+        const data: Point.AsObject = {
             xDeprecated: this.xDeprecated,
             yDeprecated: this.yDeprecated,
             x: this.x,
@@ -1162,6 +1150,14 @@ export class Point extends pb_1.Message {
         return Point.deserialize(bytes);
     }
 }
+export namespace Point {
+    export type AsObject = {
+        xDeprecated: number;
+        yDeprecated: number;
+        x: number;
+        y: number;
+    };
+}
 export class InteractiveAnnotation extends pb_1.Message {
     #one_of_decls: number[][] = [[2]];
     constructor(data?: any[] | ({
@@ -1202,10 +1198,7 @@ export class InteractiveAnnotation extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [2])];
     }
-    static fromObject(data: {
-        polygonVertices?: Parameters<typeof Point.fromObject>[0][];
-        location?: Parameters<typeof Location.fromObject>[0];
-    }): InteractiveAnnotation {
+    static fromObject(data: RecursivePartial<InteractiveAnnotation.AsObject>): InteractiveAnnotation {
         const message = new InteractiveAnnotation({
             polygonVertices: data.polygonVertices.map(item => Point.fromObject(item))
         });
@@ -1215,10 +1208,7 @@ export class InteractiveAnnotation extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            polygonVertices: Parameters<typeof Point.fromObject>[0][];
-            location?: Parameters<typeof Location.fromObject>[0];
-        } = {
+        const data: InteractiveAnnotation.AsObject = {
             polygonVertices: this.polygonVertices.map((item: Point) => item.toObject())
         };
         if (this.location != null) {
@@ -1260,6 +1250,12 @@ export class InteractiveAnnotation extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): InteractiveAnnotation {
         return InteractiveAnnotation.deserialize(bytes);
     }
+}
+export namespace InteractiveAnnotation {
+    export type AsObject = {
+        polygonVertices: Point.AsObject[];
+        location?: Location.AsObject;
+    };
 }
 export class AdReplyInfo extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -1322,12 +1318,7 @@ export class AdReplyInfo extends pb_1.Message {
     get has_caption() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        advertiserName?: string;
-        mediaType?: AdReplyInfo.AD_REPLY_INFO_MEDIATYPE;
-        jpegThumbnail?: Uint8Array;
-        caption?: string;
-    }): AdReplyInfo {
+    static fromObject(data: RecursivePartial<AdReplyInfo.AsObject>): AdReplyInfo {
         const message = new AdReplyInfo({});
         if (data.advertiserName != null) {
             message.advertiserName = data.advertiserName;
@@ -1344,12 +1335,7 @@ export class AdReplyInfo extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            advertiserName: string;
-            mediaType: AdReplyInfo.AD_REPLY_INFO_MEDIATYPE;
-            jpegThumbnail: Uint8Array;
-            caption: string;
-        } = {
+        const data: AdReplyInfo.AsObject = {
             advertiserName: this.advertiserName,
             mediaType: this.mediaType,
             jpegThumbnail: this.jpegThumbnail,
@@ -1403,6 +1389,12 @@ export class AdReplyInfo extends pb_1.Message {
     }
 }
 export namespace AdReplyInfo {
+    export type AsObject = {
+        advertiserName: string;
+        mediaType: AdReplyInfo.AD_REPLY_INFO_MEDIATYPE;
+        jpegThumbnail: Uint8Array;
+        caption: string;
+    };
     export enum AD_REPLY_INFO_MEDIATYPE {
         NONE = 0,
         IMAGE = 1,
@@ -1608,23 +1600,7 @@ export class ContextInfo extends pb_1.Message {
     get has_ephemeralSharedSecret() {
         return pb_1.Message.getField(this, 27) != null;
     }
-    static fromObject(data: {
-        stanzaId?: string;
-        participant?: string;
-        quotedMessage?: Parameters<typeof Message.fromObject>[0];
-        remoteJid?: string;
-        mentionedJid?: string[];
-        conversionSource?: string;
-        conversionData?: Uint8Array;
-        conversionDelaySeconds?: number;
-        forwardingScore?: number;
-        isForwarded?: boolean;
-        quotedAd?: Parameters<typeof AdReplyInfo.fromObject>[0];
-        placeholderKey?: Parameters<typeof MessageKey.fromObject>[0];
-        expiration?: number;
-        ephemeralSettingTimestamp?: number;
-        ephemeralSharedSecret?: Uint8Array;
-    }): ContextInfo {
+    static fromObject(data: RecursivePartial<ContextInfo.AsObject>): ContextInfo {
         const message = new ContextInfo({
             mentionedJid: data.mentionedJid
         });
@@ -1673,23 +1649,7 @@ export class ContextInfo extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            stanzaId: string;
-            participant: string;
-            quotedMessage?: Parameters<typeof Message.fromObject>[0];
-            remoteJid: string;
-            mentionedJid: string[];
-            conversionSource: string;
-            conversionData: Uint8Array;
-            conversionDelaySeconds: number;
-            forwardingScore: number;
-            isForwarded: boolean;
-            quotedAd?: Parameters<typeof AdReplyInfo.fromObject>[0];
-            placeholderKey?: Parameters<typeof MessageKey.fromObject>[0];
-            expiration: number;
-            ephemeralSettingTimestamp: number;
-            ephemeralSharedSecret: Uint8Array;
-        } = {
+        const data: ContextInfo.AsObject = {
             stanzaId: this.stanzaId,
             participant: this.participant,
             remoteJid: this.remoteJid,
@@ -1814,6 +1774,25 @@ export class ContextInfo extends pb_1.Message {
         return ContextInfo.deserialize(bytes);
     }
 }
+export namespace ContextInfo {
+    export type AsObject = {
+        stanzaId: string;
+        participant: string;
+        quotedMessage?: Message.AsObject;
+        remoteJid: string;
+        mentionedJid: string[];
+        conversionSource: string;
+        conversionData: Uint8Array;
+        conversionDelaySeconds: number;
+        forwardingScore: number;
+        isForwarded: boolean;
+        quotedAd?: AdReplyInfo.AsObject;
+        placeholderKey?: MessageKey.AsObject;
+        expiration: number;
+        ephemeralSettingTimestamp: number;
+        ephemeralSharedSecret: Uint8Array;
+    };
+}
 export class SenderKeyDistributionMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -1849,10 +1828,7 @@ export class SenderKeyDistributionMessage extends pb_1.Message {
     get has_axolotlSenderKeyDistributionMessage() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        groupId?: string;
-        axolotlSenderKeyDistributionMessage?: Uint8Array;
-    }): SenderKeyDistributionMessage {
+    static fromObject(data: RecursivePartial<SenderKeyDistributionMessage.AsObject>): SenderKeyDistributionMessage {
         const message = new SenderKeyDistributionMessage({});
         if (data.groupId != null) {
             message.groupId = data.groupId;
@@ -1863,10 +1839,7 @@ export class SenderKeyDistributionMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            groupId: string;
-            axolotlSenderKeyDistributionMessage: Uint8Array;
-        } = {
+        const data: SenderKeyDistributionMessage.AsObject = {
             groupId: this.groupId,
             axolotlSenderKeyDistributionMessage: this.axolotlSenderKeyDistributionMessage
         };
@@ -1906,6 +1879,12 @@ export class SenderKeyDistributionMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): SenderKeyDistributionMessage {
         return SenderKeyDistributionMessage.deserialize(bytes);
     }
+}
+export namespace SenderKeyDistributionMessage {
+    export type AsObject = {
+        groupId: string;
+        axolotlSenderKeyDistributionMessage: Uint8Array;
+    };
 }
 export class ImageMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -2179,29 +2158,7 @@ export class ImageMessage extends pb_1.Message {
     get has_midQualityFileEncSha256() {
         return pb_1.Message.getField(this, 24) != null;
     }
-    static fromObject(data: {
-        url?: string;
-        mimetype?: string;
-        caption?: string;
-        fileSha256?: Uint8Array;
-        fileLength?: number;
-        height?: number;
-        width?: number;
-        mediaKey?: Uint8Array;
-        fileEncSha256?: Uint8Array;
-        interactiveAnnotations?: Parameters<typeof InteractiveAnnotation.fromObject>[0][];
-        directPath?: string;
-        mediaKeyTimestamp?: number;
-        jpegThumbnail?: Uint8Array;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        firstScanSidecar?: Uint8Array;
-        firstScanLength?: number;
-        experimentGroupId?: number;
-        scansSidecar?: Uint8Array;
-        scanLengths?: number[];
-        midQualityFileSha256?: Uint8Array;
-        midQualityFileEncSha256?: Uint8Array;
-    }): ImageMessage {
+    static fromObject(data: RecursivePartial<ImageMessage.AsObject>): ImageMessage {
         const message = new ImageMessage({
             interactiveAnnotations: data.interactiveAnnotations.map(item => InteractiveAnnotation.fromObject(item)),
             scanLengths: data.scanLengths
@@ -2266,29 +2223,7 @@ export class ImageMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            url: string;
-            mimetype: string;
-            caption: string;
-            fileSha256: Uint8Array;
-            fileLength: number;
-            height: number;
-            width: number;
-            mediaKey: Uint8Array;
-            fileEncSha256: Uint8Array;
-            interactiveAnnotations: Parameters<typeof InteractiveAnnotation.fromObject>[0][];
-            directPath: string;
-            mediaKeyTimestamp: number;
-            jpegThumbnail: Uint8Array;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-            firstScanSidecar: Uint8Array;
-            firstScanLength: number;
-            experimentGroupId: number;
-            scansSidecar: Uint8Array;
-            scanLengths: number[];
-            midQualityFileSha256: Uint8Array;
-            midQualityFileEncSha256: Uint8Array;
-        } = {
+        const data: ImageMessage.AsObject = {
             url: this.url,
             mimetype: this.mimetype,
             caption: this.caption,
@@ -2445,6 +2380,31 @@ export class ImageMessage extends pb_1.Message {
         return ImageMessage.deserialize(bytes);
     }
 }
+export namespace ImageMessage {
+    export type AsObject = {
+        url: string;
+        mimetype: string;
+        caption: string;
+        fileSha256: Uint8Array;
+        fileLength: number;
+        height: number;
+        width: number;
+        mediaKey: Uint8Array;
+        fileEncSha256: Uint8Array;
+        interactiveAnnotations: InteractiveAnnotation.AsObject[];
+        directPath: string;
+        mediaKeyTimestamp: number;
+        jpegThumbnail: Uint8Array;
+        contextInfo?: ContextInfo.AsObject;
+        firstScanSidecar: Uint8Array;
+        firstScanLength: number;
+        experimentGroupId: number;
+        scansSidecar: Uint8Array;
+        scanLengths: number[];
+        midQualityFileSha256: Uint8Array;
+        midQualityFileEncSha256: Uint8Array;
+    };
+}
 export class ContactMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -2493,11 +2453,7 @@ export class ContactMessage extends pb_1.Message {
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        displayName?: string;
-        vcard?: string;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-    }): ContactMessage {
+    static fromObject(data: RecursivePartial<ContactMessage.AsObject>): ContactMessage {
         const message = new ContactMessage({});
         if (data.displayName != null) {
             message.displayName = data.displayName;
@@ -2511,11 +2467,7 @@ export class ContactMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayName: string;
-            vcard: string;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        } = {
+        const data: ContactMessage.AsObject = {
             displayName: this.displayName,
             vcard: this.vcard
         };
@@ -2563,6 +2515,13 @@ export class ContactMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): ContactMessage {
         return ContactMessage.deserialize(bytes);
     }
+}
+export namespace ContactMessage {
+    export type AsObject = {
+        displayName: string;
+        vcard: string;
+        contextInfo?: ContextInfo.AsObject;
+    };
 }
 export class LocationMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -2729,20 +2688,7 @@ export class LocationMessage extends pb_1.Message {
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        degreesLatitude?: number;
-        degreesLongitude?: number;
-        name?: string;
-        address?: string;
-        url?: string;
-        isLive?: boolean;
-        accuracyInMeters?: number;
-        speedInMps?: number;
-        degreesClockwiseFromMagneticNorth?: number;
-        comment?: string;
-        jpegThumbnail?: Uint8Array;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-    }): LocationMessage {
+    static fromObject(data: RecursivePartial<LocationMessage.AsObject>): LocationMessage {
         const message = new LocationMessage({});
         if (data.degreesLatitude != null) {
             message.degreesLatitude = data.degreesLatitude;
@@ -2783,20 +2729,7 @@ export class LocationMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            degreesLatitude: number;
-            degreesLongitude: number;
-            name: string;
-            address: string;
-            url: string;
-            isLive: boolean;
-            accuracyInMeters: number;
-            speedInMps: number;
-            degreesClockwiseFromMagneticNorth: number;
-            comment: string;
-            jpegThumbnail: Uint8Array;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        } = {
+        const data: LocationMessage.AsObject = {
             degreesLatitude: this.degreesLatitude,
             degreesLongitude: this.degreesLongitude,
             name: this.name,
@@ -2898,6 +2831,22 @@ export class LocationMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): LocationMessage {
         return LocationMessage.deserialize(bytes);
     }
+}
+export namespace LocationMessage {
+    export type AsObject = {
+        degreesLatitude: number;
+        degreesLongitude: number;
+        name: string;
+        address: string;
+        url: string;
+        isLive: boolean;
+        accuracyInMeters: number;
+        speedInMps: number;
+        degreesClockwiseFromMagneticNorth: number;
+        comment: string;
+        jpegThumbnail: Uint8Array;
+        contextInfo?: ContextInfo.AsObject;
+    };
 }
 export class ExtendedTextMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -3064,20 +3013,7 @@ export class ExtendedTextMessage extends pb_1.Message {
     get has_doNotPlayInline() {
         return pb_1.Message.getField(this, 18) != null;
     }
-    static fromObject(data: {
-        text?: string;
-        matchedText?: string;
-        canonicalUrl?: string;
-        description?: string;
-        title?: string;
-        textArgb?: number;
-        backgroundArgb?: number;
-        font?: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_FONTTYPE;
-        previewType?: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_PREVIEWTYPE;
-        jpegThumbnail?: Uint8Array;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        doNotPlayInline?: boolean;
-    }): ExtendedTextMessage {
+    static fromObject(data: RecursivePartial<ExtendedTextMessage.AsObject>): ExtendedTextMessage {
         const message = new ExtendedTextMessage({});
         if (data.text != null) {
             message.text = data.text;
@@ -3118,20 +3054,7 @@ export class ExtendedTextMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            text: string;
-            matchedText: string;
-            canonicalUrl: string;
-            description: string;
-            title: string;
-            textArgb: number;
-            backgroundArgb: number;
-            font: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_FONTTYPE;
-            previewType: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_PREVIEWTYPE;
-            jpegThumbnail: Uint8Array;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-            doNotPlayInline: boolean;
-        } = {
+        const data: ExtendedTextMessage.AsObject = {
             text: this.text,
             matchedText: this.matchedText,
             canonicalUrl: this.canonicalUrl,
@@ -3235,6 +3158,20 @@ export class ExtendedTextMessage extends pb_1.Message {
     }
 }
 export namespace ExtendedTextMessage {
+    export type AsObject = {
+        text: string;
+        matchedText: string;
+        canonicalUrl: string;
+        description: string;
+        title: string;
+        textArgb: number;
+        backgroundArgb: number;
+        font: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_FONTTYPE;
+        previewType: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_PREVIEWTYPE;
+        jpegThumbnail: Uint8Array;
+        contextInfo?: ContextInfo.AsObject;
+        doNotPlayInline: boolean;
+    };
     export enum EXTENDED_TEXT_MESSAGE_FONTTYPE {
         SANS_SERIF = 0,
         SERIF = 1,
@@ -3426,21 +3363,7 @@ export class DocumentMessage extends pb_1.Message {
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        url?: string;
-        mimetype?: string;
-        title?: string;
-        fileSha256?: Uint8Array;
-        fileLength?: number;
-        pageCount?: number;
-        mediaKey?: Uint8Array;
-        fileName?: string;
-        fileEncSha256?: Uint8Array;
-        directPath?: string;
-        mediaKeyTimestamp?: number;
-        jpegThumbnail?: Uint8Array;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-    }): DocumentMessage {
+    static fromObject(data: RecursivePartial<DocumentMessage.AsObject>): DocumentMessage {
         const message = new DocumentMessage({});
         if (data.url != null) {
             message.url = data.url;
@@ -3484,21 +3407,7 @@ export class DocumentMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            url: string;
-            mimetype: string;
-            title: string;
-            fileSha256: Uint8Array;
-            fileLength: number;
-            pageCount: number;
-            mediaKey: Uint8Array;
-            fileName: string;
-            fileEncSha256: Uint8Array;
-            directPath: string;
-            mediaKeyTimestamp: number;
-            jpegThumbnail: Uint8Array;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        } = {
+        const data: DocumentMessage.AsObject = {
             url: this.url,
             mimetype: this.mimetype,
             title: this.title,
@@ -3606,6 +3515,23 @@ export class DocumentMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): DocumentMessage {
         return DocumentMessage.deserialize(bytes);
     }
+}
+export namespace DocumentMessage {
+    export type AsObject = {
+        url: string;
+        mimetype: string;
+        title: string;
+        fileSha256: Uint8Array;
+        fileLength: number;
+        pageCount: number;
+        mediaKey: Uint8Array;
+        fileName: string;
+        fileEncSha256: Uint8Array;
+        directPath: string;
+        mediaKeyTimestamp: number;
+        jpegThumbnail: Uint8Array;
+        contextInfo?: ContextInfo.AsObject;
+    };
 }
 export class AudioMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -3772,20 +3698,7 @@ export class AudioMessage extends pb_1.Message {
     get has_streamingSidecar() {
         return pb_1.Message.getField(this, 18) != null;
     }
-    static fromObject(data: {
-        url?: string;
-        mimetype?: string;
-        fileSha256?: Uint8Array;
-        fileLength?: number;
-        seconds?: number;
-        ptt?: boolean;
-        mediaKey?: Uint8Array;
-        fileEncSha256?: Uint8Array;
-        directPath?: string;
-        mediaKeyTimestamp?: number;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        streamingSidecar?: Uint8Array;
-    }): AudioMessage {
+    static fromObject(data: RecursivePartial<AudioMessage.AsObject>): AudioMessage {
         const message = new AudioMessage({});
         if (data.url != null) {
             message.url = data.url;
@@ -3826,20 +3739,7 @@ export class AudioMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            url: string;
-            mimetype: string;
-            fileSha256: Uint8Array;
-            fileLength: number;
-            seconds: number;
-            ptt: boolean;
-            mediaKey: Uint8Array;
-            fileEncSha256: Uint8Array;
-            directPath: string;
-            mediaKeyTimestamp: number;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-            streamingSidecar: Uint8Array;
-        } = {
+        const data: AudioMessage.AsObject = {
             url: this.url,
             mimetype: this.mimetype,
             fileSha256: this.fileSha256,
@@ -3941,6 +3841,22 @@ export class AudioMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): AudioMessage {
         return AudioMessage.deserialize(bytes);
     }
+}
+export namespace AudioMessage {
+    export type AsObject = {
+        url: string;
+        mimetype: string;
+        fileSha256: Uint8Array;
+        fileLength: number;
+        seconds: number;
+        ptt: boolean;
+        mediaKey: Uint8Array;
+        fileEncSha256: Uint8Array;
+        directPath: string;
+        mediaKeyTimestamp: number;
+        contextInfo?: ContextInfo.AsObject;
+        streamingSidecar: Uint8Array;
+    };
 }
 export class VideoMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -4180,26 +4096,7 @@ export class VideoMessage extends pb_1.Message {
     get has_gifAttribution() {
         return pb_1.Message.getField(this, 19) != null;
     }
-    static fromObject(data: {
-        url?: string;
-        mimetype?: string;
-        fileSha256?: Uint8Array;
-        fileLength?: number;
-        seconds?: number;
-        mediaKey?: Uint8Array;
-        caption?: string;
-        gifPlayback?: boolean;
-        height?: number;
-        width?: number;
-        fileEncSha256?: Uint8Array;
-        interactiveAnnotations?: Parameters<typeof InteractiveAnnotation.fromObject>[0][];
-        directPath?: string;
-        mediaKeyTimestamp?: number;
-        jpegThumbnail?: Uint8Array;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        streamingSidecar?: Uint8Array;
-        gifAttribution?: VideoMessage.VIDEO_MESSAGE_ATTRIBUTION;
-    }): VideoMessage {
+    static fromObject(data: RecursivePartial<VideoMessage.AsObject>): VideoMessage {
         const message = new VideoMessage({
             interactiveAnnotations: data.interactiveAnnotations.map(item => InteractiveAnnotation.fromObject(item))
         });
@@ -4257,26 +4154,7 @@ export class VideoMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            url: string;
-            mimetype: string;
-            fileSha256: Uint8Array;
-            fileLength: number;
-            seconds: number;
-            mediaKey: Uint8Array;
-            caption: string;
-            gifPlayback: boolean;
-            height: number;
-            width: number;
-            fileEncSha256: Uint8Array;
-            interactiveAnnotations: Parameters<typeof InteractiveAnnotation.fromObject>[0][];
-            directPath: string;
-            mediaKeyTimestamp: number;
-            jpegThumbnail: Uint8Array;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-            streamingSidecar: Uint8Array;
-            gifAttribution: VideoMessage.VIDEO_MESSAGE_ATTRIBUTION;
-        } = {
+        const data: VideoMessage.AsObject = {
             url: this.url,
             mimetype: this.mimetype,
             fileSha256: this.fileSha256,
@@ -4416,6 +4294,26 @@ export class VideoMessage extends pb_1.Message {
     }
 }
 export namespace VideoMessage {
+    export type AsObject = {
+        url: string;
+        mimetype: string;
+        fileSha256: Uint8Array;
+        fileLength: number;
+        seconds: number;
+        mediaKey: Uint8Array;
+        caption: string;
+        gifPlayback: boolean;
+        height: number;
+        width: number;
+        fileEncSha256: Uint8Array;
+        interactiveAnnotations: InteractiveAnnotation.AsObject[];
+        directPath: string;
+        mediaKeyTimestamp: number;
+        jpegThumbnail: Uint8Array;
+        contextInfo?: ContextInfo.AsObject;
+        streamingSidecar: Uint8Array;
+        gifAttribution: VideoMessage.VIDEO_MESSAGE_ATTRIBUTION;
+    };
     export enum VIDEO_MESSAGE_ATTRIBUTION {
         NONE = 0,
         GIPHY = 1,
@@ -4444,9 +4342,7 @@ export class Call extends pb_1.Message {
     get has_callKey() {
         return pb_1.Message.getField(this, 1) != null;
     }
-    static fromObject(data: {
-        callKey?: Uint8Array;
-    }): Call {
+    static fromObject(data: RecursivePartial<Call.AsObject>): Call {
         const message = new Call({});
         if (data.callKey != null) {
             message.callKey = data.callKey;
@@ -4454,9 +4350,7 @@ export class Call extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            callKey: Uint8Array;
-        } = {
+        const data: Call.AsObject = {
             callKey: this.callKey
         };
         return data;
@@ -4490,6 +4384,11 @@ export class Call extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Call {
         return Call.deserialize(bytes);
     }
+}
+export namespace Call {
+    export type AsObject = {
+        callKey: Uint8Array;
+    };
 }
 export class Chat extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -4526,10 +4425,7 @@ export class Chat extends pb_1.Message {
     get has_id() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        displayName?: string;
-        id?: string;
-    }): Chat {
+    static fromObject(data: RecursivePartial<Chat.AsObject>): Chat {
         const message = new Chat({});
         if (data.displayName != null) {
             message.displayName = data.displayName;
@@ -4540,10 +4436,7 @@ export class Chat extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayName: string;
-            id: string;
-        } = {
+        const data: Chat.AsObject = {
             displayName: this.displayName,
             id: this.id
         };
@@ -4583,6 +4476,12 @@ export class Chat extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Chat {
         return Chat.deserialize(bytes);
     }
+}
+export namespace Chat {
+    export type AsObject = {
+        displayName: string;
+        id: string;
+    };
 }
 export class ProtocolMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -4658,13 +4557,7 @@ export class ProtocolMessage extends pb_1.Message {
     get has_historySyncNotification() {
         return pb_1.Message.getField(this, 6) != null;
     }
-    static fromObject(data: {
-        key?: Parameters<typeof MessageKey.fromObject>[0];
-        type?: ProtocolMessage.PROTOCOL_MESSAGE_TYPE;
-        ephemeralExpiration?: number;
-        ephemeralSettingTimestamp?: number;
-        historySyncNotification?: Parameters<typeof HistorySyncNotification.fromObject>[0];
-    }): ProtocolMessage {
+    static fromObject(data: RecursivePartial<ProtocolMessage.AsObject>): ProtocolMessage {
         const message = new ProtocolMessage({});
         if (data.key != null) {
             message.key = MessageKey.fromObject(data.key);
@@ -4684,13 +4577,7 @@ export class ProtocolMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            key?: Parameters<typeof MessageKey.fromObject>[0];
-            type: ProtocolMessage.PROTOCOL_MESSAGE_TYPE;
-            ephemeralExpiration: number;
-            ephemeralSettingTimestamp: number;
-            historySyncNotification?: Parameters<typeof HistorySyncNotification.fromObject>[0];
-        } = {
+        const data: ProtocolMessage.AsObject = {
             type: this.type,
             ephemeralExpiration: this.ephemeralExpiration,
             ephemeralSettingTimestamp: this.ephemeralSettingTimestamp
@@ -4754,6 +4641,13 @@ export class ProtocolMessage extends pb_1.Message {
     }
 }
 export namespace ProtocolMessage {
+    export type AsObject = {
+        key?: MessageKey.AsObject;
+        type: ProtocolMessage.PROTOCOL_MESSAGE_TYPE;
+        ephemeralExpiration: number;
+        ephemeralSettingTimestamp: number;
+        historySyncNotification?: HistorySyncNotification.AsObject;
+    };
     export enum PROTOCOL_MESSAGE_TYPE {
         REVOKE = 0,
         EPHEMERAL_SETTING = 3,
@@ -4874,16 +4768,7 @@ export class HistorySyncNotification extends pb_1.Message {
     get has_originalMessageId() {
         return pb_1.Message.getField(this, 8) != null;
     }
-    static fromObject(data: {
-        fileSha256?: Uint8Array;
-        fileLength?: number;
-        mediaKey?: Uint8Array;
-        fileEncSha256?: Uint8Array;
-        directPath?: string;
-        syncType?: HistorySyncNotification.HISTORY_SYNC_NOTIFICATION_HISTORYSYNCTYPE;
-        chunkOrder?: number;
-        originalMessageId?: string;
-    }): HistorySyncNotification {
+    static fromObject(data: RecursivePartial<HistorySyncNotification.AsObject>): HistorySyncNotification {
         const message = new HistorySyncNotification({});
         if (data.fileSha256 != null) {
             message.fileSha256 = data.fileSha256;
@@ -4912,16 +4797,7 @@ export class HistorySyncNotification extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            fileSha256: Uint8Array;
-            fileLength: number;
-            mediaKey: Uint8Array;
-            fileEncSha256: Uint8Array;
-            directPath: string;
-            syncType: HistorySyncNotification.HISTORY_SYNC_NOTIFICATION_HISTORYSYNCTYPE;
-            chunkOrder: number;
-            originalMessageId: string;
-        } = {
+        const data: HistorySyncNotification.AsObject = {
             fileSha256: this.fileSha256,
             fileLength: this.fileLength,
             mediaKey: this.mediaKey,
@@ -4999,6 +4875,16 @@ export class HistorySyncNotification extends pb_1.Message {
     }
 }
 export namespace HistorySyncNotification {
+    export type AsObject = {
+        fileSha256: Uint8Array;
+        fileLength: number;
+        mediaKey: Uint8Array;
+        fileEncSha256: Uint8Array;
+        directPath: string;
+        syncType: HistorySyncNotification.HISTORY_SYNC_NOTIFICATION_HISTORYSYNCTYPE;
+        chunkOrder: number;
+        originalMessageId: string;
+    };
     export enum HISTORY_SYNC_NOTIFICATION_HISTORYSYNCTYPE {
         INITIAL_BOOTSTRAP = 0,
         INITIAL_STATUS_V3 = 1,
@@ -5050,11 +4936,7 @@ export class ContactsArrayMessage extends pb_1.Message {
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        displayName?: string;
-        contacts?: Parameters<typeof ContactMessage.fromObject>[0][];
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-    }): ContactsArrayMessage {
+    static fromObject(data: RecursivePartial<ContactsArrayMessage.AsObject>): ContactsArrayMessage {
         const message = new ContactsArrayMessage({
             contacts: data.contacts.map(item => ContactMessage.fromObject(item))
         });
@@ -5067,11 +4949,7 @@ export class ContactsArrayMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            displayName: string;
-            contacts: Parameters<typeof ContactMessage.fromObject>[0][];
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        } = {
+        const data: ContactsArrayMessage.AsObject = {
             displayName: this.displayName,
             contacts: this.contacts.map((item: ContactMessage) => item.toObject())
         };
@@ -5120,6 +4998,13 @@ export class ContactsArrayMessage extends pb_1.Message {
         return ContactsArrayMessage.deserialize(bytes);
     }
 }
+export namespace ContactsArrayMessage {
+    export type AsObject = {
+        displayName: string;
+        contacts: ContactMessage.AsObject[];
+        contextInfo?: ContextInfo.AsObject;
+    };
+}
 export class HSMCurrency extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -5155,10 +5040,7 @@ export class HSMCurrency extends pb_1.Message {
     get has_amount1000() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        currencyCode?: string;
-        amount1000?: number;
-    }): HSMCurrency {
+    static fromObject(data: RecursivePartial<HSMCurrency.AsObject>): HSMCurrency {
         const message = new HSMCurrency({});
         if (data.currencyCode != null) {
             message.currencyCode = data.currencyCode;
@@ -5169,10 +5051,7 @@ export class HSMCurrency extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            currencyCode: string;
-            amount1000: number;
-        } = {
+        const data: HSMCurrency.AsObject = {
             currencyCode: this.currencyCode,
             amount1000: this.amount1000
         };
@@ -5212,6 +5091,12 @@ export class HSMCurrency extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): HSMCurrency {
         return HSMCurrency.deserialize(bytes);
     }
+}
+export namespace HSMCurrency {
+    export type AsObject = {
+        currencyCode: string;
+        amount1000: number;
+    };
 }
 export class HSMDateTimeComponent extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -5313,15 +5198,7 @@ export class HSMDateTimeComponent extends pb_1.Message {
     get has_calendar() {
         return pb_1.Message.getField(this, 7) != null;
     }
-    static fromObject(data: {
-        dayOfWeek?: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_DAYOFWEEKTYPE;
-        year?: number;
-        month?: number;
-        dayOfMonth?: number;
-        hour?: number;
-        minute?: number;
-        calendar?: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_CALENDARTYPE;
-    }): HSMDateTimeComponent {
+    static fromObject(data: RecursivePartial<HSMDateTimeComponent.AsObject>): HSMDateTimeComponent {
         const message = new HSMDateTimeComponent({});
         if (data.dayOfWeek != null) {
             message.dayOfWeek = data.dayOfWeek;
@@ -5347,15 +5224,7 @@ export class HSMDateTimeComponent extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            dayOfWeek: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_DAYOFWEEKTYPE;
-            year: number;
-            month: number;
-            dayOfMonth: number;
-            hour: number;
-            minute: number;
-            calendar: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_CALENDARTYPE;
-        } = {
+        const data: HSMDateTimeComponent.AsObject = {
             dayOfWeek: this.dayOfWeek,
             year: this.year,
             month: this.month,
@@ -5427,6 +5296,15 @@ export class HSMDateTimeComponent extends pb_1.Message {
     }
 }
 export namespace HSMDateTimeComponent {
+    export type AsObject = {
+        dayOfWeek: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_DAYOFWEEKTYPE;
+        year: number;
+        month: number;
+        dayOfMonth: number;
+        hour: number;
+        minute: number;
+        calendar: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_CALENDARTYPE;
+    };
     export enum HSM_DATE_TIME_COMPONENT_DAYOFWEEKTYPE {
         MONDAY = 1,
         TUESDAY = 2,
@@ -5463,9 +5341,7 @@ export class HSMDateTimeUnixEpoch extends pb_1.Message {
     get has_timestamp() {
         return pb_1.Message.getField(this, 1) != null;
     }
-    static fromObject(data: {
-        timestamp?: number;
-    }): HSMDateTimeUnixEpoch {
+    static fromObject(data: RecursivePartial<HSMDateTimeUnixEpoch.AsObject>): HSMDateTimeUnixEpoch {
         const message = new HSMDateTimeUnixEpoch({});
         if (data.timestamp != null) {
             message.timestamp = data.timestamp;
@@ -5473,9 +5349,7 @@ export class HSMDateTimeUnixEpoch extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            timestamp: number;
-        } = {
+        const data: HSMDateTimeUnixEpoch.AsObject = {
             timestamp: this.timestamp
         };
         return data;
@@ -5509,6 +5383,11 @@ export class HSMDateTimeUnixEpoch extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): HSMDateTimeUnixEpoch {
         return HSMDateTimeUnixEpoch.deserialize(bytes);
     }
+}
+export namespace HSMDateTimeUnixEpoch {
+    export type AsObject = {
+        timestamp: number;
+    };
 }
 export class HSMDateTime extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2]];
@@ -5558,10 +5437,7 @@ export class HSMDateTime extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2])];
     }
-    static fromObject(data: {
-        component?: Parameters<typeof HSMDateTimeComponent.fromObject>[0];
-        unixEpoch?: Parameters<typeof HSMDateTimeUnixEpoch.fromObject>[0];
-    }): HSMDateTime {
+    static fromObject(data: RecursivePartial<HSMDateTime.AsObject>): HSMDateTime {
         const message = new HSMDateTime({});
         if (data.component != null) {
             message.component = HSMDateTimeComponent.fromObject(data.component);
@@ -5572,10 +5448,7 @@ export class HSMDateTime extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            component?: Parameters<typeof HSMDateTimeComponent.fromObject>[0];
-            unixEpoch?: Parameters<typeof HSMDateTimeUnixEpoch.fromObject>[0];
-        } = {};
+        const data: HSMDateTime.AsObject = {};
         if (this.component != null) {
             data.component = this.component.toObject();
         }
@@ -5618,6 +5491,12 @@ export class HSMDateTime extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): HSMDateTime {
         return HSMDateTime.deserialize(bytes);
     }
+}
+export namespace HSMDateTime {
+    export type AsObject = {
+        component?: HSMDateTimeComponent.AsObject;
+        unixEpoch?: HSMDateTimeUnixEpoch.AsObject;
+    };
 }
 export class HSMLocalizableParameter extends pb_1.Message {
     #one_of_decls: number[][] = [[2, 3]];
@@ -5681,11 +5560,7 @@ export class HSMLocalizableParameter extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [2, 3])];
     }
-    static fromObject(data: {
-        default?: string;
-        currency?: Parameters<typeof HSMCurrency.fromObject>[0];
-        dateTime?: Parameters<typeof HSMDateTime.fromObject>[0];
-    }): HSMLocalizableParameter {
+    static fromObject(data: RecursivePartial<HSMLocalizableParameter.AsObject>): HSMLocalizableParameter {
         const message = new HSMLocalizableParameter({});
         if (data.default != null) {
             message.default = data.default;
@@ -5699,11 +5574,7 @@ export class HSMLocalizableParameter extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            default: string;
-            currency?: Parameters<typeof HSMCurrency.fromObject>[0];
-            dateTime?: Parameters<typeof HSMDateTime.fromObject>[0];
-        } = {
+        const data: HSMLocalizableParameter.AsObject = {
             default: this.default
         };
         if (this.currency != null) {
@@ -5753,6 +5624,13 @@ export class HSMLocalizableParameter extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): HSMLocalizableParameter {
         return HSMLocalizableParameter.deserialize(bytes);
     }
+}
+export namespace HSMLocalizableParameter {
+    export type AsObject = {
+        default: string;
+        currency?: HSMCurrency.AsObject;
+        dateTime?: HSMDateTime.AsObject;
+    };
 }
 export class HighlyStructuredMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -5870,17 +5748,7 @@ export class HighlyStructuredMessage extends pb_1.Message {
     get has_hydratedHsm() {
         return pb_1.Message.getField(this, 9) != null;
     }
-    static fromObject(data: {
-        namespace?: string;
-        elementName?: string;
-        params?: string[];
-        fallbackLg?: string;
-        fallbackLc?: string;
-        localizableParams?: Parameters<typeof HSMLocalizableParameter.fromObject>[0][];
-        deterministicLg?: string;
-        deterministicLc?: string;
-        hydratedHsm?: Parameters<typeof TemplateMessage.fromObject>[0];
-    }): HighlyStructuredMessage {
+    static fromObject(data: RecursivePartial<HighlyStructuredMessage.AsObject>): HighlyStructuredMessage {
         const message = new HighlyStructuredMessage({
             params: data.params,
             localizableParams: data.localizableParams.map(item => HSMLocalizableParameter.fromObject(item))
@@ -5909,17 +5777,7 @@ export class HighlyStructuredMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            namespace: string;
-            elementName: string;
-            params: string[];
-            fallbackLg: string;
-            fallbackLc: string;
-            localizableParams: Parameters<typeof HSMLocalizableParameter.fromObject>[0][];
-            deterministicLg: string;
-            deterministicLc: string;
-            hydratedHsm?: Parameters<typeof TemplateMessage.fromObject>[0];
-        } = {
+        const data: HighlyStructuredMessage.AsObject = {
             namespace: this.namespace,
             elementName: this.elementName,
             params: this.params,
@@ -6004,6 +5862,19 @@ export class HighlyStructuredMessage extends pb_1.Message {
         return HighlyStructuredMessage.deserialize(bytes);
     }
 }
+export namespace HighlyStructuredMessage {
+    export type AsObject = {
+        namespace: string;
+        elementName: string;
+        params: string[];
+        fallbackLg: string;
+        fallbackLc: string;
+        localizableParams: HSMLocalizableParameter.AsObject[];
+        deterministicLg: string;
+        deterministicLc: string;
+        hydratedHsm?: TemplateMessage.AsObject;
+    };
+}
 export class SendPaymentMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -6039,10 +5910,7 @@ export class SendPaymentMessage extends pb_1.Message {
     get has_requestMessageKey() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        noteMessage?: Parameters<typeof Message.fromObject>[0];
-        requestMessageKey?: Parameters<typeof MessageKey.fromObject>[0];
-    }): SendPaymentMessage {
+    static fromObject(data: RecursivePartial<SendPaymentMessage.AsObject>): SendPaymentMessage {
         const message = new SendPaymentMessage({});
         if (data.noteMessage != null) {
             message.noteMessage = Message.fromObject(data.noteMessage);
@@ -6053,10 +5921,7 @@ export class SendPaymentMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            noteMessage?: Parameters<typeof Message.fromObject>[0];
-            requestMessageKey?: Parameters<typeof MessageKey.fromObject>[0];
-        } = {};
+        const data: SendPaymentMessage.AsObject = {};
         if (this.noteMessage != null) {
             data.noteMessage = this.noteMessage.toObject();
         }
@@ -6099,6 +5964,12 @@ export class SendPaymentMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): SendPaymentMessage {
         return SendPaymentMessage.deserialize(bytes);
     }
+}
+export namespace SendPaymentMessage {
+    export type AsObject = {
+        noteMessage?: Message.AsObject;
+        requestMessageKey?: MessageKey.AsObject;
+    };
 }
 export class RequestPaymentMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -6174,13 +6045,7 @@ export class RequestPaymentMessage extends pb_1.Message {
     get has_expiryTimestamp() {
         return pb_1.Message.getField(this, 5) != null;
     }
-    static fromObject(data: {
-        noteMessage?: Parameters<typeof Message.fromObject>[0];
-        currencyCodeIso4217?: string;
-        amount1000?: number;
-        requestFrom?: string;
-        expiryTimestamp?: number;
-    }): RequestPaymentMessage {
+    static fromObject(data: RecursivePartial<RequestPaymentMessage.AsObject>): RequestPaymentMessage {
         const message = new RequestPaymentMessage({});
         if (data.noteMessage != null) {
             message.noteMessage = Message.fromObject(data.noteMessage);
@@ -6200,13 +6065,7 @@ export class RequestPaymentMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            noteMessage?: Parameters<typeof Message.fromObject>[0];
-            currencyCodeIso4217: string;
-            amount1000: number;
-            requestFrom: string;
-            expiryTimestamp: number;
-        } = {
+        const data: RequestPaymentMessage.AsObject = {
             currencyCodeIso4217: this.currencyCodeIso4217,
             amount1000: this.amount1000,
             requestFrom: this.requestFrom,
@@ -6267,6 +6126,15 @@ export class RequestPaymentMessage extends pb_1.Message {
         return RequestPaymentMessage.deserialize(bytes);
     }
 }
+export namespace RequestPaymentMessage {
+    export type AsObject = {
+        noteMessage?: Message.AsObject;
+        currencyCodeIso4217: string;
+        amount1000: number;
+        requestFrom: string;
+        expiryTimestamp: number;
+    };
+}
 export class DeclinePaymentRequestMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -6289,9 +6157,7 @@ export class DeclinePaymentRequestMessage extends pb_1.Message {
     get has_key() {
         return pb_1.Message.getField(this, 1) != null;
     }
-    static fromObject(data: {
-        key?: Parameters<typeof MessageKey.fromObject>[0];
-    }): DeclinePaymentRequestMessage {
+    static fromObject(data: RecursivePartial<DeclinePaymentRequestMessage.AsObject>): DeclinePaymentRequestMessage {
         const message = new DeclinePaymentRequestMessage({});
         if (data.key != null) {
             message.key = MessageKey.fromObject(data.key);
@@ -6299,9 +6165,7 @@ export class DeclinePaymentRequestMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            key?: Parameters<typeof MessageKey.fromObject>[0];
-        } = {};
+        const data: DeclinePaymentRequestMessage.AsObject = {};
         if (this.key != null) {
             data.key = this.key.toObject();
         }
@@ -6337,6 +6201,11 @@ export class DeclinePaymentRequestMessage extends pb_1.Message {
         return DeclinePaymentRequestMessage.deserialize(bytes);
     }
 }
+export namespace DeclinePaymentRequestMessage {
+    export type AsObject = {
+        key?: MessageKey.AsObject;
+    };
+}
 export class CancelPaymentRequestMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -6359,9 +6228,7 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
     get has_key() {
         return pb_1.Message.getField(this, 1) != null;
     }
-    static fromObject(data: {
-        key?: Parameters<typeof MessageKey.fromObject>[0];
-    }): CancelPaymentRequestMessage {
+    static fromObject(data: RecursivePartial<CancelPaymentRequestMessage.AsObject>): CancelPaymentRequestMessage {
         const message = new CancelPaymentRequestMessage({});
         if (data.key != null) {
             message.key = MessageKey.fromObject(data.key);
@@ -6369,9 +6236,7 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            key?: Parameters<typeof MessageKey.fromObject>[0];
-        } = {};
+        const data: CancelPaymentRequestMessage.AsObject = {};
         if (this.key != null) {
             data.key = this.key.toObject();
         }
@@ -6406,6 +6271,11 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): CancelPaymentRequestMessage {
         return CancelPaymentRequestMessage.deserialize(bytes);
     }
+}
+export namespace CancelPaymentRequestMessage {
+    export type AsObject = {
+        key?: MessageKey.AsObject;
+    };
 }
 export class LiveLocationMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -6546,18 +6416,7 @@ export class LiveLocationMessage extends pb_1.Message {
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        degreesLatitude?: number;
-        degreesLongitude?: number;
-        accuracyInMeters?: number;
-        speedInMps?: number;
-        degreesClockwiseFromMagneticNorth?: number;
-        caption?: string;
-        sequenceNumber?: number;
-        timeOffset?: number;
-        jpegThumbnail?: Uint8Array;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-    }): LiveLocationMessage {
+    static fromObject(data: RecursivePartial<LiveLocationMessage.AsObject>): LiveLocationMessage {
         const message = new LiveLocationMessage({});
         if (data.degreesLatitude != null) {
             message.degreesLatitude = data.degreesLatitude;
@@ -6592,18 +6451,7 @@ export class LiveLocationMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            degreesLatitude: number;
-            degreesLongitude: number;
-            accuracyInMeters: number;
-            speedInMps: number;
-            degreesClockwiseFromMagneticNorth: number;
-            caption: string;
-            sequenceNumber: number;
-            timeOffset: number;
-            jpegThumbnail: Uint8Array;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        } = {
+        const data: LiveLocationMessage.AsObject = {
             degreesLatitude: this.degreesLatitude,
             degreesLongitude: this.degreesLongitude,
             accuracyInMeters: this.accuracyInMeters,
@@ -6693,6 +6541,20 @@ export class LiveLocationMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): LiveLocationMessage {
         return LiveLocationMessage.deserialize(bytes);
     }
+}
+export namespace LiveLocationMessage {
+    export type AsObject = {
+        degreesLatitude: number;
+        degreesLongitude: number;
+        accuracyInMeters: number;
+        speedInMps: number;
+        degreesClockwiseFromMagneticNorth: number;
+        caption: string;
+        sequenceNumber: number;
+        timeOffset: number;
+        jpegThumbnail: Uint8Array;
+        contextInfo?: ContextInfo.AsObject;
+    };
 }
 export class StickerMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -6898,23 +6760,7 @@ export class StickerMessage extends pb_1.Message {
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        url?: string;
-        fileSha256?: Uint8Array;
-        fileEncSha256?: Uint8Array;
-        mediaKey?: Uint8Array;
-        mimetype?: string;
-        height?: number;
-        width?: number;
-        directPath?: string;
-        fileLength?: number;
-        mediaKeyTimestamp?: number;
-        firstFrameLength?: number;
-        firstFrameSidecar?: Uint8Array;
-        isAnimated?: boolean;
-        pngThumbnail?: Uint8Array;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-    }): StickerMessage {
+    static fromObject(data: RecursivePartial<StickerMessage.AsObject>): StickerMessage {
         const message = new StickerMessage({});
         if (data.url != null) {
             message.url = data.url;
@@ -6964,23 +6810,7 @@ export class StickerMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            url: string;
-            fileSha256: Uint8Array;
-            fileEncSha256: Uint8Array;
-            mediaKey: Uint8Array;
-            mimetype: string;
-            height: number;
-            width: number;
-            directPath: string;
-            fileLength: number;
-            mediaKeyTimestamp: number;
-            firstFrameLength: number;
-            firstFrameSidecar: Uint8Array;
-            isAnimated: boolean;
-            pngThumbnail: Uint8Array;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        } = {
+        const data: StickerMessage.AsObject = {
             url: this.url,
             fileSha256: this.fileSha256,
             fileEncSha256: this.fileEncSha256,
@@ -7100,6 +6930,25 @@ export class StickerMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): StickerMessage {
         return StickerMessage.deserialize(bytes);
     }
+}
+export namespace StickerMessage {
+    export type AsObject = {
+        url: string;
+        fileSha256: Uint8Array;
+        fileEncSha256: Uint8Array;
+        mediaKey: Uint8Array;
+        mimetype: string;
+        height: number;
+        width: number;
+        directPath: string;
+        fileLength: number;
+        mediaKeyTimestamp: number;
+        firstFrameLength: number;
+        firstFrameSidecar: Uint8Array;
+        isAnimated: boolean;
+        pngThumbnail: Uint8Array;
+        contextInfo?: ContextInfo.AsObject;
+    };
 }
 export class FourRowTemplate extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2, 3, 4, 5]];
@@ -7247,16 +7096,7 @@ export class FourRowTemplate extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3, 4, 5])];
     }
-    static fromObject(data: {
-        content?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        footer?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        buttons?: Parameters<typeof TemplateButton.fromObject>[0][];
-        documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
-        highlyStructuredMessage?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
-        videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
-        locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
-    }): FourRowTemplate {
+    static fromObject(data: RecursivePartial<FourRowTemplate.AsObject>): FourRowTemplate {
         const message = new FourRowTemplate({
             buttons: data.buttons.map(item => TemplateButton.fromObject(item))
         });
@@ -7284,16 +7124,7 @@ export class FourRowTemplate extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            content?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-            footer?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-            buttons: Parameters<typeof TemplateButton.fromObject>[0][];
-            documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
-            highlyStructuredMessage?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-            imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
-            videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
-            locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
-        } = {
+        const data: FourRowTemplate.AsObject = {
             buttons: this.buttons.map((item: TemplateButton) => item.toObject())
         };
         if (this.content != null) {
@@ -7383,6 +7214,18 @@ export class FourRowTemplate extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): FourRowTemplate {
         return FourRowTemplate.deserialize(bytes);
     }
+}
+export namespace FourRowTemplate {
+    export type AsObject = {
+        content?: HighlyStructuredMessage.AsObject;
+        footer?: HighlyStructuredMessage.AsObject;
+        buttons: TemplateButton.AsObject[];
+        documentMessage?: DocumentMessage.AsObject;
+        highlyStructuredMessage?: HighlyStructuredMessage.AsObject;
+        imageMessage?: ImageMessage.AsObject;
+        videoMessage?: VideoMessage.AsObject;
+        locationMessage?: LocationMessage.AsObject;
+    };
 }
 export class HydratedFourRowTemplate extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2, 3, 4, 5]];
@@ -7543,17 +7386,7 @@ export class HydratedFourRowTemplate extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3, 4, 5])];
     }
-    static fromObject(data: {
-        hydratedContentText?: string;
-        hydratedFooterText?: string;
-        hydratedButtons?: Parameters<typeof HydratedTemplateButton.fromObject>[0][];
-        templateId?: string;
-        documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
-        hydratedTitleText?: string;
-        imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
-        videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
-        locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
-    }): HydratedFourRowTemplate {
+    static fromObject(data: RecursivePartial<HydratedFourRowTemplate.AsObject>): HydratedFourRowTemplate {
         const message = new HydratedFourRowTemplate({
             hydratedButtons: data.hydratedButtons.map(item => HydratedTemplateButton.fromObject(item))
         });
@@ -7584,17 +7417,7 @@ export class HydratedFourRowTemplate extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            hydratedContentText: string;
-            hydratedFooterText: string;
-            hydratedButtons: Parameters<typeof HydratedTemplateButton.fromObject>[0][];
-            templateId: string;
-            documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
-            hydratedTitleText: string;
-            imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
-            videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
-            locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
-        } = {
+        const data: HydratedFourRowTemplate.AsObject = {
             hydratedContentText: this.hydratedContentText,
             hydratedFooterText: this.hydratedFooterText,
             hydratedButtons: this.hydratedButtons.map((item: HydratedTemplateButton) => item.toObject()),
@@ -7685,6 +7508,19 @@ export class HydratedFourRowTemplate extends pb_1.Message {
         return HydratedFourRowTemplate.deserialize(bytes);
     }
 }
+export namespace HydratedFourRowTemplate {
+    export type AsObject = {
+        hydratedContentText: string;
+        hydratedFooterText: string;
+        hydratedButtons: HydratedTemplateButton.AsObject[];
+        templateId: string;
+        documentMessage?: DocumentMessage.AsObject;
+        hydratedTitleText: string;
+        imageMessage?: ImageMessage.AsObject;
+        videoMessage?: VideoMessage.AsObject;
+        locationMessage?: LocationMessage.AsObject;
+    };
+}
 export class TemplateMessage extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2]];
     constructor(data?: any[] | ({
@@ -7760,12 +7596,7 @@ export class TemplateMessage extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2])];
     }
-    static fromObject(data: {
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        hydratedTemplate?: Parameters<typeof HydratedFourRowTemplate.fromObject>[0];
-        fourRowTemplate?: Parameters<typeof FourRowTemplate.fromObject>[0];
-        hydratedFourRowTemplate?: Parameters<typeof HydratedFourRowTemplate.fromObject>[0];
-    }): TemplateMessage {
+    static fromObject(data: RecursivePartial<TemplateMessage.AsObject>): TemplateMessage {
         const message = new TemplateMessage({});
         if (data.contextInfo != null) {
             message.contextInfo = ContextInfo.fromObject(data.contextInfo);
@@ -7782,12 +7613,7 @@ export class TemplateMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-            hydratedTemplate?: Parameters<typeof HydratedFourRowTemplate.fromObject>[0];
-            fourRowTemplate?: Parameters<typeof FourRowTemplate.fromObject>[0];
-            hydratedFourRowTemplate?: Parameters<typeof HydratedFourRowTemplate.fromObject>[0];
-        } = {};
+        const data: TemplateMessage.AsObject = {};
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
         }
@@ -7846,6 +7672,14 @@ export class TemplateMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): TemplateMessage {
         return TemplateMessage.deserialize(bytes);
     }
+}
+export namespace TemplateMessage {
+    export type AsObject = {
+        contextInfo?: ContextInfo.AsObject;
+        hydratedTemplate?: HydratedFourRowTemplate.AsObject;
+        fourRowTemplate?: FourRowTemplate.AsObject;
+        hydratedFourRowTemplate?: HydratedFourRowTemplate.AsObject;
+    };
 }
 export class TemplateButtonReplyMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -7908,12 +7742,7 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
     get has_selectedIndex() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: {
-        selectedId?: string;
-        selectedDisplayText?: string;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        selectedIndex?: number;
-    }): TemplateButtonReplyMessage {
+    static fromObject(data: RecursivePartial<TemplateButtonReplyMessage.AsObject>): TemplateButtonReplyMessage {
         const message = new TemplateButtonReplyMessage({});
         if (data.selectedId != null) {
             message.selectedId = data.selectedId;
@@ -7930,12 +7759,7 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            selectedId: string;
-            selectedDisplayText: string;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-            selectedIndex: number;
-        } = {
+        const data: TemplateButtonReplyMessage.AsObject = {
             selectedId: this.selectedId,
             selectedDisplayText: this.selectedDisplayText,
             selectedIndex: this.selectedIndex
@@ -7990,6 +7814,14 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
         return TemplateButtonReplyMessage.deserialize(bytes);
     }
 }
+export namespace TemplateButtonReplyMessage {
+    export type AsObject = {
+        selectedId: string;
+        selectedDisplayText: string;
+        contextInfo?: ContextInfo.AsObject;
+        selectedIndex: number;
+    };
+}
 export class CatalogSnapshot extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -8038,11 +7870,7 @@ export class CatalogSnapshot extends pb_1.Message {
     get has_description() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        catalogImage?: Parameters<typeof ImageMessage.fromObject>[0];
-        title?: string;
-        description?: string;
-    }): CatalogSnapshot {
+    static fromObject(data: RecursivePartial<CatalogSnapshot.AsObject>): CatalogSnapshot {
         const message = new CatalogSnapshot({});
         if (data.catalogImage != null) {
             message.catalogImage = ImageMessage.fromObject(data.catalogImage);
@@ -8056,11 +7884,7 @@ export class CatalogSnapshot extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            catalogImage?: Parameters<typeof ImageMessage.fromObject>[0];
-            title: string;
-            description: string;
-        } = {
+        const data: CatalogSnapshot.AsObject = {
             title: this.title,
             description: this.description
         };
@@ -8108,6 +7932,13 @@ export class CatalogSnapshot extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): CatalogSnapshot {
         return CatalogSnapshot.deserialize(bytes);
     }
+}
+export namespace CatalogSnapshot {
+    export type AsObject = {
+        catalogImage?: ImageMessage.AsObject;
+        title: string;
+        description: string;
+    };
 }
 export class ProductSnapshot extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -8248,18 +8079,7 @@ export class ProductSnapshot extends pb_1.Message {
     get has_firstImageId() {
         return pb_1.Message.getField(this, 11) != null;
     }
-    static fromObject(data: {
-        productImage?: Parameters<typeof ImageMessage.fromObject>[0];
-        productId?: string;
-        title?: string;
-        description?: string;
-        currencyCode?: string;
-        priceAmount1000?: number;
-        retailerId?: string;
-        url?: string;
-        productImageCount?: number;
-        firstImageId?: string;
-    }): ProductSnapshot {
+    static fromObject(data: RecursivePartial<ProductSnapshot.AsObject>): ProductSnapshot {
         const message = new ProductSnapshot({});
         if (data.productImage != null) {
             message.productImage = ImageMessage.fromObject(data.productImage);
@@ -8294,18 +8114,7 @@ export class ProductSnapshot extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            productImage?: Parameters<typeof ImageMessage.fromObject>[0];
-            productId: string;
-            title: string;
-            description: string;
-            currencyCode: string;
-            priceAmount1000: number;
-            retailerId: string;
-            url: string;
-            productImageCount: number;
-            firstImageId: string;
-        } = {
+        const data: ProductSnapshot.AsObject = {
             productId: this.productId,
             title: this.title,
             description: this.description,
@@ -8396,6 +8205,20 @@ export class ProductSnapshot extends pb_1.Message {
         return ProductSnapshot.deserialize(bytes);
     }
 }
+export namespace ProductSnapshot {
+    export type AsObject = {
+        productImage?: ImageMessage.AsObject;
+        productId: string;
+        title: string;
+        description: string;
+        currencyCode: string;
+        priceAmount1000: number;
+        retailerId: string;
+        url: string;
+        productImageCount: number;
+        firstImageId: string;
+    };
+}
 export class ProductMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -8457,12 +8280,7 @@ export class ProductMessage extends pb_1.Message {
     get has_contextInfo() {
         return pb_1.Message.getField(this, 17) != null;
     }
-    static fromObject(data: {
-        product?: Parameters<typeof ProductSnapshot.fromObject>[0];
-        businessOwnerJid?: string;
-        catalog?: Parameters<typeof CatalogSnapshot.fromObject>[0];
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-    }): ProductMessage {
+    static fromObject(data: RecursivePartial<ProductMessage.AsObject>): ProductMessage {
         const message = new ProductMessage({});
         if (data.product != null) {
             message.product = ProductSnapshot.fromObject(data.product);
@@ -8479,12 +8297,7 @@ export class ProductMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            product?: Parameters<typeof ProductSnapshot.fromObject>[0];
-            businessOwnerJid: string;
-            catalog?: Parameters<typeof CatalogSnapshot.fromObject>[0];
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        } = {
+        const data: ProductMessage.AsObject = {
             businessOwnerJid: this.businessOwnerJid
         };
         if (this.product != null) {
@@ -8542,6 +8355,14 @@ export class ProductMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): ProductMessage {
         return ProductMessage.deserialize(bytes);
     }
+}
+export namespace ProductMessage {
+    export type AsObject = {
+        product?: ProductSnapshot.AsObject;
+        businessOwnerJid: string;
+        catalog?: CatalogSnapshot.AsObject;
+        contextInfo?: ContextInfo.AsObject;
+    };
 }
 export class GroupInviteMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -8643,15 +8464,7 @@ export class GroupInviteMessage extends pb_1.Message {
     get has_contextInfo() {
         return pb_1.Message.getField(this, 7) != null;
     }
-    static fromObject(data: {
-        groupJid?: string;
-        inviteCode?: string;
-        inviteExpiration?: number;
-        groupName?: string;
-        jpegThumbnail?: Uint8Array;
-        caption?: string;
-        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-    }): GroupInviteMessage {
+    static fromObject(data: RecursivePartial<GroupInviteMessage.AsObject>): GroupInviteMessage {
         const message = new GroupInviteMessage({});
         if (data.groupJid != null) {
             message.groupJid = data.groupJid;
@@ -8677,15 +8490,7 @@ export class GroupInviteMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            groupJid: string;
-            inviteCode: string;
-            inviteExpiration: number;
-            groupName: string;
-            jpegThumbnail: Uint8Array;
-            caption: string;
-            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
-        } = {
+        const data: GroupInviteMessage.AsObject = {
             groupJid: this.groupJid,
             inviteCode: this.inviteCode,
             inviteExpiration: this.inviteExpiration,
@@ -8758,6 +8563,17 @@ export class GroupInviteMessage extends pb_1.Message {
         return GroupInviteMessage.deserialize(bytes);
     }
 }
+export namespace GroupInviteMessage {
+    export type AsObject = {
+        groupJid: string;
+        inviteCode: string;
+        inviteExpiration: number;
+        groupName: string;
+        jpegThumbnail: Uint8Array;
+        caption: string;
+        contextInfo?: ContextInfo.AsObject;
+    };
+}
 export class DeviceSentMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -8806,11 +8622,7 @@ export class DeviceSentMessage extends pb_1.Message {
     get has_phash() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        destinationJid?: string;
-        message?: Parameters<typeof Message.fromObject>[0];
-        phash?: string;
-    }): DeviceSentMessage {
+    static fromObject(data: RecursivePartial<DeviceSentMessage.AsObject>): DeviceSentMessage {
         const message = new DeviceSentMessage({});
         if (data.destinationJid != null) {
             message.destinationJid = data.destinationJid;
@@ -8824,11 +8636,7 @@ export class DeviceSentMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            destinationJid: string;
-            message?: Parameters<typeof Message.fromObject>[0];
-            phash: string;
-        } = {
+        const data: DeviceSentMessage.AsObject = {
             destinationJid: this.destinationJid,
             phash: this.phash
         };
@@ -8876,6 +8684,13 @@ export class DeviceSentMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): DeviceSentMessage {
         return DeviceSentMessage.deserialize(bytes);
     }
+}
+export namespace DeviceSentMessage {
+    export type AsObject = {
+        destinationJid: string;
+        message?: Message.AsObject;
+        phash: string;
+    };
 }
 export class Message extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -9224,34 +9039,7 @@ export class Message extends pb_1.Message {
     get has_deviceSentMessage() {
         return pb_1.Message.getField(this, 31) != null;
     }
-    static fromObject(data: {
-        conversation?: string;
-        senderKeyDistributionMessage?: Parameters<typeof SenderKeyDistributionMessage.fromObject>[0];
-        imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
-        contactMessage?: Parameters<typeof ContactMessage.fromObject>[0];
-        locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
-        extendedTextMessage?: Parameters<typeof ExtendedTextMessage.fromObject>[0];
-        documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
-        audioMessage?: Parameters<typeof AudioMessage.fromObject>[0];
-        videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
-        call?: Parameters<typeof Call.fromObject>[0];
-        chat?: Parameters<typeof Chat.fromObject>[0];
-        protocolMessage?: Parameters<typeof ProtocolMessage.fromObject>[0];
-        contactsArrayMessage?: Parameters<typeof ContactsArrayMessage.fromObject>[0];
-        highlyStructuredMessage?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-        fastRatchetKeySenderKeyDistributionMessage?: Parameters<typeof SenderKeyDistributionMessage.fromObject>[0];
-        sendPaymentMessage?: Parameters<typeof SendPaymentMessage.fromObject>[0];
-        liveLocationMessage?: Parameters<typeof LiveLocationMessage.fromObject>[0];
-        requestPaymentMessage?: Parameters<typeof RequestPaymentMessage.fromObject>[0];
-        declinePaymentRequestMessage?: Parameters<typeof DeclinePaymentRequestMessage.fromObject>[0];
-        cancelPaymentRequestMessage?: Parameters<typeof CancelPaymentRequestMessage.fromObject>[0];
-        templateMessage?: Parameters<typeof TemplateMessage.fromObject>[0];
-        stickerMessage?: Parameters<typeof StickerMessage.fromObject>[0];
-        groupInviteMessage?: Parameters<typeof GroupInviteMessage.fromObject>[0];
-        templateButtonReplyMessage?: Parameters<typeof TemplateButtonReplyMessage.fromObject>[0];
-        productMessage?: Parameters<typeof ProductMessage.fromObject>[0];
-        deviceSentMessage?: Parameters<typeof DeviceSentMessage.fromObject>[0];
-    }): Message {
+    static fromObject(data: RecursivePartial<Message.AsObject>): Message {
         const message = new Message({});
         if (data.conversation != null) {
             message.conversation = data.conversation;
@@ -9334,34 +9122,7 @@ export class Message extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            conversation: string;
-            senderKeyDistributionMessage?: Parameters<typeof SenderKeyDistributionMessage.fromObject>[0];
-            imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
-            contactMessage?: Parameters<typeof ContactMessage.fromObject>[0];
-            locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
-            extendedTextMessage?: Parameters<typeof ExtendedTextMessage.fromObject>[0];
-            documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
-            audioMessage?: Parameters<typeof AudioMessage.fromObject>[0];
-            videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
-            call?: Parameters<typeof Call.fromObject>[0];
-            chat?: Parameters<typeof Chat.fromObject>[0];
-            protocolMessage?: Parameters<typeof ProtocolMessage.fromObject>[0];
-            contactsArrayMessage?: Parameters<typeof ContactsArrayMessage.fromObject>[0];
-            highlyStructuredMessage?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
-            fastRatchetKeySenderKeyDistributionMessage?: Parameters<typeof SenderKeyDistributionMessage.fromObject>[0];
-            sendPaymentMessage?: Parameters<typeof SendPaymentMessage.fromObject>[0];
-            liveLocationMessage?: Parameters<typeof LiveLocationMessage.fromObject>[0];
-            requestPaymentMessage?: Parameters<typeof RequestPaymentMessage.fromObject>[0];
-            declinePaymentRequestMessage?: Parameters<typeof DeclinePaymentRequestMessage.fromObject>[0];
-            cancelPaymentRequestMessage?: Parameters<typeof CancelPaymentRequestMessage.fromObject>[0];
-            templateMessage?: Parameters<typeof TemplateMessage.fromObject>[0];
-            stickerMessage?: Parameters<typeof StickerMessage.fromObject>[0];
-            groupInviteMessage?: Parameters<typeof GroupInviteMessage.fromObject>[0];
-            templateButtonReplyMessage?: Parameters<typeof TemplateButtonReplyMessage.fromObject>[0];
-            productMessage?: Parameters<typeof ProductMessage.fromObject>[0];
-            deviceSentMessage?: Parameters<typeof DeviceSentMessage.fromObject>[0];
-        } = {
+        const data: Message.AsObject = {
             conversation: this.conversation
         };
         if (this.senderKeyDistributionMessage != null) {
@@ -9596,6 +9357,36 @@ export class Message extends pb_1.Message {
         return Message.deserialize(bytes);
     }
 }
+export namespace Message {
+    export type AsObject = {
+        conversation: string;
+        senderKeyDistributionMessage?: SenderKeyDistributionMessage.AsObject;
+        imageMessage?: ImageMessage.AsObject;
+        contactMessage?: ContactMessage.AsObject;
+        locationMessage?: LocationMessage.AsObject;
+        extendedTextMessage?: ExtendedTextMessage.AsObject;
+        documentMessage?: DocumentMessage.AsObject;
+        audioMessage?: AudioMessage.AsObject;
+        videoMessage?: VideoMessage.AsObject;
+        call?: Call.AsObject;
+        chat?: Chat.AsObject;
+        protocolMessage?: ProtocolMessage.AsObject;
+        contactsArrayMessage?: ContactsArrayMessage.AsObject;
+        highlyStructuredMessage?: HighlyStructuredMessage.AsObject;
+        fastRatchetKeySenderKeyDistributionMessage?: SenderKeyDistributionMessage.AsObject;
+        sendPaymentMessage?: SendPaymentMessage.AsObject;
+        liveLocationMessage?: LiveLocationMessage.AsObject;
+        requestPaymentMessage?: RequestPaymentMessage.AsObject;
+        declinePaymentRequestMessage?: DeclinePaymentRequestMessage.AsObject;
+        cancelPaymentRequestMessage?: CancelPaymentRequestMessage.AsObject;
+        templateMessage?: TemplateMessage.AsObject;
+        stickerMessage?: StickerMessage.AsObject;
+        groupInviteMessage?: GroupInviteMessage.AsObject;
+        templateButtonReplyMessage?: TemplateButtonReplyMessage.AsObject;
+        productMessage?: ProductMessage.AsObject;
+        deviceSentMessage?: DeviceSentMessage.AsObject;
+    };
+}
 export class MessageKey extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -9657,12 +9448,7 @@ export class MessageKey extends pb_1.Message {
     get has_participant() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: {
-        remoteJid?: string;
-        fromMe?: boolean;
-        id?: string;
-        participant?: string;
-    }): MessageKey {
+    static fromObject(data: RecursivePartial<MessageKey.AsObject>): MessageKey {
         const message = new MessageKey({});
         if (data.remoteJid != null) {
             message.remoteJid = data.remoteJid;
@@ -9679,12 +9465,7 @@ export class MessageKey extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            remoteJid: string;
-            fromMe: boolean;
-            id: string;
-            participant: string;
-        } = {
+        const data: MessageKey.AsObject = {
             remoteJid: this.remoteJid,
             fromMe: this.fromMe,
             id: this.id,
@@ -9736,6 +9517,14 @@ export class MessageKey extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): MessageKey {
         return MessageKey.deserialize(bytes);
     }
+}
+export namespace MessageKey {
+    export type AsObject = {
+        remoteJid: string;
+        fromMe: boolean;
+        id: string;
+        participant: string;
+    };
 }
 export class WebFeatures extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -10175,41 +9964,7 @@ export class WebFeatures extends pb_1.Message {
     get has_syncdRelease1() {
         return pb_1.Message.getField(this, 35) != null;
     }
-    static fromObject(data: {
-        labelsDisplay?: WebFeatures.WEB_FEATURES_FLAG;
-        voipIndividualOutgoing?: WebFeatures.WEB_FEATURES_FLAG;
-        groupsV3?: WebFeatures.WEB_FEATURES_FLAG;
-        groupsV3Create?: WebFeatures.WEB_FEATURES_FLAG;
-        changeNumberV2?: WebFeatures.WEB_FEATURES_FLAG;
-        queryStatusV3Thumbnail?: WebFeatures.WEB_FEATURES_FLAG;
-        liveLocations?: WebFeatures.WEB_FEATURES_FLAG;
-        queryVname?: WebFeatures.WEB_FEATURES_FLAG;
-        voipIndividualIncoming?: WebFeatures.WEB_FEATURES_FLAG;
-        quickRepliesQuery?: WebFeatures.WEB_FEATURES_FLAG;
-        payments?: WebFeatures.WEB_FEATURES_FLAG;
-        stickerPackQuery?: WebFeatures.WEB_FEATURES_FLAG;
-        liveLocationsFinal?: WebFeatures.WEB_FEATURES_FLAG;
-        labelsEdit?: WebFeatures.WEB_FEATURES_FLAG;
-        mediaUpload?: WebFeatures.WEB_FEATURES_FLAG;
-        mediaUploadRichQuickReplies?: WebFeatures.WEB_FEATURES_FLAG;
-        vnameV2?: WebFeatures.WEB_FEATURES_FLAG;
-        videoPlaybackUrl?: WebFeatures.WEB_FEATURES_FLAG;
-        statusRanking?: WebFeatures.WEB_FEATURES_FLAG;
-        voipIndividualVideo?: WebFeatures.WEB_FEATURES_FLAG;
-        thirdPartyStickers?: WebFeatures.WEB_FEATURES_FLAG;
-        frequentlyForwardedSetting?: WebFeatures.WEB_FEATURES_FLAG;
-        groupsV4JoinPermission?: WebFeatures.WEB_FEATURES_FLAG;
-        recentStickers?: WebFeatures.WEB_FEATURES_FLAG;
-        catalog?: WebFeatures.WEB_FEATURES_FLAG;
-        starredStickers?: WebFeatures.WEB_FEATURES_FLAG;
-        voipGroupCall?: WebFeatures.WEB_FEATURES_FLAG;
-        templateMessage?: WebFeatures.WEB_FEATURES_FLAG;
-        templateMessageInteractivity?: WebFeatures.WEB_FEATURES_FLAG;
-        ephemeralMessages?: WebFeatures.WEB_FEATURES_FLAG;
-        e2ENotificationSync?: WebFeatures.WEB_FEATURES_FLAG;
-        recentStickersV2?: WebFeatures.WEB_FEATURES_FLAG;
-        syncdRelease1?: WebFeatures.WEB_FEATURES_FLAG;
-    }): WebFeatures {
+    static fromObject(data: RecursivePartial<WebFeatures.AsObject>): WebFeatures {
         const message = new WebFeatures({});
         if (data.labelsDisplay != null) {
             message.labelsDisplay = data.labelsDisplay;
@@ -10313,41 +10068,7 @@ export class WebFeatures extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            labelsDisplay: WebFeatures.WEB_FEATURES_FLAG;
-            voipIndividualOutgoing: WebFeatures.WEB_FEATURES_FLAG;
-            groupsV3: WebFeatures.WEB_FEATURES_FLAG;
-            groupsV3Create: WebFeatures.WEB_FEATURES_FLAG;
-            changeNumberV2: WebFeatures.WEB_FEATURES_FLAG;
-            queryStatusV3Thumbnail: WebFeatures.WEB_FEATURES_FLAG;
-            liveLocations: WebFeatures.WEB_FEATURES_FLAG;
-            queryVname: WebFeatures.WEB_FEATURES_FLAG;
-            voipIndividualIncoming: WebFeatures.WEB_FEATURES_FLAG;
-            quickRepliesQuery: WebFeatures.WEB_FEATURES_FLAG;
-            payments: WebFeatures.WEB_FEATURES_FLAG;
-            stickerPackQuery: WebFeatures.WEB_FEATURES_FLAG;
-            liveLocationsFinal: WebFeatures.WEB_FEATURES_FLAG;
-            labelsEdit: WebFeatures.WEB_FEATURES_FLAG;
-            mediaUpload: WebFeatures.WEB_FEATURES_FLAG;
-            mediaUploadRichQuickReplies: WebFeatures.WEB_FEATURES_FLAG;
-            vnameV2: WebFeatures.WEB_FEATURES_FLAG;
-            videoPlaybackUrl: WebFeatures.WEB_FEATURES_FLAG;
-            statusRanking: WebFeatures.WEB_FEATURES_FLAG;
-            voipIndividualVideo: WebFeatures.WEB_FEATURES_FLAG;
-            thirdPartyStickers: WebFeatures.WEB_FEATURES_FLAG;
-            frequentlyForwardedSetting: WebFeatures.WEB_FEATURES_FLAG;
-            groupsV4JoinPermission: WebFeatures.WEB_FEATURES_FLAG;
-            recentStickers: WebFeatures.WEB_FEATURES_FLAG;
-            catalog: WebFeatures.WEB_FEATURES_FLAG;
-            starredStickers: WebFeatures.WEB_FEATURES_FLAG;
-            voipGroupCall: WebFeatures.WEB_FEATURES_FLAG;
-            templateMessage: WebFeatures.WEB_FEATURES_FLAG;
-            templateMessageInteractivity: WebFeatures.WEB_FEATURES_FLAG;
-            ephemeralMessages: WebFeatures.WEB_FEATURES_FLAG;
-            e2ENotificationSync: WebFeatures.WEB_FEATURES_FLAG;
-            recentStickersV2: WebFeatures.WEB_FEATURES_FLAG;
-            syncdRelease1: WebFeatures.WEB_FEATURES_FLAG;
-        } = {
+        const data: WebFeatures.AsObject = {
             labelsDisplay: this.labelsDisplay,
             voipIndividualOutgoing: this.voipIndividualOutgoing,
             groupsV3: this.groupsV3,
@@ -10575,6 +10296,41 @@ export class WebFeatures extends pb_1.Message {
     }
 }
 export namespace WebFeatures {
+    export type AsObject = {
+        labelsDisplay: WebFeatures.WEB_FEATURES_FLAG;
+        voipIndividualOutgoing: WebFeatures.WEB_FEATURES_FLAG;
+        groupsV3: WebFeatures.WEB_FEATURES_FLAG;
+        groupsV3Create: WebFeatures.WEB_FEATURES_FLAG;
+        changeNumberV2: WebFeatures.WEB_FEATURES_FLAG;
+        queryStatusV3Thumbnail: WebFeatures.WEB_FEATURES_FLAG;
+        liveLocations: WebFeatures.WEB_FEATURES_FLAG;
+        queryVname: WebFeatures.WEB_FEATURES_FLAG;
+        voipIndividualIncoming: WebFeatures.WEB_FEATURES_FLAG;
+        quickRepliesQuery: WebFeatures.WEB_FEATURES_FLAG;
+        payments: WebFeatures.WEB_FEATURES_FLAG;
+        stickerPackQuery: WebFeatures.WEB_FEATURES_FLAG;
+        liveLocationsFinal: WebFeatures.WEB_FEATURES_FLAG;
+        labelsEdit: WebFeatures.WEB_FEATURES_FLAG;
+        mediaUpload: WebFeatures.WEB_FEATURES_FLAG;
+        mediaUploadRichQuickReplies: WebFeatures.WEB_FEATURES_FLAG;
+        vnameV2: WebFeatures.WEB_FEATURES_FLAG;
+        videoPlaybackUrl: WebFeatures.WEB_FEATURES_FLAG;
+        statusRanking: WebFeatures.WEB_FEATURES_FLAG;
+        voipIndividualVideo: WebFeatures.WEB_FEATURES_FLAG;
+        thirdPartyStickers: WebFeatures.WEB_FEATURES_FLAG;
+        frequentlyForwardedSetting: WebFeatures.WEB_FEATURES_FLAG;
+        groupsV4JoinPermission: WebFeatures.WEB_FEATURES_FLAG;
+        recentStickers: WebFeatures.WEB_FEATURES_FLAG;
+        catalog: WebFeatures.WEB_FEATURES_FLAG;
+        starredStickers: WebFeatures.WEB_FEATURES_FLAG;
+        voipGroupCall: WebFeatures.WEB_FEATURES_FLAG;
+        templateMessage: WebFeatures.WEB_FEATURES_FLAG;
+        templateMessageInteractivity: WebFeatures.WEB_FEATURES_FLAG;
+        ephemeralMessages: WebFeatures.WEB_FEATURES_FLAG;
+        e2ENotificationSync: WebFeatures.WEB_FEATURES_FLAG;
+        recentStickersV2: WebFeatures.WEB_FEATURES_FLAG;
+        syncdRelease1: WebFeatures.WEB_FEATURES_FLAG;
+    };
     export enum WEB_FEATURES_FLAG {
         NOT_STARTED = 0,
         FORCE_UPGRADE = 1,
@@ -10638,12 +10394,7 @@ export class TabletNotificationsInfo extends pb_1.Message {
     set notifyMessage(value: NotificationMessageInfo[]) {
         pb_1.Message.setRepeatedWrapperField(this, 5, value);
     }
-    static fromObject(data: {
-        timestamp?: number;
-        unreadChats?: number;
-        notifyMessageCount?: number;
-        notifyMessage?: Parameters<typeof NotificationMessageInfo.fromObject>[0][];
-    }): TabletNotificationsInfo {
+    static fromObject(data: RecursivePartial<TabletNotificationsInfo.AsObject>): TabletNotificationsInfo {
         const message = new TabletNotificationsInfo({
             notifyMessage: data.notifyMessage.map(item => NotificationMessageInfo.fromObject(item))
         });
@@ -10659,12 +10410,7 @@ export class TabletNotificationsInfo extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            timestamp: number;
-            unreadChats: number;
-            notifyMessageCount: number;
-            notifyMessage: Parameters<typeof NotificationMessageInfo.fromObject>[0][];
-        } = {
+        const data: TabletNotificationsInfo.AsObject = {
             timestamp: this.timestamp,
             unreadChats: this.unreadChats,
             notifyMessageCount: this.notifyMessageCount,
@@ -10716,6 +10462,14 @@ export class TabletNotificationsInfo extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): TabletNotificationsInfo {
         return TabletNotificationsInfo.deserialize(bytes);
     }
+}
+export namespace TabletNotificationsInfo {
+    export type AsObject = {
+        timestamp: number;
+        unreadChats: number;
+        notifyMessageCount: number;
+        notifyMessage: NotificationMessageInfo.AsObject[];
+    };
 }
 export class NotificationMessageInfo extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -10778,12 +10532,7 @@ export class NotificationMessageInfo extends pb_1.Message {
     get has_participant() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: {
-        key?: Parameters<typeof MessageKey.fromObject>[0];
-        message?: Parameters<typeof Message.fromObject>[0];
-        messageTimestamp?: number;
-        participant?: string;
-    }): NotificationMessageInfo {
+    static fromObject(data: RecursivePartial<NotificationMessageInfo.AsObject>): NotificationMessageInfo {
         const message = new NotificationMessageInfo({});
         if (data.key != null) {
             message.key = MessageKey.fromObject(data.key);
@@ -10800,12 +10549,7 @@ export class NotificationMessageInfo extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            key?: Parameters<typeof MessageKey.fromObject>[0];
-            message?: Parameters<typeof Message.fromObject>[0];
-            messageTimestamp: number;
-            participant: string;
-        } = {
+        const data: NotificationMessageInfo.AsObject = {
             messageTimestamp: this.messageTimestamp,
             participant: this.participant
         };
@@ -10861,6 +10605,14 @@ export class NotificationMessageInfo extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): NotificationMessageInfo {
         return NotificationMessageInfo.deserialize(bytes);
     }
+}
+export namespace NotificationMessageInfo {
+    export type AsObject = {
+        key?: MessageKey.AsObject;
+        message?: Message.AsObject;
+        messageTimestamp: number;
+        participant: string;
+    };
 }
 export class WebNotificationsInfo extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -10918,12 +10670,7 @@ export class WebNotificationsInfo extends pb_1.Message {
     set notifyMessages(value: WebMessageInfo[]) {
         pb_1.Message.setRepeatedWrapperField(this, 5, value);
     }
-    static fromObject(data: {
-        timestamp?: number;
-        unreadChats?: number;
-        notifyMessageCount?: number;
-        notifyMessages?: Parameters<typeof WebMessageInfo.fromObject>[0][];
-    }): WebNotificationsInfo {
+    static fromObject(data: RecursivePartial<WebNotificationsInfo.AsObject>): WebNotificationsInfo {
         const message = new WebNotificationsInfo({
             notifyMessages: data.notifyMessages.map(item => WebMessageInfo.fromObject(item))
         });
@@ -10939,12 +10686,7 @@ export class WebNotificationsInfo extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            timestamp: number;
-            unreadChats: number;
-            notifyMessageCount: number;
-            notifyMessages: Parameters<typeof WebMessageInfo.fromObject>[0][];
-        } = {
+        const data: WebNotificationsInfo.AsObject = {
             timestamp: this.timestamp,
             unreadChats: this.unreadChats,
             notifyMessageCount: this.notifyMessageCount,
@@ -10996,6 +10738,14 @@ export class WebNotificationsInfo extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): WebNotificationsInfo {
         return WebNotificationsInfo.deserialize(bytes);
     }
+}
+export namespace WebNotificationsInfo {
+    export type AsObject = {
+        timestamp: number;
+        unreadChats: number;
+        notifyMessageCount: number;
+        notifyMessages: WebMessageInfo.AsObject[];
+    };
 }
 export class PaymentInfo extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -11136,18 +10886,7 @@ export class PaymentInfo extends pb_1.Message {
     get has_txnStatus() {
         return pb_1.Message.getField(this, 10) != null;
     }
-    static fromObject(data: {
-        currencyDeprecated?: PaymentInfo.PAYMENT_INFO_CURRENCY;
-        amount1000?: number;
-        receiverJid?: string;
-        status?: PaymentInfo.PAYMENT_INFO_STATUS;
-        transactionTimestamp?: number;
-        requestMessageKey?: Parameters<typeof MessageKey.fromObject>[0];
-        expiryTimestamp?: number;
-        futureproofed?: boolean;
-        currency?: string;
-        txnStatus?: PaymentInfo.PAYMENT_INFO_TXNSTATUS;
-    }): PaymentInfo {
+    static fromObject(data: RecursivePartial<PaymentInfo.AsObject>): PaymentInfo {
         const message = new PaymentInfo({});
         if (data.currencyDeprecated != null) {
             message.currencyDeprecated = data.currencyDeprecated;
@@ -11182,18 +10921,7 @@ export class PaymentInfo extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            currencyDeprecated: PaymentInfo.PAYMENT_INFO_CURRENCY;
-            amount1000: number;
-            receiverJid: string;
-            status: PaymentInfo.PAYMENT_INFO_STATUS;
-            transactionTimestamp: number;
-            requestMessageKey?: Parameters<typeof MessageKey.fromObject>[0];
-            expiryTimestamp: number;
-            futureproofed: boolean;
-            currency: string;
-            txnStatus: PaymentInfo.PAYMENT_INFO_TXNSTATUS;
-        } = {
+        const data: PaymentInfo.AsObject = {
             currencyDeprecated: this.currencyDeprecated,
             amount1000: this.amount1000,
             receiverJid: this.receiverJid,
@@ -11285,6 +11013,18 @@ export class PaymentInfo extends pb_1.Message {
     }
 }
 export namespace PaymentInfo {
+    export type AsObject = {
+        currencyDeprecated: PaymentInfo.PAYMENT_INFO_CURRENCY;
+        amount1000: number;
+        receiverJid: string;
+        status: PaymentInfo.PAYMENT_INFO_STATUS;
+        transactionTimestamp: number;
+        requestMessageKey?: MessageKey.AsObject;
+        expiryTimestamp: number;
+        futureproofed: boolean;
+        currency: string;
+        txnStatus: PaymentInfo.PAYMENT_INFO_TXNSTATUS;
+    };
     export enum PAYMENT_INFO_CURRENCY {
         UNKNOWN_CURRENCY = 0,
         INR = 1
@@ -11643,32 +11383,7 @@ export class WebMessageInfo extends pb_1.Message {
     get has_ephemeralOffToOn() {
         return pb_1.Message.getField(this, 34) != null;
     }
-    static fromObject(data: {
-        key?: Parameters<typeof MessageKey.fromObject>[0];
-        message?: Parameters<typeof Message.fromObject>[0];
-        messageTimestamp?: number;
-        status?: WebMessageInfo.WEB_MESSAGE_INFO_STATUS;
-        participant?: string;
-        ignore?: boolean;
-        starred?: boolean;
-        broadcast?: boolean;
-        pushName?: string;
-        mediaCiphertextSha256?: Uint8Array;
-        multicast?: boolean;
-        urlText?: boolean;
-        urlNumber?: boolean;
-        messageStubType?: WebMessageInfo.WEB_MESSAGE_INFO_STUBTYPE;
-        clearMedia?: boolean;
-        messageStubParameters?: string[];
-        duration?: number;
-        labels?: string[];
-        paymentInfo?: Parameters<typeof PaymentInfo.fromObject>[0];
-        finalLiveLocation?: Parameters<typeof LiveLocationMessage.fromObject>[0];
-        quotedPaymentInfo?: Parameters<typeof PaymentInfo.fromObject>[0];
-        ephemeralStartTimestamp?: number;
-        ephemeralDuration?: number;
-        ephemeralOffToOn?: boolean;
-    }): WebMessageInfo {
+    static fromObject(data: RecursivePartial<WebMessageInfo.AsObject>): WebMessageInfo {
         const message = new WebMessageInfo({
             key: MessageKey.fromObject(data.key),
             messageStubParameters: data.messageStubParameters,
@@ -11740,32 +11455,7 @@ export class WebMessageInfo extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            key?: Parameters<typeof MessageKey.fromObject>[0];
-            message?: Parameters<typeof Message.fromObject>[0];
-            messageTimestamp: number;
-            status: WebMessageInfo.WEB_MESSAGE_INFO_STATUS;
-            participant: string;
-            ignore: boolean;
-            starred: boolean;
-            broadcast: boolean;
-            pushName: string;
-            mediaCiphertextSha256: Uint8Array;
-            multicast: boolean;
-            urlText: boolean;
-            urlNumber: boolean;
-            messageStubType: WebMessageInfo.WEB_MESSAGE_INFO_STUBTYPE;
-            clearMedia: boolean;
-            messageStubParameters: string[];
-            duration: number;
-            labels: string[];
-            paymentInfo?: Parameters<typeof PaymentInfo.fromObject>[0];
-            finalLiveLocation?: Parameters<typeof LiveLocationMessage.fromObject>[0];
-            quotedPaymentInfo?: Parameters<typeof PaymentInfo.fromObject>[0];
-            ephemeralStartTimestamp: number;
-            ephemeralDuration: number;
-            ephemeralOffToOn: boolean;
-        } = {
+        const data: WebMessageInfo.AsObject = {
             messageTimestamp: this.messageTimestamp,
             status: this.status,
             participant: this.participant,
@@ -11949,6 +11639,32 @@ export class WebMessageInfo extends pb_1.Message {
     }
 }
 export namespace WebMessageInfo {
+    export type AsObject = {
+        key?: MessageKey.AsObject;
+        message?: Message.AsObject;
+        messageTimestamp: number;
+        status: WebMessageInfo.WEB_MESSAGE_INFO_STATUS;
+        participant: string;
+        ignore: boolean;
+        starred: boolean;
+        broadcast: boolean;
+        pushName: string;
+        mediaCiphertextSha256: Uint8Array;
+        multicast: boolean;
+        urlText: boolean;
+        urlNumber: boolean;
+        messageStubType: WebMessageInfo.WEB_MESSAGE_INFO_STUBTYPE;
+        clearMedia: boolean;
+        messageStubParameters: string[];
+        duration: number;
+        labels: string[];
+        paymentInfo?: PaymentInfo.AsObject;
+        finalLiveLocation?: LiveLocationMessage.AsObject;
+        quotedPaymentInfo?: PaymentInfo.AsObject;
+        ephemeralStartTimestamp: number;
+        ephemeralDuration: number;
+        ephemeralOffToOn: boolean;
+    };
     export enum WEB_MESSAGE_INFO_STATUS {
         ERROR = 0,
         PENDING = 1,

--- a/test/conformance/packedproto2/packed_proto2.ts
+++ b/test/conformance/packedproto2/packed_proto2.ts
@@ -54,15 +54,12 @@ export class HydratedQuickReplyButton extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayText?: string;
-            id?: string;
-        } = {};
-        if (this.displayText != null) {
-            data.displayText = this.displayText;
-        }
-        if (this.id != null) {
-            data.id = this.id;
-        }
+            displayText: string;
+            id: string;
+        } = {
+            displayText: this.displayText,
+            id: this.id
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -150,15 +147,12 @@ export class HydratedURLButton extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayText?: string;
-            url?: string;
-        } = {};
-        if (this.displayText != null) {
-            data.displayText = this.displayText;
-        }
-        if (this.url != null) {
-            data.url = this.url;
-        }
+            displayText: string;
+            url: string;
+        } = {
+            displayText: this.displayText,
+            url: this.url
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -246,15 +240,12 @@ export class HydratedCallButton extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayText?: string;
-            phoneNumber?: string;
-        } = {};
-        if (this.displayText != null) {
-            data.displayText = this.displayText;
-        }
-        if (this.phoneNumber != null) {
-            data.phoneNumber = this.phoneNumber;
-        }
+            displayText: string;
+            phoneNumber: string;
+        } = {
+            displayText: this.displayText,
+            phoneNumber: this.phoneNumber
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -375,9 +366,9 @@ export class HydratedTemplateButton extends pb_1.Message {
     }
     static fromObject(data: {
         index?: number;
-        quickReplyButton?: ReturnType<typeof HydratedQuickReplyButton.prototype.toObject>;
-        urlButton?: ReturnType<typeof HydratedURLButton.prototype.toObject>;
-        callButton?: ReturnType<typeof HydratedCallButton.prototype.toObject>;
+        quickReplyButton?: Parameters<typeof HydratedQuickReplyButton.fromObject>[0];
+        urlButton?: Parameters<typeof HydratedURLButton.fromObject>[0];
+        callButton?: Parameters<typeof HydratedCallButton.fromObject>[0];
     }): HydratedTemplateButton {
         const message = new HydratedTemplateButton({});
         if (data.index != null) {
@@ -396,14 +387,13 @@ export class HydratedTemplateButton extends pb_1.Message {
     }
     toObject() {
         const data: {
-            index?: number;
-            quickReplyButton?: ReturnType<typeof HydratedQuickReplyButton.prototype.toObject>;
-            urlButton?: ReturnType<typeof HydratedURLButton.prototype.toObject>;
-            callButton?: ReturnType<typeof HydratedCallButton.prototype.toObject>;
-        } = {};
-        if (this.index != null) {
-            data.index = this.index;
-        }
+            index: number;
+            quickReplyButton?: Parameters<typeof HydratedQuickReplyButton.fromObject>[0];
+            urlButton?: Parameters<typeof HydratedURLButton.fromObject>[0];
+            callButton?: Parameters<typeof HydratedCallButton.fromObject>[0];
+        } = {
+            index: this.index
+        };
         if (this.quickReplyButton != null) {
             data.quickReplyButton = this.quickReplyButton.toObject();
         }
@@ -496,7 +486,7 @@ export class QuickReplyButton extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     static fromObject(data: {
-        displayText?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
+        displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
         id?: string;
     }): QuickReplyButton {
         const message = new QuickReplyButton({});
@@ -510,14 +500,13 @@ export class QuickReplyButton extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayText?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-            id?: string;
-        } = {};
+            displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+            id: string;
+        } = {
+            id: this.id
+        };
         if (this.displayText != null) {
             data.displayText = this.displayText.toObject();
-        }
-        if (this.id != null) {
-            data.id = this.id;
         }
         return data;
     }
@@ -592,8 +581,8 @@ export class URLButton extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     static fromObject(data: {
-        displayText?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-        url?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
+        displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+        url?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
     }): URLButton {
         const message = new URLButton({});
         if (data.displayText != null) {
@@ -606,8 +595,8 @@ export class URLButton extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayText?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-            url?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
+            displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+            url?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
         } = {};
         if (this.displayText != null) {
             data.displayText = this.displayText.toObject();
@@ -688,8 +677,8 @@ export class CallButton extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     static fromObject(data: {
-        displayText?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-        phoneNumber?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
+        displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+        phoneNumber?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
     }): CallButton {
         const message = new CallButton({});
         if (data.displayText != null) {
@@ -702,8 +691,8 @@ export class CallButton extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayText?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-            phoneNumber?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
+            displayText?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+            phoneNumber?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
         } = {};
         if (this.displayText != null) {
             data.displayText = this.displayText.toObject();
@@ -831,9 +820,9 @@ export class TemplateButton extends pb_1.Message {
     }
     static fromObject(data: {
         index?: number;
-        quickReplyButton?: ReturnType<typeof QuickReplyButton.prototype.toObject>;
-        urlButton?: ReturnType<typeof URLButton.prototype.toObject>;
-        callButton?: ReturnType<typeof CallButton.prototype.toObject>;
+        quickReplyButton?: Parameters<typeof QuickReplyButton.fromObject>[0];
+        urlButton?: Parameters<typeof URLButton.fromObject>[0];
+        callButton?: Parameters<typeof CallButton.fromObject>[0];
     }): TemplateButton {
         const message = new TemplateButton({});
         if (data.index != null) {
@@ -852,14 +841,13 @@ export class TemplateButton extends pb_1.Message {
     }
     toObject() {
         const data: {
-            index?: number;
-            quickReplyButton?: ReturnType<typeof QuickReplyButton.prototype.toObject>;
-            urlButton?: ReturnType<typeof URLButton.prototype.toObject>;
-            callButton?: ReturnType<typeof CallButton.prototype.toObject>;
-        } = {};
-        if (this.index != null) {
-            data.index = this.index;
-        }
+            index: number;
+            quickReplyButton?: Parameters<typeof QuickReplyButton.fromObject>[0];
+            urlButton?: Parameters<typeof URLButton.fromObject>[0];
+            callButton?: Parameters<typeof CallButton.fromObject>[0];
+        } = {
+            index: this.index
+        };
         if (this.quickReplyButton != null) {
             data.quickReplyButton = this.quickReplyButton.toObject();
         }
@@ -983,19 +971,14 @@ export class Location extends pb_1.Message {
     }
     toObject() {
         const data: {
-            degreesLatitude?: number;
-            degreesLongitude?: number;
-            name?: string;
-        } = {};
-        if (this.degreesLatitude != null) {
-            data.degreesLatitude = this.degreesLatitude;
-        }
-        if (this.degreesLongitude != null) {
-            data.degreesLongitude = this.degreesLongitude;
-        }
-        if (this.name != null) {
-            data.name = this.name;
-        }
+            degreesLatitude: number;
+            degreesLongitude: number;
+            name: string;
+        } = {
+            degreesLatitude: this.degreesLatitude,
+            degreesLongitude: this.degreesLongitude,
+            name: this.name
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -1122,23 +1105,16 @@ export class Point extends pb_1.Message {
     }
     toObject() {
         const data: {
-            xDeprecated?: number;
-            yDeprecated?: number;
-            x?: number;
-            y?: number;
-        } = {};
-        if (this.xDeprecated != null) {
-            data.xDeprecated = this.xDeprecated;
-        }
-        if (this.yDeprecated != null) {
-            data.yDeprecated = this.yDeprecated;
-        }
-        if (this.x != null) {
-            data.x = this.x;
-        }
-        if (this.y != null) {
-            data.y = this.y;
-        }
+            xDeprecated: number;
+            yDeprecated: number;
+            x: number;
+            y: number;
+        } = {
+            xDeprecated: this.xDeprecated,
+            yDeprecated: this.yDeprecated,
+            x: this.x,
+            y: this.y
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -1227,8 +1203,8 @@ export class InteractiveAnnotation extends pb_1.Message {
         return cases[pb_1.Message.computeOneofCase(this, [2])];
     }
     static fromObject(data: {
-        polygonVertices?: ReturnType<typeof Point.prototype.toObject>[];
-        location?: ReturnType<typeof Location.prototype.toObject>;
+        polygonVertices?: Parameters<typeof Point.fromObject>[0][];
+        location?: Parameters<typeof Location.fromObject>[0];
     }): InteractiveAnnotation {
         const message = new InteractiveAnnotation({
             polygonVertices: data.polygonVertices.map(item => Point.fromObject(item))
@@ -1240,12 +1216,11 @@ export class InteractiveAnnotation extends pb_1.Message {
     }
     toObject() {
         const data: {
-            polygonVertices?: ReturnType<typeof Point.prototype.toObject>[];
-            location?: ReturnType<typeof Location.prototype.toObject>;
-        } = {};
-        if (this.polygonVertices != null) {
-            data.polygonVertices = this.polygonVertices.map((item: Point) => item.toObject());
-        }
+            polygonVertices: Parameters<typeof Point.fromObject>[0][];
+            location?: Parameters<typeof Location.fromObject>[0];
+        } = {
+            polygonVertices: this.polygonVertices.map((item: Point) => item.toObject())
+        };
         if (this.location != null) {
             data.location = this.location.toObject();
         }
@@ -1370,23 +1345,16 @@ export class AdReplyInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            advertiserName?: string;
-            mediaType?: AdReplyInfo.AD_REPLY_INFO_MEDIATYPE;
-            jpegThumbnail?: Uint8Array;
-            caption?: string;
-        } = {};
-        if (this.advertiserName != null) {
-            data.advertiserName = this.advertiserName;
-        }
-        if (this.mediaType != null) {
-            data.mediaType = this.mediaType;
-        }
-        if (this.jpegThumbnail != null) {
-            data.jpegThumbnail = this.jpegThumbnail;
-        }
-        if (this.caption != null) {
-            data.caption = this.caption;
-        }
+            advertiserName: string;
+            mediaType: AdReplyInfo.AD_REPLY_INFO_MEDIATYPE;
+            jpegThumbnail: Uint8Array;
+            caption: string;
+        } = {
+            advertiserName: this.advertiserName,
+            mediaType: this.mediaType,
+            jpegThumbnail: this.jpegThumbnail,
+            caption: this.caption
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -1643,16 +1611,16 @@ export class ContextInfo extends pb_1.Message {
     static fromObject(data: {
         stanzaId?: string;
         participant?: string;
-        quotedMessage?: ReturnType<typeof Message.prototype.toObject>;
+        quotedMessage?: Parameters<typeof Message.fromObject>[0];
         remoteJid?: string;
-        mentionedJid: string[];
+        mentionedJid?: string[];
         conversionSource?: string;
         conversionData?: Uint8Array;
         conversionDelaySeconds?: number;
         forwardingScore?: number;
         isForwarded?: boolean;
-        quotedAd?: ReturnType<typeof AdReplyInfo.prototype.toObject>;
-        placeholderKey?: ReturnType<typeof MessageKey.prototype.toObject>;
+        quotedAd?: Parameters<typeof AdReplyInfo.fromObject>[0];
+        placeholderKey?: Parameters<typeof MessageKey.fromObject>[0];
         expiration?: number;
         ephemeralSettingTimestamp?: number;
         ephemeralSharedSecret?: Uint8Array;
@@ -1706,65 +1674,43 @@ export class ContextInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            stanzaId?: string;
-            participant?: string;
-            quotedMessage?: ReturnType<typeof Message.prototype.toObject>;
-            remoteJid?: string;
+            stanzaId: string;
+            participant: string;
+            quotedMessage?: Parameters<typeof Message.fromObject>[0];
+            remoteJid: string;
             mentionedJid: string[];
-            conversionSource?: string;
-            conversionData?: Uint8Array;
-            conversionDelaySeconds?: number;
-            forwardingScore?: number;
-            isForwarded?: boolean;
-            quotedAd?: ReturnType<typeof AdReplyInfo.prototype.toObject>;
-            placeholderKey?: ReturnType<typeof MessageKey.prototype.toObject>;
-            expiration?: number;
-            ephemeralSettingTimestamp?: number;
-            ephemeralSharedSecret?: Uint8Array;
+            conversionSource: string;
+            conversionData: Uint8Array;
+            conversionDelaySeconds: number;
+            forwardingScore: number;
+            isForwarded: boolean;
+            quotedAd?: Parameters<typeof AdReplyInfo.fromObject>[0];
+            placeholderKey?: Parameters<typeof MessageKey.fromObject>[0];
+            expiration: number;
+            ephemeralSettingTimestamp: number;
+            ephemeralSharedSecret: Uint8Array;
         } = {
-            mentionedJid: this.mentionedJid
+            stanzaId: this.stanzaId,
+            participant: this.participant,
+            remoteJid: this.remoteJid,
+            mentionedJid: this.mentionedJid,
+            conversionSource: this.conversionSource,
+            conversionData: this.conversionData,
+            conversionDelaySeconds: this.conversionDelaySeconds,
+            forwardingScore: this.forwardingScore,
+            isForwarded: this.isForwarded,
+            expiration: this.expiration,
+            ephemeralSettingTimestamp: this.ephemeralSettingTimestamp,
+            ephemeralSharedSecret: this.ephemeralSharedSecret
         };
-        if (this.stanzaId != null) {
-            data.stanzaId = this.stanzaId;
-        }
-        if (this.participant != null) {
-            data.participant = this.participant;
-        }
         if (this.quotedMessage != null) {
             data.quotedMessage = this.quotedMessage.toObject();
-        }
-        if (this.remoteJid != null) {
-            data.remoteJid = this.remoteJid;
-        }
-        if (this.conversionSource != null) {
-            data.conversionSource = this.conversionSource;
-        }
-        if (this.conversionData != null) {
-            data.conversionData = this.conversionData;
-        }
-        if (this.conversionDelaySeconds != null) {
-            data.conversionDelaySeconds = this.conversionDelaySeconds;
-        }
-        if (this.forwardingScore != null) {
-            data.forwardingScore = this.forwardingScore;
-        }
-        if (this.isForwarded != null) {
-            data.isForwarded = this.isForwarded;
         }
         if (this.quotedAd != null) {
             data.quotedAd = this.quotedAd.toObject();
         }
         if (this.placeholderKey != null) {
             data.placeholderKey = this.placeholderKey.toObject();
-        }
-        if (this.expiration != null) {
-            data.expiration = this.expiration;
-        }
-        if (this.ephemeralSettingTimestamp != null) {
-            data.ephemeralSettingTimestamp = this.ephemeralSettingTimestamp;
-        }
-        if (this.ephemeralSharedSecret != null) {
-            data.ephemeralSharedSecret = this.ephemeralSharedSecret;
         }
         return data;
     }
@@ -1918,15 +1864,12 @@ export class SenderKeyDistributionMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            groupId?: string;
-            axolotlSenderKeyDistributionMessage?: Uint8Array;
-        } = {};
-        if (this.groupId != null) {
-            data.groupId = this.groupId;
-        }
-        if (this.axolotlSenderKeyDistributionMessage != null) {
-            data.axolotlSenderKeyDistributionMessage = this.axolotlSenderKeyDistributionMessage;
-        }
+            groupId: string;
+            axolotlSenderKeyDistributionMessage: Uint8Array;
+        } = {
+            groupId: this.groupId,
+            axolotlSenderKeyDistributionMessage: this.axolotlSenderKeyDistributionMessage
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -2246,16 +2189,16 @@ export class ImageMessage extends pb_1.Message {
         width?: number;
         mediaKey?: Uint8Array;
         fileEncSha256?: Uint8Array;
-        interactiveAnnotations?: ReturnType<typeof InteractiveAnnotation.prototype.toObject>[];
+        interactiveAnnotations?: Parameters<typeof InteractiveAnnotation.fromObject>[0][];
         directPath?: string;
         mediaKeyTimestamp?: number;
         jpegThumbnail?: Uint8Array;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
         firstScanSidecar?: Uint8Array;
         firstScanLength?: number;
         experimentGroupId?: number;
         scansSidecar?: Uint8Array;
-        scanLengths: number[];
+        scanLengths?: number[];
         midQualityFileSha256?: Uint8Array;
         midQualityFileEncSha256?: Uint8Array;
     }): ImageMessage {
@@ -2324,89 +2267,51 @@ export class ImageMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            url?: string;
-            mimetype?: string;
-            caption?: string;
-            fileSha256?: Uint8Array;
-            fileLength?: number;
-            height?: number;
-            width?: number;
-            mediaKey?: Uint8Array;
-            fileEncSha256?: Uint8Array;
-            interactiveAnnotations?: ReturnType<typeof InteractiveAnnotation.prototype.toObject>[];
-            directPath?: string;
-            mediaKeyTimestamp?: number;
-            jpegThumbnail?: Uint8Array;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-            firstScanSidecar?: Uint8Array;
-            firstScanLength?: number;
-            experimentGroupId?: number;
-            scansSidecar?: Uint8Array;
+            url: string;
+            mimetype: string;
+            caption: string;
+            fileSha256: Uint8Array;
+            fileLength: number;
+            height: number;
+            width: number;
+            mediaKey: Uint8Array;
+            fileEncSha256: Uint8Array;
+            interactiveAnnotations: Parameters<typeof InteractiveAnnotation.fromObject>[0][];
+            directPath: string;
+            mediaKeyTimestamp: number;
+            jpegThumbnail: Uint8Array;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+            firstScanSidecar: Uint8Array;
+            firstScanLength: number;
+            experimentGroupId: number;
+            scansSidecar: Uint8Array;
             scanLengths: number[];
-            midQualityFileSha256?: Uint8Array;
-            midQualityFileEncSha256?: Uint8Array;
+            midQualityFileSha256: Uint8Array;
+            midQualityFileEncSha256: Uint8Array;
         } = {
-            scanLengths: this.scanLengths
+            url: this.url,
+            mimetype: this.mimetype,
+            caption: this.caption,
+            fileSha256: this.fileSha256,
+            fileLength: this.fileLength,
+            height: this.height,
+            width: this.width,
+            mediaKey: this.mediaKey,
+            fileEncSha256: this.fileEncSha256,
+            interactiveAnnotations: this.interactiveAnnotations.map((item: InteractiveAnnotation) => item.toObject()),
+            directPath: this.directPath,
+            mediaKeyTimestamp: this.mediaKeyTimestamp,
+            jpegThumbnail: this.jpegThumbnail,
+            firstScanSidecar: this.firstScanSidecar,
+            firstScanLength: this.firstScanLength,
+            experimentGroupId: this.experimentGroupId,
+            scansSidecar: this.scansSidecar,
+            scanLengths: this.scanLengths,
+            midQualityFileSha256: this.midQualityFileSha256,
+            midQualityFileEncSha256: this.midQualityFileEncSha256
         };
-        if (this.url != null) {
-            data.url = this.url;
-        }
-        if (this.mimetype != null) {
-            data.mimetype = this.mimetype;
-        }
-        if (this.caption != null) {
-            data.caption = this.caption;
-        }
-        if (this.fileSha256 != null) {
-            data.fileSha256 = this.fileSha256;
-        }
-        if (this.fileLength != null) {
-            data.fileLength = this.fileLength;
-        }
-        if (this.height != null) {
-            data.height = this.height;
-        }
-        if (this.width != null) {
-            data.width = this.width;
-        }
-        if (this.mediaKey != null) {
-            data.mediaKey = this.mediaKey;
-        }
-        if (this.fileEncSha256 != null) {
-            data.fileEncSha256 = this.fileEncSha256;
-        }
-        if (this.interactiveAnnotations != null) {
-            data.interactiveAnnotations = this.interactiveAnnotations.map((item: InteractiveAnnotation) => item.toObject());
-        }
-        if (this.directPath != null) {
-            data.directPath = this.directPath;
-        }
-        if (this.mediaKeyTimestamp != null) {
-            data.mediaKeyTimestamp = this.mediaKeyTimestamp;
-        }
-        if (this.jpegThumbnail != null) {
-            data.jpegThumbnail = this.jpegThumbnail;
-        }
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
-        }
-        if (this.firstScanSidecar != null) {
-            data.firstScanSidecar = this.firstScanSidecar;
-        }
-        if (this.firstScanLength != null) {
-            data.firstScanLength = this.firstScanLength;
-        }
-        if (this.experimentGroupId != null) {
-            data.experimentGroupId = this.experimentGroupId;
-        }
-        if (this.scansSidecar != null) {
-            data.scansSidecar = this.scansSidecar;
-        }
-        if (this.midQualityFileSha256 != null) {
-            data.midQualityFileSha256 = this.midQualityFileSha256;
-        }
-        if (this.midQualityFileEncSha256 != null) {
-            data.midQualityFileEncSha256 = this.midQualityFileEncSha256;
         }
         return data;
     }
@@ -2591,7 +2496,7 @@ export class ContactMessage extends pb_1.Message {
     static fromObject(data: {
         displayName?: string;
         vcard?: string;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
     }): ContactMessage {
         const message = new ContactMessage({});
         if (data.displayName != null) {
@@ -2607,16 +2512,13 @@ export class ContactMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayName?: string;
-            vcard?: string;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        } = {};
-        if (this.displayName != null) {
-            data.displayName = this.displayName;
-        }
-        if (this.vcard != null) {
-            data.vcard = this.vcard;
-        }
+            displayName: string;
+            vcard: string;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        } = {
+            displayName: this.displayName,
+            vcard: this.vcard
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
         }
@@ -2839,7 +2741,7 @@ export class LocationMessage extends pb_1.Message {
         degreesClockwiseFromMagneticNorth?: number;
         comment?: string;
         jpegThumbnail?: Uint8Array;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
     }): LocationMessage {
         const message = new LocationMessage({});
         if (data.degreesLatitude != null) {
@@ -2882,52 +2784,31 @@ export class LocationMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            degreesLatitude?: number;
-            degreesLongitude?: number;
-            name?: string;
-            address?: string;
-            url?: string;
-            isLive?: boolean;
-            accuracyInMeters?: number;
-            speedInMps?: number;
-            degreesClockwiseFromMagneticNorth?: number;
-            comment?: string;
-            jpegThumbnail?: Uint8Array;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        } = {};
-        if (this.degreesLatitude != null) {
-            data.degreesLatitude = this.degreesLatitude;
-        }
-        if (this.degreesLongitude != null) {
-            data.degreesLongitude = this.degreesLongitude;
-        }
-        if (this.name != null) {
-            data.name = this.name;
-        }
-        if (this.address != null) {
-            data.address = this.address;
-        }
-        if (this.url != null) {
-            data.url = this.url;
-        }
-        if (this.isLive != null) {
-            data.isLive = this.isLive;
-        }
-        if (this.accuracyInMeters != null) {
-            data.accuracyInMeters = this.accuracyInMeters;
-        }
-        if (this.speedInMps != null) {
-            data.speedInMps = this.speedInMps;
-        }
-        if (this.degreesClockwiseFromMagneticNorth != null) {
-            data.degreesClockwiseFromMagneticNorth = this.degreesClockwiseFromMagneticNorth;
-        }
-        if (this.comment != null) {
-            data.comment = this.comment;
-        }
-        if (this.jpegThumbnail != null) {
-            data.jpegThumbnail = this.jpegThumbnail;
-        }
+            degreesLatitude: number;
+            degreesLongitude: number;
+            name: string;
+            address: string;
+            url: string;
+            isLive: boolean;
+            accuracyInMeters: number;
+            speedInMps: number;
+            degreesClockwiseFromMagneticNorth: number;
+            comment: string;
+            jpegThumbnail: Uint8Array;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        } = {
+            degreesLatitude: this.degreesLatitude,
+            degreesLongitude: this.degreesLongitude,
+            name: this.name,
+            address: this.address,
+            url: this.url,
+            isLive: this.isLive,
+            accuracyInMeters: this.accuracyInMeters,
+            speedInMps: this.speedInMps,
+            degreesClockwiseFromMagneticNorth: this.degreesClockwiseFromMagneticNorth,
+            comment: this.comment,
+            jpegThumbnail: this.jpegThumbnail
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
         }
@@ -3194,7 +3075,7 @@ export class ExtendedTextMessage extends pb_1.Message {
         font?: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_FONTTYPE;
         previewType?: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_PREVIEWTYPE;
         jpegThumbnail?: Uint8Array;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
         doNotPlayInline?: boolean;
     }): ExtendedTextMessage {
         const message = new ExtendedTextMessage({});
@@ -3238,54 +3119,33 @@ export class ExtendedTextMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            text?: string;
-            matchedText?: string;
-            canonicalUrl?: string;
-            description?: string;
-            title?: string;
-            textArgb?: number;
-            backgroundArgb?: number;
-            font?: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_FONTTYPE;
-            previewType?: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_PREVIEWTYPE;
-            jpegThumbnail?: Uint8Array;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-            doNotPlayInline?: boolean;
-        } = {};
-        if (this.text != null) {
-            data.text = this.text;
-        }
-        if (this.matchedText != null) {
-            data.matchedText = this.matchedText;
-        }
-        if (this.canonicalUrl != null) {
-            data.canonicalUrl = this.canonicalUrl;
-        }
-        if (this.description != null) {
-            data.description = this.description;
-        }
-        if (this.title != null) {
-            data.title = this.title;
-        }
-        if (this.textArgb != null) {
-            data.textArgb = this.textArgb;
-        }
-        if (this.backgroundArgb != null) {
-            data.backgroundArgb = this.backgroundArgb;
-        }
-        if (this.font != null) {
-            data.font = this.font;
-        }
-        if (this.previewType != null) {
-            data.previewType = this.previewType;
-        }
-        if (this.jpegThumbnail != null) {
-            data.jpegThumbnail = this.jpegThumbnail;
-        }
+            text: string;
+            matchedText: string;
+            canonicalUrl: string;
+            description: string;
+            title: string;
+            textArgb: number;
+            backgroundArgb: number;
+            font: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_FONTTYPE;
+            previewType: ExtendedTextMessage.EXTENDED_TEXT_MESSAGE_PREVIEWTYPE;
+            jpegThumbnail: Uint8Array;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+            doNotPlayInline: boolean;
+        } = {
+            text: this.text,
+            matchedText: this.matchedText,
+            canonicalUrl: this.canonicalUrl,
+            description: this.description,
+            title: this.title,
+            textArgb: this.textArgb,
+            backgroundArgb: this.backgroundArgb,
+            font: this.font,
+            previewType: this.previewType,
+            jpegThumbnail: this.jpegThumbnail,
+            doNotPlayInline: this.doNotPlayInline
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
-        }
-        if (this.doNotPlayInline != null) {
-            data.doNotPlayInline = this.doNotPlayInline;
         }
         return data;
     }
@@ -3579,7 +3439,7 @@ export class DocumentMessage extends pb_1.Message {
         directPath?: string;
         mediaKeyTimestamp?: number;
         jpegThumbnail?: Uint8Array;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
     }): DocumentMessage {
         const message = new DocumentMessage({});
         if (data.url != null) {
@@ -3625,56 +3485,33 @@ export class DocumentMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            url?: string;
-            mimetype?: string;
-            title?: string;
-            fileSha256?: Uint8Array;
-            fileLength?: number;
-            pageCount?: number;
-            mediaKey?: Uint8Array;
-            fileName?: string;
-            fileEncSha256?: Uint8Array;
-            directPath?: string;
-            mediaKeyTimestamp?: number;
-            jpegThumbnail?: Uint8Array;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        } = {};
-        if (this.url != null) {
-            data.url = this.url;
-        }
-        if (this.mimetype != null) {
-            data.mimetype = this.mimetype;
-        }
-        if (this.title != null) {
-            data.title = this.title;
-        }
-        if (this.fileSha256 != null) {
-            data.fileSha256 = this.fileSha256;
-        }
-        if (this.fileLength != null) {
-            data.fileLength = this.fileLength;
-        }
-        if (this.pageCount != null) {
-            data.pageCount = this.pageCount;
-        }
-        if (this.mediaKey != null) {
-            data.mediaKey = this.mediaKey;
-        }
-        if (this.fileName != null) {
-            data.fileName = this.fileName;
-        }
-        if (this.fileEncSha256 != null) {
-            data.fileEncSha256 = this.fileEncSha256;
-        }
-        if (this.directPath != null) {
-            data.directPath = this.directPath;
-        }
-        if (this.mediaKeyTimestamp != null) {
-            data.mediaKeyTimestamp = this.mediaKeyTimestamp;
-        }
-        if (this.jpegThumbnail != null) {
-            data.jpegThumbnail = this.jpegThumbnail;
-        }
+            url: string;
+            mimetype: string;
+            title: string;
+            fileSha256: Uint8Array;
+            fileLength: number;
+            pageCount: number;
+            mediaKey: Uint8Array;
+            fileName: string;
+            fileEncSha256: Uint8Array;
+            directPath: string;
+            mediaKeyTimestamp: number;
+            jpegThumbnail: Uint8Array;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        } = {
+            url: this.url,
+            mimetype: this.mimetype,
+            title: this.title,
+            fileSha256: this.fileSha256,
+            fileLength: this.fileLength,
+            pageCount: this.pageCount,
+            mediaKey: this.mediaKey,
+            fileName: this.fileName,
+            fileEncSha256: this.fileEncSha256,
+            directPath: this.directPath,
+            mediaKeyTimestamp: this.mediaKeyTimestamp,
+            jpegThumbnail: this.jpegThumbnail
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
         }
@@ -3946,7 +3783,7 @@ export class AudioMessage extends pb_1.Message {
         fileEncSha256?: Uint8Array;
         directPath?: string;
         mediaKeyTimestamp?: number;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
         streamingSidecar?: Uint8Array;
     }): AudioMessage {
         const message = new AudioMessage({});
@@ -3990,54 +3827,33 @@ export class AudioMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            url?: string;
-            mimetype?: string;
-            fileSha256?: Uint8Array;
-            fileLength?: number;
-            seconds?: number;
-            ptt?: boolean;
-            mediaKey?: Uint8Array;
-            fileEncSha256?: Uint8Array;
-            directPath?: string;
-            mediaKeyTimestamp?: number;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-            streamingSidecar?: Uint8Array;
-        } = {};
-        if (this.url != null) {
-            data.url = this.url;
-        }
-        if (this.mimetype != null) {
-            data.mimetype = this.mimetype;
-        }
-        if (this.fileSha256 != null) {
-            data.fileSha256 = this.fileSha256;
-        }
-        if (this.fileLength != null) {
-            data.fileLength = this.fileLength;
-        }
-        if (this.seconds != null) {
-            data.seconds = this.seconds;
-        }
-        if (this.ptt != null) {
-            data.ptt = this.ptt;
-        }
-        if (this.mediaKey != null) {
-            data.mediaKey = this.mediaKey;
-        }
-        if (this.fileEncSha256 != null) {
-            data.fileEncSha256 = this.fileEncSha256;
-        }
-        if (this.directPath != null) {
-            data.directPath = this.directPath;
-        }
-        if (this.mediaKeyTimestamp != null) {
-            data.mediaKeyTimestamp = this.mediaKeyTimestamp;
-        }
+            url: string;
+            mimetype: string;
+            fileSha256: Uint8Array;
+            fileLength: number;
+            seconds: number;
+            ptt: boolean;
+            mediaKey: Uint8Array;
+            fileEncSha256: Uint8Array;
+            directPath: string;
+            mediaKeyTimestamp: number;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+            streamingSidecar: Uint8Array;
+        } = {
+            url: this.url,
+            mimetype: this.mimetype,
+            fileSha256: this.fileSha256,
+            fileLength: this.fileLength,
+            seconds: this.seconds,
+            ptt: this.ptt,
+            mediaKey: this.mediaKey,
+            fileEncSha256: this.fileEncSha256,
+            directPath: this.directPath,
+            mediaKeyTimestamp: this.mediaKeyTimestamp,
+            streamingSidecar: this.streamingSidecar
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
-        }
-        if (this.streamingSidecar != null) {
-            data.streamingSidecar = this.streamingSidecar;
         }
         return data;
     }
@@ -4376,11 +4192,11 @@ export class VideoMessage extends pb_1.Message {
         height?: number;
         width?: number;
         fileEncSha256?: Uint8Array;
-        interactiveAnnotations?: ReturnType<typeof InteractiveAnnotation.prototype.toObject>[];
+        interactiveAnnotations?: Parameters<typeof InteractiveAnnotation.fromObject>[0][];
         directPath?: string;
         mediaKeyTimestamp?: number;
         jpegThumbnail?: Uint8Array;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
         streamingSidecar?: Uint8Array;
         gifAttribution?: VideoMessage.VIDEO_MESSAGE_ATTRIBUTION;
     }): VideoMessage {
@@ -4442,78 +4258,45 @@ export class VideoMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            url?: string;
-            mimetype?: string;
-            fileSha256?: Uint8Array;
-            fileLength?: number;
-            seconds?: number;
-            mediaKey?: Uint8Array;
-            caption?: string;
-            gifPlayback?: boolean;
-            height?: number;
-            width?: number;
-            fileEncSha256?: Uint8Array;
-            interactiveAnnotations?: ReturnType<typeof InteractiveAnnotation.prototype.toObject>[];
-            directPath?: string;
-            mediaKeyTimestamp?: number;
-            jpegThumbnail?: Uint8Array;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-            streamingSidecar?: Uint8Array;
-            gifAttribution?: VideoMessage.VIDEO_MESSAGE_ATTRIBUTION;
-        } = {};
-        if (this.url != null) {
-            data.url = this.url;
-        }
-        if (this.mimetype != null) {
-            data.mimetype = this.mimetype;
-        }
-        if (this.fileSha256 != null) {
-            data.fileSha256 = this.fileSha256;
-        }
-        if (this.fileLength != null) {
-            data.fileLength = this.fileLength;
-        }
-        if (this.seconds != null) {
-            data.seconds = this.seconds;
-        }
-        if (this.mediaKey != null) {
-            data.mediaKey = this.mediaKey;
-        }
-        if (this.caption != null) {
-            data.caption = this.caption;
-        }
-        if (this.gifPlayback != null) {
-            data.gifPlayback = this.gifPlayback;
-        }
-        if (this.height != null) {
-            data.height = this.height;
-        }
-        if (this.width != null) {
-            data.width = this.width;
-        }
-        if (this.fileEncSha256 != null) {
-            data.fileEncSha256 = this.fileEncSha256;
-        }
-        if (this.interactiveAnnotations != null) {
-            data.interactiveAnnotations = this.interactiveAnnotations.map((item: InteractiveAnnotation) => item.toObject());
-        }
-        if (this.directPath != null) {
-            data.directPath = this.directPath;
-        }
-        if (this.mediaKeyTimestamp != null) {
-            data.mediaKeyTimestamp = this.mediaKeyTimestamp;
-        }
-        if (this.jpegThumbnail != null) {
-            data.jpegThumbnail = this.jpegThumbnail;
-        }
+            url: string;
+            mimetype: string;
+            fileSha256: Uint8Array;
+            fileLength: number;
+            seconds: number;
+            mediaKey: Uint8Array;
+            caption: string;
+            gifPlayback: boolean;
+            height: number;
+            width: number;
+            fileEncSha256: Uint8Array;
+            interactiveAnnotations: Parameters<typeof InteractiveAnnotation.fromObject>[0][];
+            directPath: string;
+            mediaKeyTimestamp: number;
+            jpegThumbnail: Uint8Array;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+            streamingSidecar: Uint8Array;
+            gifAttribution: VideoMessage.VIDEO_MESSAGE_ATTRIBUTION;
+        } = {
+            url: this.url,
+            mimetype: this.mimetype,
+            fileSha256: this.fileSha256,
+            fileLength: this.fileLength,
+            seconds: this.seconds,
+            mediaKey: this.mediaKey,
+            caption: this.caption,
+            gifPlayback: this.gifPlayback,
+            height: this.height,
+            width: this.width,
+            fileEncSha256: this.fileEncSha256,
+            interactiveAnnotations: this.interactiveAnnotations.map((item: InteractiveAnnotation) => item.toObject()),
+            directPath: this.directPath,
+            mediaKeyTimestamp: this.mediaKeyTimestamp,
+            jpegThumbnail: this.jpegThumbnail,
+            streamingSidecar: this.streamingSidecar,
+            gifAttribution: this.gifAttribution
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
-        }
-        if (this.streamingSidecar != null) {
-            data.streamingSidecar = this.streamingSidecar;
-        }
-        if (this.gifAttribution != null) {
-            data.gifAttribution = this.gifAttribution;
         }
         return data;
     }
@@ -4672,11 +4455,10 @@ export class Call extends pb_1.Message {
     }
     toObject() {
         const data: {
-            callKey?: Uint8Array;
-        } = {};
-        if (this.callKey != null) {
-            data.callKey = this.callKey;
-        }
+            callKey: Uint8Array;
+        } = {
+            callKey: this.callKey
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -4759,15 +4541,12 @@ export class Chat extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayName?: string;
-            id?: string;
-        } = {};
-        if (this.displayName != null) {
-            data.displayName = this.displayName;
-        }
-        if (this.id != null) {
-            data.id = this.id;
-        }
+            displayName: string;
+            id: string;
+        } = {
+            displayName: this.displayName,
+            id: this.id
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -4880,11 +4659,11 @@ export class ProtocolMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 6) != null;
     }
     static fromObject(data: {
-        key?: ReturnType<typeof MessageKey.prototype.toObject>;
+        key?: Parameters<typeof MessageKey.fromObject>[0];
         type?: ProtocolMessage.PROTOCOL_MESSAGE_TYPE;
         ephemeralExpiration?: number;
         ephemeralSettingTimestamp?: number;
-        historySyncNotification?: ReturnType<typeof HistorySyncNotification.prototype.toObject>;
+        historySyncNotification?: Parameters<typeof HistorySyncNotification.fromObject>[0];
     }): ProtocolMessage {
         const message = new ProtocolMessage({});
         if (data.key != null) {
@@ -4906,23 +4685,18 @@ export class ProtocolMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            key?: ReturnType<typeof MessageKey.prototype.toObject>;
-            type?: ProtocolMessage.PROTOCOL_MESSAGE_TYPE;
-            ephemeralExpiration?: number;
-            ephemeralSettingTimestamp?: number;
-            historySyncNotification?: ReturnType<typeof HistorySyncNotification.prototype.toObject>;
-        } = {};
+            key?: Parameters<typeof MessageKey.fromObject>[0];
+            type: ProtocolMessage.PROTOCOL_MESSAGE_TYPE;
+            ephemeralExpiration: number;
+            ephemeralSettingTimestamp: number;
+            historySyncNotification?: Parameters<typeof HistorySyncNotification.fromObject>[0];
+        } = {
+            type: this.type,
+            ephemeralExpiration: this.ephemeralExpiration,
+            ephemeralSettingTimestamp: this.ephemeralSettingTimestamp
+        };
         if (this.key != null) {
             data.key = this.key.toObject();
-        }
-        if (this.type != null) {
-            data.type = this.type;
-        }
-        if (this.ephemeralExpiration != null) {
-            data.ephemeralExpiration = this.ephemeralExpiration;
-        }
-        if (this.ephemeralSettingTimestamp != null) {
-            data.ephemeralSettingTimestamp = this.ephemeralSettingTimestamp;
         }
         if (this.historySyncNotification != null) {
             data.historySyncNotification = this.historySyncNotification.toObject();
@@ -5139,39 +4913,24 @@ export class HistorySyncNotification extends pb_1.Message {
     }
     toObject() {
         const data: {
-            fileSha256?: Uint8Array;
-            fileLength?: number;
-            mediaKey?: Uint8Array;
-            fileEncSha256?: Uint8Array;
-            directPath?: string;
-            syncType?: HistorySyncNotification.HISTORY_SYNC_NOTIFICATION_HISTORYSYNCTYPE;
-            chunkOrder?: number;
-            originalMessageId?: string;
-        } = {};
-        if (this.fileSha256 != null) {
-            data.fileSha256 = this.fileSha256;
-        }
-        if (this.fileLength != null) {
-            data.fileLength = this.fileLength;
-        }
-        if (this.mediaKey != null) {
-            data.mediaKey = this.mediaKey;
-        }
-        if (this.fileEncSha256 != null) {
-            data.fileEncSha256 = this.fileEncSha256;
-        }
-        if (this.directPath != null) {
-            data.directPath = this.directPath;
-        }
-        if (this.syncType != null) {
-            data.syncType = this.syncType;
-        }
-        if (this.chunkOrder != null) {
-            data.chunkOrder = this.chunkOrder;
-        }
-        if (this.originalMessageId != null) {
-            data.originalMessageId = this.originalMessageId;
-        }
+            fileSha256: Uint8Array;
+            fileLength: number;
+            mediaKey: Uint8Array;
+            fileEncSha256: Uint8Array;
+            directPath: string;
+            syncType: HistorySyncNotification.HISTORY_SYNC_NOTIFICATION_HISTORYSYNCTYPE;
+            chunkOrder: number;
+            originalMessageId: string;
+        } = {
+            fileSha256: this.fileSha256,
+            fileLength: this.fileLength,
+            mediaKey: this.mediaKey,
+            fileEncSha256: this.fileEncSha256,
+            directPath: this.directPath,
+            syncType: this.syncType,
+            chunkOrder: this.chunkOrder,
+            originalMessageId: this.originalMessageId
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -5293,8 +5052,8 @@ export class ContactsArrayMessage extends pb_1.Message {
     }
     static fromObject(data: {
         displayName?: string;
-        contacts?: ReturnType<typeof ContactMessage.prototype.toObject>[];
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contacts?: Parameters<typeof ContactMessage.fromObject>[0][];
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
     }): ContactsArrayMessage {
         const message = new ContactsArrayMessage({
             contacts: data.contacts.map(item => ContactMessage.fromObject(item))
@@ -5309,16 +5068,13 @@ export class ContactsArrayMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            displayName?: string;
-            contacts?: ReturnType<typeof ContactMessage.prototype.toObject>[];
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        } = {};
-        if (this.displayName != null) {
-            data.displayName = this.displayName;
-        }
-        if (this.contacts != null) {
-            data.contacts = this.contacts.map((item: ContactMessage) => item.toObject());
-        }
+            displayName: string;
+            contacts: Parameters<typeof ContactMessage.fromObject>[0][];
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        } = {
+            displayName: this.displayName,
+            contacts: this.contacts.map((item: ContactMessage) => item.toObject())
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
         }
@@ -5414,15 +5170,12 @@ export class HSMCurrency extends pb_1.Message {
     }
     toObject() {
         const data: {
-            currencyCode?: string;
-            amount1000?: number;
-        } = {};
-        if (this.currencyCode != null) {
-            data.currencyCode = this.currencyCode;
-        }
-        if (this.amount1000 != null) {
-            data.amount1000 = this.amount1000;
-        }
+            currencyCode: string;
+            amount1000: number;
+        } = {
+            currencyCode: this.currencyCode,
+            amount1000: this.amount1000
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -5595,35 +5348,22 @@ export class HSMDateTimeComponent extends pb_1.Message {
     }
     toObject() {
         const data: {
-            dayOfWeek?: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_DAYOFWEEKTYPE;
-            year?: number;
-            month?: number;
-            dayOfMonth?: number;
-            hour?: number;
-            minute?: number;
-            calendar?: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_CALENDARTYPE;
-        } = {};
-        if (this.dayOfWeek != null) {
-            data.dayOfWeek = this.dayOfWeek;
-        }
-        if (this.year != null) {
-            data.year = this.year;
-        }
-        if (this.month != null) {
-            data.month = this.month;
-        }
-        if (this.dayOfMonth != null) {
-            data.dayOfMonth = this.dayOfMonth;
-        }
-        if (this.hour != null) {
-            data.hour = this.hour;
-        }
-        if (this.minute != null) {
-            data.minute = this.minute;
-        }
-        if (this.calendar != null) {
-            data.calendar = this.calendar;
-        }
+            dayOfWeek: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_DAYOFWEEKTYPE;
+            year: number;
+            month: number;
+            dayOfMonth: number;
+            hour: number;
+            minute: number;
+            calendar: HSMDateTimeComponent.HSM_DATE_TIME_COMPONENT_CALENDARTYPE;
+        } = {
+            dayOfWeek: this.dayOfWeek,
+            year: this.year,
+            month: this.month,
+            dayOfMonth: this.dayOfMonth,
+            hour: this.hour,
+            minute: this.minute,
+            calendar: this.calendar
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -5734,11 +5474,10 @@ export class HSMDateTimeUnixEpoch extends pb_1.Message {
     }
     toObject() {
         const data: {
-            timestamp?: number;
-        } = {};
-        if (this.timestamp != null) {
-            data.timestamp = this.timestamp;
-        }
+            timestamp: number;
+        } = {
+            timestamp: this.timestamp
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -5820,8 +5559,8 @@ export class HSMDateTime extends pb_1.Message {
         return cases[pb_1.Message.computeOneofCase(this, [1, 2])];
     }
     static fromObject(data: {
-        component?: ReturnType<typeof HSMDateTimeComponent.prototype.toObject>;
-        unixEpoch?: ReturnType<typeof HSMDateTimeUnixEpoch.prototype.toObject>;
+        component?: Parameters<typeof HSMDateTimeComponent.fromObject>[0];
+        unixEpoch?: Parameters<typeof HSMDateTimeUnixEpoch.fromObject>[0];
     }): HSMDateTime {
         const message = new HSMDateTime({});
         if (data.component != null) {
@@ -5834,8 +5573,8 @@ export class HSMDateTime extends pb_1.Message {
     }
     toObject() {
         const data: {
-            component?: ReturnType<typeof HSMDateTimeComponent.prototype.toObject>;
-            unixEpoch?: ReturnType<typeof HSMDateTimeUnixEpoch.prototype.toObject>;
+            component?: Parameters<typeof HSMDateTimeComponent.fromObject>[0];
+            unixEpoch?: Parameters<typeof HSMDateTimeUnixEpoch.fromObject>[0];
         } = {};
         if (this.component != null) {
             data.component = this.component.toObject();
@@ -5944,8 +5683,8 @@ export class HSMLocalizableParameter extends pb_1.Message {
     }
     static fromObject(data: {
         default?: string;
-        currency?: ReturnType<typeof HSMCurrency.prototype.toObject>;
-        dateTime?: ReturnType<typeof HSMDateTime.prototype.toObject>;
+        currency?: Parameters<typeof HSMCurrency.fromObject>[0];
+        dateTime?: Parameters<typeof HSMDateTime.fromObject>[0];
     }): HSMLocalizableParameter {
         const message = new HSMLocalizableParameter({});
         if (data.default != null) {
@@ -5961,13 +5700,12 @@ export class HSMLocalizableParameter extends pb_1.Message {
     }
     toObject() {
         const data: {
-            default?: string;
-            currency?: ReturnType<typeof HSMCurrency.prototype.toObject>;
-            dateTime?: ReturnType<typeof HSMDateTime.prototype.toObject>;
-        } = {};
-        if (this.default != null) {
-            data.default = this.default;
-        }
+            default: string;
+            currency?: Parameters<typeof HSMCurrency.fromObject>[0];
+            dateTime?: Parameters<typeof HSMDateTime.fromObject>[0];
+        } = {
+            default: this.default
+        };
         if (this.currency != null) {
             data.currency = this.currency.toObject();
         }
@@ -6135,13 +5873,13 @@ export class HighlyStructuredMessage extends pb_1.Message {
     static fromObject(data: {
         namespace?: string;
         elementName?: string;
-        params: string[];
+        params?: string[];
         fallbackLg?: string;
         fallbackLc?: string;
-        localizableParams?: ReturnType<typeof HSMLocalizableParameter.prototype.toObject>[];
+        localizableParams?: Parameters<typeof HSMLocalizableParameter.fromObject>[0][];
         deterministicLg?: string;
         deterministicLc?: string;
-        hydratedHsm?: ReturnType<typeof TemplateMessage.prototype.toObject>;
+        hydratedHsm?: Parameters<typeof TemplateMessage.fromObject>[0];
     }): HighlyStructuredMessage {
         const message = new HighlyStructuredMessage({
             params: data.params,
@@ -6172,39 +5910,25 @@ export class HighlyStructuredMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            namespace?: string;
-            elementName?: string;
+            namespace: string;
+            elementName: string;
             params: string[];
-            fallbackLg?: string;
-            fallbackLc?: string;
-            localizableParams?: ReturnType<typeof HSMLocalizableParameter.prototype.toObject>[];
-            deterministicLg?: string;
-            deterministicLc?: string;
-            hydratedHsm?: ReturnType<typeof TemplateMessage.prototype.toObject>;
+            fallbackLg: string;
+            fallbackLc: string;
+            localizableParams: Parameters<typeof HSMLocalizableParameter.fromObject>[0][];
+            deterministicLg: string;
+            deterministicLc: string;
+            hydratedHsm?: Parameters<typeof TemplateMessage.fromObject>[0];
         } = {
-            params: this.params
+            namespace: this.namespace,
+            elementName: this.elementName,
+            params: this.params,
+            fallbackLg: this.fallbackLg,
+            fallbackLc: this.fallbackLc,
+            localizableParams: this.localizableParams.map((item: HSMLocalizableParameter) => item.toObject()),
+            deterministicLg: this.deterministicLg,
+            deterministicLc: this.deterministicLc
         };
-        if (this.namespace != null) {
-            data.namespace = this.namespace;
-        }
-        if (this.elementName != null) {
-            data.elementName = this.elementName;
-        }
-        if (this.fallbackLg != null) {
-            data.fallbackLg = this.fallbackLg;
-        }
-        if (this.fallbackLc != null) {
-            data.fallbackLc = this.fallbackLc;
-        }
-        if (this.localizableParams != null) {
-            data.localizableParams = this.localizableParams.map((item: HSMLocalizableParameter) => item.toObject());
-        }
-        if (this.deterministicLg != null) {
-            data.deterministicLg = this.deterministicLg;
-        }
-        if (this.deterministicLc != null) {
-            data.deterministicLc = this.deterministicLc;
-        }
         if (this.hydratedHsm != null) {
             data.hydratedHsm = this.hydratedHsm.toObject();
         }
@@ -6316,8 +6040,8 @@ export class SendPaymentMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 3) != null;
     }
     static fromObject(data: {
-        noteMessage?: ReturnType<typeof Message.prototype.toObject>;
-        requestMessageKey?: ReturnType<typeof MessageKey.prototype.toObject>;
+        noteMessage?: Parameters<typeof Message.fromObject>[0];
+        requestMessageKey?: Parameters<typeof MessageKey.fromObject>[0];
     }): SendPaymentMessage {
         const message = new SendPaymentMessage({});
         if (data.noteMessage != null) {
@@ -6330,8 +6054,8 @@ export class SendPaymentMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            noteMessage?: ReturnType<typeof Message.prototype.toObject>;
-            requestMessageKey?: ReturnType<typeof MessageKey.prototype.toObject>;
+            noteMessage?: Parameters<typeof Message.fromObject>[0];
+            requestMessageKey?: Parameters<typeof MessageKey.fromObject>[0];
         } = {};
         if (this.noteMessage != null) {
             data.noteMessage = this.noteMessage.toObject();
@@ -6451,7 +6175,7 @@ export class RequestPaymentMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 5) != null;
     }
     static fromObject(data: {
-        noteMessage?: ReturnType<typeof Message.prototype.toObject>;
+        noteMessage?: Parameters<typeof Message.fromObject>[0];
         currencyCodeIso4217?: string;
         amount1000?: number;
         requestFrom?: string;
@@ -6477,26 +6201,19 @@ export class RequestPaymentMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            noteMessage?: ReturnType<typeof Message.prototype.toObject>;
-            currencyCodeIso4217?: string;
-            amount1000?: number;
-            requestFrom?: string;
-            expiryTimestamp?: number;
-        } = {};
+            noteMessage?: Parameters<typeof Message.fromObject>[0];
+            currencyCodeIso4217: string;
+            amount1000: number;
+            requestFrom: string;
+            expiryTimestamp: number;
+        } = {
+            currencyCodeIso4217: this.currencyCodeIso4217,
+            amount1000: this.amount1000,
+            requestFrom: this.requestFrom,
+            expiryTimestamp: this.expiryTimestamp
+        };
         if (this.noteMessage != null) {
             data.noteMessage = this.noteMessage.toObject();
-        }
-        if (this.currencyCodeIso4217 != null) {
-            data.currencyCodeIso4217 = this.currencyCodeIso4217;
-        }
-        if (this.amount1000 != null) {
-            data.amount1000 = this.amount1000;
-        }
-        if (this.requestFrom != null) {
-            data.requestFrom = this.requestFrom;
-        }
-        if (this.expiryTimestamp != null) {
-            data.expiryTimestamp = this.expiryTimestamp;
         }
         return data;
     }
@@ -6573,7 +6290,7 @@ export class DeclinePaymentRequestMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     static fromObject(data: {
-        key?: ReturnType<typeof MessageKey.prototype.toObject>;
+        key?: Parameters<typeof MessageKey.fromObject>[0];
     }): DeclinePaymentRequestMessage {
         const message = new DeclinePaymentRequestMessage({});
         if (data.key != null) {
@@ -6583,7 +6300,7 @@ export class DeclinePaymentRequestMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            key?: ReturnType<typeof MessageKey.prototype.toObject>;
+            key?: Parameters<typeof MessageKey.fromObject>[0];
         } = {};
         if (this.key != null) {
             data.key = this.key.toObject();
@@ -6643,7 +6360,7 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     static fromObject(data: {
-        key?: ReturnType<typeof MessageKey.prototype.toObject>;
+        key?: Parameters<typeof MessageKey.fromObject>[0];
     }): CancelPaymentRequestMessage {
         const message = new CancelPaymentRequestMessage({});
         if (data.key != null) {
@@ -6653,7 +6370,7 @@ export class CancelPaymentRequestMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            key?: ReturnType<typeof MessageKey.prototype.toObject>;
+            key?: Parameters<typeof MessageKey.fromObject>[0];
         } = {};
         if (this.key != null) {
             data.key = this.key.toObject();
@@ -6839,7 +6556,7 @@ export class LiveLocationMessage extends pb_1.Message {
         sequenceNumber?: number;
         timeOffset?: number;
         jpegThumbnail?: Uint8Array;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
     }): LiveLocationMessage {
         const message = new LiveLocationMessage({});
         if (data.degreesLatitude != null) {
@@ -6876,44 +6593,27 @@ export class LiveLocationMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            degreesLatitude?: number;
-            degreesLongitude?: number;
-            accuracyInMeters?: number;
-            speedInMps?: number;
-            degreesClockwiseFromMagneticNorth?: number;
-            caption?: string;
-            sequenceNumber?: number;
-            timeOffset?: number;
-            jpegThumbnail?: Uint8Array;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        } = {};
-        if (this.degreesLatitude != null) {
-            data.degreesLatitude = this.degreesLatitude;
-        }
-        if (this.degreesLongitude != null) {
-            data.degreesLongitude = this.degreesLongitude;
-        }
-        if (this.accuracyInMeters != null) {
-            data.accuracyInMeters = this.accuracyInMeters;
-        }
-        if (this.speedInMps != null) {
-            data.speedInMps = this.speedInMps;
-        }
-        if (this.degreesClockwiseFromMagneticNorth != null) {
-            data.degreesClockwiseFromMagneticNorth = this.degreesClockwiseFromMagneticNorth;
-        }
-        if (this.caption != null) {
-            data.caption = this.caption;
-        }
-        if (this.sequenceNumber != null) {
-            data.sequenceNumber = this.sequenceNumber;
-        }
-        if (this.timeOffset != null) {
-            data.timeOffset = this.timeOffset;
-        }
-        if (this.jpegThumbnail != null) {
-            data.jpegThumbnail = this.jpegThumbnail;
-        }
+            degreesLatitude: number;
+            degreesLongitude: number;
+            accuracyInMeters: number;
+            speedInMps: number;
+            degreesClockwiseFromMagneticNorth: number;
+            caption: string;
+            sequenceNumber: number;
+            timeOffset: number;
+            jpegThumbnail: Uint8Array;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        } = {
+            degreesLatitude: this.degreesLatitude,
+            degreesLongitude: this.degreesLongitude,
+            accuracyInMeters: this.accuracyInMeters,
+            speedInMps: this.speedInMps,
+            degreesClockwiseFromMagneticNorth: this.degreesClockwiseFromMagneticNorth,
+            caption: this.caption,
+            sequenceNumber: this.sequenceNumber,
+            timeOffset: this.timeOffset,
+            jpegThumbnail: this.jpegThumbnail
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
         }
@@ -7213,7 +6913,7 @@ export class StickerMessage extends pb_1.Message {
         firstFrameSidecar?: Uint8Array;
         isAnimated?: boolean;
         pngThumbnail?: Uint8Array;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
     }): StickerMessage {
         const message = new StickerMessage({});
         if (data.url != null) {
@@ -7265,64 +6965,37 @@ export class StickerMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            url?: string;
-            fileSha256?: Uint8Array;
-            fileEncSha256?: Uint8Array;
-            mediaKey?: Uint8Array;
-            mimetype?: string;
-            height?: number;
-            width?: number;
-            directPath?: string;
-            fileLength?: number;
-            mediaKeyTimestamp?: number;
-            firstFrameLength?: number;
-            firstFrameSidecar?: Uint8Array;
-            isAnimated?: boolean;
-            pngThumbnail?: Uint8Array;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        } = {};
-        if (this.url != null) {
-            data.url = this.url;
-        }
-        if (this.fileSha256 != null) {
-            data.fileSha256 = this.fileSha256;
-        }
-        if (this.fileEncSha256 != null) {
-            data.fileEncSha256 = this.fileEncSha256;
-        }
-        if (this.mediaKey != null) {
-            data.mediaKey = this.mediaKey;
-        }
-        if (this.mimetype != null) {
-            data.mimetype = this.mimetype;
-        }
-        if (this.height != null) {
-            data.height = this.height;
-        }
-        if (this.width != null) {
-            data.width = this.width;
-        }
-        if (this.directPath != null) {
-            data.directPath = this.directPath;
-        }
-        if (this.fileLength != null) {
-            data.fileLength = this.fileLength;
-        }
-        if (this.mediaKeyTimestamp != null) {
-            data.mediaKeyTimestamp = this.mediaKeyTimestamp;
-        }
-        if (this.firstFrameLength != null) {
-            data.firstFrameLength = this.firstFrameLength;
-        }
-        if (this.firstFrameSidecar != null) {
-            data.firstFrameSidecar = this.firstFrameSidecar;
-        }
-        if (this.isAnimated != null) {
-            data.isAnimated = this.isAnimated;
-        }
-        if (this.pngThumbnail != null) {
-            data.pngThumbnail = this.pngThumbnail;
-        }
+            url: string;
+            fileSha256: Uint8Array;
+            fileEncSha256: Uint8Array;
+            mediaKey: Uint8Array;
+            mimetype: string;
+            height: number;
+            width: number;
+            directPath: string;
+            fileLength: number;
+            mediaKeyTimestamp: number;
+            firstFrameLength: number;
+            firstFrameSidecar: Uint8Array;
+            isAnimated: boolean;
+            pngThumbnail: Uint8Array;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        } = {
+            url: this.url,
+            fileSha256: this.fileSha256,
+            fileEncSha256: this.fileEncSha256,
+            mediaKey: this.mediaKey,
+            mimetype: this.mimetype,
+            height: this.height,
+            width: this.width,
+            directPath: this.directPath,
+            fileLength: this.fileLength,
+            mediaKeyTimestamp: this.mediaKeyTimestamp,
+            firstFrameLength: this.firstFrameLength,
+            firstFrameSidecar: this.firstFrameSidecar,
+            isAnimated: this.isAnimated,
+            pngThumbnail: this.pngThumbnail
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
         }
@@ -7575,14 +7248,14 @@ export class FourRowTemplate extends pb_1.Message {
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3, 4, 5])];
     }
     static fromObject(data: {
-        content?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-        footer?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-        buttons?: ReturnType<typeof TemplateButton.prototype.toObject>[];
-        documentMessage?: ReturnType<typeof DocumentMessage.prototype.toObject>;
-        highlyStructuredMessage?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-        imageMessage?: ReturnType<typeof ImageMessage.prototype.toObject>;
-        videoMessage?: ReturnType<typeof VideoMessage.prototype.toObject>;
-        locationMessage?: ReturnType<typeof LocationMessage.prototype.toObject>;
+        content?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+        footer?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+        buttons?: Parameters<typeof TemplateButton.fromObject>[0][];
+        documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
+        highlyStructuredMessage?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+        imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
+        videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
+        locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
     }): FourRowTemplate {
         const message = new FourRowTemplate({
             buttons: data.buttons.map(item => TemplateButton.fromObject(item))
@@ -7612,23 +7285,22 @@ export class FourRowTemplate extends pb_1.Message {
     }
     toObject() {
         const data: {
-            content?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-            footer?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-            buttons?: ReturnType<typeof TemplateButton.prototype.toObject>[];
-            documentMessage?: ReturnType<typeof DocumentMessage.prototype.toObject>;
-            highlyStructuredMessage?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-            imageMessage?: ReturnType<typeof ImageMessage.prototype.toObject>;
-            videoMessage?: ReturnType<typeof VideoMessage.prototype.toObject>;
-            locationMessage?: ReturnType<typeof LocationMessage.prototype.toObject>;
-        } = {};
+            content?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+            footer?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+            buttons: Parameters<typeof TemplateButton.fromObject>[0][];
+            documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
+            highlyStructuredMessage?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+            imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
+            videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
+            locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
+        } = {
+            buttons: this.buttons.map((item: TemplateButton) => item.toObject())
+        };
         if (this.content != null) {
             data.content = this.content.toObject();
         }
         if (this.footer != null) {
             data.footer = this.footer.toObject();
-        }
-        if (this.buttons != null) {
-            data.buttons = this.buttons.map((item: TemplateButton) => item.toObject());
         }
         if (this.documentMessage != null) {
             data.documentMessage = this.documentMessage.toObject();
@@ -7874,13 +7546,13 @@ export class HydratedFourRowTemplate extends pb_1.Message {
     static fromObject(data: {
         hydratedContentText?: string;
         hydratedFooterText?: string;
-        hydratedButtons?: ReturnType<typeof HydratedTemplateButton.prototype.toObject>[];
+        hydratedButtons?: Parameters<typeof HydratedTemplateButton.fromObject>[0][];
         templateId?: string;
-        documentMessage?: ReturnType<typeof DocumentMessage.prototype.toObject>;
+        documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
         hydratedTitleText?: string;
-        imageMessage?: ReturnType<typeof ImageMessage.prototype.toObject>;
-        videoMessage?: ReturnType<typeof VideoMessage.prototype.toObject>;
-        locationMessage?: ReturnType<typeof LocationMessage.prototype.toObject>;
+        imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
+        videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
+        locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
     }): HydratedFourRowTemplate {
         const message = new HydratedFourRowTemplate({
             hydratedButtons: data.hydratedButtons.map(item => HydratedTemplateButton.fromObject(item))
@@ -7913,33 +7585,24 @@ export class HydratedFourRowTemplate extends pb_1.Message {
     }
     toObject() {
         const data: {
-            hydratedContentText?: string;
-            hydratedFooterText?: string;
-            hydratedButtons?: ReturnType<typeof HydratedTemplateButton.prototype.toObject>[];
-            templateId?: string;
-            documentMessage?: ReturnType<typeof DocumentMessage.prototype.toObject>;
-            hydratedTitleText?: string;
-            imageMessage?: ReturnType<typeof ImageMessage.prototype.toObject>;
-            videoMessage?: ReturnType<typeof VideoMessage.prototype.toObject>;
-            locationMessage?: ReturnType<typeof LocationMessage.prototype.toObject>;
-        } = {};
-        if (this.hydratedContentText != null) {
-            data.hydratedContentText = this.hydratedContentText;
-        }
-        if (this.hydratedFooterText != null) {
-            data.hydratedFooterText = this.hydratedFooterText;
-        }
-        if (this.hydratedButtons != null) {
-            data.hydratedButtons = this.hydratedButtons.map((item: HydratedTemplateButton) => item.toObject());
-        }
-        if (this.templateId != null) {
-            data.templateId = this.templateId;
-        }
+            hydratedContentText: string;
+            hydratedFooterText: string;
+            hydratedButtons: Parameters<typeof HydratedTemplateButton.fromObject>[0][];
+            templateId: string;
+            documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
+            hydratedTitleText: string;
+            imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
+            videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
+            locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
+        } = {
+            hydratedContentText: this.hydratedContentText,
+            hydratedFooterText: this.hydratedFooterText,
+            hydratedButtons: this.hydratedButtons.map((item: HydratedTemplateButton) => item.toObject()),
+            templateId: this.templateId,
+            hydratedTitleText: this.hydratedTitleText
+        };
         if (this.documentMessage != null) {
             data.documentMessage = this.documentMessage.toObject();
-        }
-        if (this.hydratedTitleText != null) {
-            data.hydratedTitleText = this.hydratedTitleText;
         }
         if (this.imageMessage != null) {
             data.imageMessage = this.imageMessage.toObject();
@@ -8098,10 +7761,10 @@ export class TemplateMessage extends pb_1.Message {
         return cases[pb_1.Message.computeOneofCase(this, [1, 2])];
     }
     static fromObject(data: {
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        hydratedTemplate?: ReturnType<typeof HydratedFourRowTemplate.prototype.toObject>;
-        fourRowTemplate?: ReturnType<typeof FourRowTemplate.prototype.toObject>;
-        hydratedFourRowTemplate?: ReturnType<typeof HydratedFourRowTemplate.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        hydratedTemplate?: Parameters<typeof HydratedFourRowTemplate.fromObject>[0];
+        fourRowTemplate?: Parameters<typeof FourRowTemplate.fromObject>[0];
+        hydratedFourRowTemplate?: Parameters<typeof HydratedFourRowTemplate.fromObject>[0];
     }): TemplateMessage {
         const message = new TemplateMessage({});
         if (data.contextInfo != null) {
@@ -8120,10 +7783,10 @@ export class TemplateMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-            hydratedTemplate?: ReturnType<typeof HydratedFourRowTemplate.prototype.toObject>;
-            fourRowTemplate?: ReturnType<typeof FourRowTemplate.prototype.toObject>;
-            hydratedFourRowTemplate?: ReturnType<typeof HydratedFourRowTemplate.prototype.toObject>;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+            hydratedTemplate?: Parameters<typeof HydratedFourRowTemplate.fromObject>[0];
+            fourRowTemplate?: Parameters<typeof FourRowTemplate.fromObject>[0];
+            hydratedFourRowTemplate?: Parameters<typeof HydratedFourRowTemplate.fromObject>[0];
         } = {};
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
@@ -8248,7 +7911,7 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
     static fromObject(data: {
         selectedId?: string;
         selectedDisplayText?: string;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
         selectedIndex?: number;
     }): TemplateButtonReplyMessage {
         const message = new TemplateButtonReplyMessage({});
@@ -8268,22 +7931,17 @@ export class TemplateButtonReplyMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            selectedId?: string;
-            selectedDisplayText?: string;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-            selectedIndex?: number;
-        } = {};
-        if (this.selectedId != null) {
-            data.selectedId = this.selectedId;
-        }
-        if (this.selectedDisplayText != null) {
-            data.selectedDisplayText = this.selectedDisplayText;
-        }
+            selectedId: string;
+            selectedDisplayText: string;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+            selectedIndex: number;
+        } = {
+            selectedId: this.selectedId,
+            selectedDisplayText: this.selectedDisplayText,
+            selectedIndex: this.selectedIndex
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
-        }
-        if (this.selectedIndex != null) {
-            data.selectedIndex = this.selectedIndex;
         }
         return data;
     }
@@ -8381,7 +8039,7 @@ export class CatalogSnapshot extends pb_1.Message {
         return pb_1.Message.getField(this, 3) != null;
     }
     static fromObject(data: {
-        catalogImage?: ReturnType<typeof ImageMessage.prototype.toObject>;
+        catalogImage?: Parameters<typeof ImageMessage.fromObject>[0];
         title?: string;
         description?: string;
     }): CatalogSnapshot {
@@ -8399,18 +8057,15 @@ export class CatalogSnapshot extends pb_1.Message {
     }
     toObject() {
         const data: {
-            catalogImage?: ReturnType<typeof ImageMessage.prototype.toObject>;
-            title?: string;
-            description?: string;
-        } = {};
+            catalogImage?: Parameters<typeof ImageMessage.fromObject>[0];
+            title: string;
+            description: string;
+        } = {
+            title: this.title,
+            description: this.description
+        };
         if (this.catalogImage != null) {
             data.catalogImage = this.catalogImage.toObject();
-        }
-        if (this.title != null) {
-            data.title = this.title;
-        }
-        if (this.description != null) {
-            data.description = this.description;
         }
         return data;
     }
@@ -8594,7 +8249,7 @@ export class ProductSnapshot extends pb_1.Message {
         return pb_1.Message.getField(this, 11) != null;
     }
     static fromObject(data: {
-        productImage?: ReturnType<typeof ImageMessage.prototype.toObject>;
+        productImage?: Parameters<typeof ImageMessage.fromObject>[0];
         productId?: string;
         title?: string;
         description?: string;
@@ -8640,46 +8295,29 @@ export class ProductSnapshot extends pb_1.Message {
     }
     toObject() {
         const data: {
-            productImage?: ReturnType<typeof ImageMessage.prototype.toObject>;
-            productId?: string;
-            title?: string;
-            description?: string;
-            currencyCode?: string;
-            priceAmount1000?: number;
-            retailerId?: string;
-            url?: string;
-            productImageCount?: number;
-            firstImageId?: string;
-        } = {};
+            productImage?: Parameters<typeof ImageMessage.fromObject>[0];
+            productId: string;
+            title: string;
+            description: string;
+            currencyCode: string;
+            priceAmount1000: number;
+            retailerId: string;
+            url: string;
+            productImageCount: number;
+            firstImageId: string;
+        } = {
+            productId: this.productId,
+            title: this.title,
+            description: this.description,
+            currencyCode: this.currencyCode,
+            priceAmount1000: this.priceAmount1000,
+            retailerId: this.retailerId,
+            url: this.url,
+            productImageCount: this.productImageCount,
+            firstImageId: this.firstImageId
+        };
         if (this.productImage != null) {
             data.productImage = this.productImage.toObject();
-        }
-        if (this.productId != null) {
-            data.productId = this.productId;
-        }
-        if (this.title != null) {
-            data.title = this.title;
-        }
-        if (this.description != null) {
-            data.description = this.description;
-        }
-        if (this.currencyCode != null) {
-            data.currencyCode = this.currencyCode;
-        }
-        if (this.priceAmount1000 != null) {
-            data.priceAmount1000 = this.priceAmount1000;
-        }
-        if (this.retailerId != null) {
-            data.retailerId = this.retailerId;
-        }
-        if (this.url != null) {
-            data.url = this.url;
-        }
-        if (this.productImageCount != null) {
-            data.productImageCount = this.productImageCount;
-        }
-        if (this.firstImageId != null) {
-            data.firstImageId = this.firstImageId;
         }
         return data;
     }
@@ -8820,10 +8458,10 @@ export class ProductMessage extends pb_1.Message {
         return pb_1.Message.getField(this, 17) != null;
     }
     static fromObject(data: {
-        product?: ReturnType<typeof ProductSnapshot.prototype.toObject>;
+        product?: Parameters<typeof ProductSnapshot.fromObject>[0];
         businessOwnerJid?: string;
-        catalog?: ReturnType<typeof CatalogSnapshot.prototype.toObject>;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        catalog?: Parameters<typeof CatalogSnapshot.fromObject>[0];
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
     }): ProductMessage {
         const message = new ProductMessage({});
         if (data.product != null) {
@@ -8842,16 +8480,15 @@ export class ProductMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            product?: ReturnType<typeof ProductSnapshot.prototype.toObject>;
-            businessOwnerJid?: string;
-            catalog?: ReturnType<typeof CatalogSnapshot.prototype.toObject>;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        } = {};
+            product?: Parameters<typeof ProductSnapshot.fromObject>[0];
+            businessOwnerJid: string;
+            catalog?: Parameters<typeof CatalogSnapshot.fromObject>[0];
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        } = {
+            businessOwnerJid: this.businessOwnerJid
+        };
         if (this.product != null) {
             data.product = this.product.toObject();
-        }
-        if (this.businessOwnerJid != null) {
-            data.businessOwnerJid = this.businessOwnerJid;
         }
         if (this.catalog != null) {
             data.catalog = this.catalog.toObject();
@@ -9013,7 +8650,7 @@ export class GroupInviteMessage extends pb_1.Message {
         groupName?: string;
         jpegThumbnail?: Uint8Array;
         caption?: string;
-        contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
+        contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
     }): GroupInviteMessage {
         const message = new GroupInviteMessage({});
         if (data.groupJid != null) {
@@ -9041,32 +8678,21 @@ export class GroupInviteMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            groupJid?: string;
-            inviteCode?: string;
-            inviteExpiration?: number;
-            groupName?: string;
-            jpegThumbnail?: Uint8Array;
-            caption?: string;
-            contextInfo?: ReturnType<typeof ContextInfo.prototype.toObject>;
-        } = {};
-        if (this.groupJid != null) {
-            data.groupJid = this.groupJid;
-        }
-        if (this.inviteCode != null) {
-            data.inviteCode = this.inviteCode;
-        }
-        if (this.inviteExpiration != null) {
-            data.inviteExpiration = this.inviteExpiration;
-        }
-        if (this.groupName != null) {
-            data.groupName = this.groupName;
-        }
-        if (this.jpegThumbnail != null) {
-            data.jpegThumbnail = this.jpegThumbnail;
-        }
-        if (this.caption != null) {
-            data.caption = this.caption;
-        }
+            groupJid: string;
+            inviteCode: string;
+            inviteExpiration: number;
+            groupName: string;
+            jpegThumbnail: Uint8Array;
+            caption: string;
+            contextInfo?: Parameters<typeof ContextInfo.fromObject>[0];
+        } = {
+            groupJid: this.groupJid,
+            inviteCode: this.inviteCode,
+            inviteExpiration: this.inviteExpiration,
+            groupName: this.groupName,
+            jpegThumbnail: this.jpegThumbnail,
+            caption: this.caption
+        };
         if (this.contextInfo != null) {
             data.contextInfo = this.contextInfo.toObject();
         }
@@ -9182,7 +8808,7 @@ export class DeviceSentMessage extends pb_1.Message {
     }
     static fromObject(data: {
         destinationJid?: string;
-        message?: ReturnType<typeof Message.prototype.toObject>;
+        message?: Parameters<typeof Message.fromObject>[0];
         phash?: string;
     }): DeviceSentMessage {
         const message = new DeviceSentMessage({});
@@ -9199,18 +8825,15 @@ export class DeviceSentMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            destinationJid?: string;
-            message?: ReturnType<typeof Message.prototype.toObject>;
-            phash?: string;
-        } = {};
-        if (this.destinationJid != null) {
-            data.destinationJid = this.destinationJid;
-        }
+            destinationJid: string;
+            message?: Parameters<typeof Message.fromObject>[0];
+            phash: string;
+        } = {
+            destinationJid: this.destinationJid,
+            phash: this.phash
+        };
         if (this.message != null) {
             data.message = this.message.toObject();
-        }
-        if (this.phash != null) {
-            data.phash = this.phash;
         }
         return data;
     }
@@ -9603,31 +9226,31 @@ export class Message extends pb_1.Message {
     }
     static fromObject(data: {
         conversation?: string;
-        senderKeyDistributionMessage?: ReturnType<typeof SenderKeyDistributionMessage.prototype.toObject>;
-        imageMessage?: ReturnType<typeof ImageMessage.prototype.toObject>;
-        contactMessage?: ReturnType<typeof ContactMessage.prototype.toObject>;
-        locationMessage?: ReturnType<typeof LocationMessage.prototype.toObject>;
-        extendedTextMessage?: ReturnType<typeof ExtendedTextMessage.prototype.toObject>;
-        documentMessage?: ReturnType<typeof DocumentMessage.prototype.toObject>;
-        audioMessage?: ReturnType<typeof AudioMessage.prototype.toObject>;
-        videoMessage?: ReturnType<typeof VideoMessage.prototype.toObject>;
-        call?: ReturnType<typeof Call.prototype.toObject>;
-        chat?: ReturnType<typeof Chat.prototype.toObject>;
-        protocolMessage?: ReturnType<typeof ProtocolMessage.prototype.toObject>;
-        contactsArrayMessage?: ReturnType<typeof ContactsArrayMessage.prototype.toObject>;
-        highlyStructuredMessage?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-        fastRatchetKeySenderKeyDistributionMessage?: ReturnType<typeof SenderKeyDistributionMessage.prototype.toObject>;
-        sendPaymentMessage?: ReturnType<typeof SendPaymentMessage.prototype.toObject>;
-        liveLocationMessage?: ReturnType<typeof LiveLocationMessage.prototype.toObject>;
-        requestPaymentMessage?: ReturnType<typeof RequestPaymentMessage.prototype.toObject>;
-        declinePaymentRequestMessage?: ReturnType<typeof DeclinePaymentRequestMessage.prototype.toObject>;
-        cancelPaymentRequestMessage?: ReturnType<typeof CancelPaymentRequestMessage.prototype.toObject>;
-        templateMessage?: ReturnType<typeof TemplateMessage.prototype.toObject>;
-        stickerMessage?: ReturnType<typeof StickerMessage.prototype.toObject>;
-        groupInviteMessage?: ReturnType<typeof GroupInviteMessage.prototype.toObject>;
-        templateButtonReplyMessage?: ReturnType<typeof TemplateButtonReplyMessage.prototype.toObject>;
-        productMessage?: ReturnType<typeof ProductMessage.prototype.toObject>;
-        deviceSentMessage?: ReturnType<typeof DeviceSentMessage.prototype.toObject>;
+        senderKeyDistributionMessage?: Parameters<typeof SenderKeyDistributionMessage.fromObject>[0];
+        imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
+        contactMessage?: Parameters<typeof ContactMessage.fromObject>[0];
+        locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
+        extendedTextMessage?: Parameters<typeof ExtendedTextMessage.fromObject>[0];
+        documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
+        audioMessage?: Parameters<typeof AudioMessage.fromObject>[0];
+        videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
+        call?: Parameters<typeof Call.fromObject>[0];
+        chat?: Parameters<typeof Chat.fromObject>[0];
+        protocolMessage?: Parameters<typeof ProtocolMessage.fromObject>[0];
+        contactsArrayMessage?: Parameters<typeof ContactsArrayMessage.fromObject>[0];
+        highlyStructuredMessage?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+        fastRatchetKeySenderKeyDistributionMessage?: Parameters<typeof SenderKeyDistributionMessage.fromObject>[0];
+        sendPaymentMessage?: Parameters<typeof SendPaymentMessage.fromObject>[0];
+        liveLocationMessage?: Parameters<typeof LiveLocationMessage.fromObject>[0];
+        requestPaymentMessage?: Parameters<typeof RequestPaymentMessage.fromObject>[0];
+        declinePaymentRequestMessage?: Parameters<typeof DeclinePaymentRequestMessage.fromObject>[0];
+        cancelPaymentRequestMessage?: Parameters<typeof CancelPaymentRequestMessage.fromObject>[0];
+        templateMessage?: Parameters<typeof TemplateMessage.fromObject>[0];
+        stickerMessage?: Parameters<typeof StickerMessage.fromObject>[0];
+        groupInviteMessage?: Parameters<typeof GroupInviteMessage.fromObject>[0];
+        templateButtonReplyMessage?: Parameters<typeof TemplateButtonReplyMessage.fromObject>[0];
+        productMessage?: Parameters<typeof ProductMessage.fromObject>[0];
+        deviceSentMessage?: Parameters<typeof DeviceSentMessage.fromObject>[0];
     }): Message {
         const message = new Message({});
         if (data.conversation != null) {
@@ -9712,36 +9335,35 @@ export class Message extends pb_1.Message {
     }
     toObject() {
         const data: {
-            conversation?: string;
-            senderKeyDistributionMessage?: ReturnType<typeof SenderKeyDistributionMessage.prototype.toObject>;
-            imageMessage?: ReturnType<typeof ImageMessage.prototype.toObject>;
-            contactMessage?: ReturnType<typeof ContactMessage.prototype.toObject>;
-            locationMessage?: ReturnType<typeof LocationMessage.prototype.toObject>;
-            extendedTextMessage?: ReturnType<typeof ExtendedTextMessage.prototype.toObject>;
-            documentMessage?: ReturnType<typeof DocumentMessage.prototype.toObject>;
-            audioMessage?: ReturnType<typeof AudioMessage.prototype.toObject>;
-            videoMessage?: ReturnType<typeof VideoMessage.prototype.toObject>;
-            call?: ReturnType<typeof Call.prototype.toObject>;
-            chat?: ReturnType<typeof Chat.prototype.toObject>;
-            protocolMessage?: ReturnType<typeof ProtocolMessage.prototype.toObject>;
-            contactsArrayMessage?: ReturnType<typeof ContactsArrayMessage.prototype.toObject>;
-            highlyStructuredMessage?: ReturnType<typeof HighlyStructuredMessage.prototype.toObject>;
-            fastRatchetKeySenderKeyDistributionMessage?: ReturnType<typeof SenderKeyDistributionMessage.prototype.toObject>;
-            sendPaymentMessage?: ReturnType<typeof SendPaymentMessage.prototype.toObject>;
-            liveLocationMessage?: ReturnType<typeof LiveLocationMessage.prototype.toObject>;
-            requestPaymentMessage?: ReturnType<typeof RequestPaymentMessage.prototype.toObject>;
-            declinePaymentRequestMessage?: ReturnType<typeof DeclinePaymentRequestMessage.prototype.toObject>;
-            cancelPaymentRequestMessage?: ReturnType<typeof CancelPaymentRequestMessage.prototype.toObject>;
-            templateMessage?: ReturnType<typeof TemplateMessage.prototype.toObject>;
-            stickerMessage?: ReturnType<typeof StickerMessage.prototype.toObject>;
-            groupInviteMessage?: ReturnType<typeof GroupInviteMessage.prototype.toObject>;
-            templateButtonReplyMessage?: ReturnType<typeof TemplateButtonReplyMessage.prototype.toObject>;
-            productMessage?: ReturnType<typeof ProductMessage.prototype.toObject>;
-            deviceSentMessage?: ReturnType<typeof DeviceSentMessage.prototype.toObject>;
-        } = {};
-        if (this.conversation != null) {
-            data.conversation = this.conversation;
-        }
+            conversation: string;
+            senderKeyDistributionMessage?: Parameters<typeof SenderKeyDistributionMessage.fromObject>[0];
+            imageMessage?: Parameters<typeof ImageMessage.fromObject>[0];
+            contactMessage?: Parameters<typeof ContactMessage.fromObject>[0];
+            locationMessage?: Parameters<typeof LocationMessage.fromObject>[0];
+            extendedTextMessage?: Parameters<typeof ExtendedTextMessage.fromObject>[0];
+            documentMessage?: Parameters<typeof DocumentMessage.fromObject>[0];
+            audioMessage?: Parameters<typeof AudioMessage.fromObject>[0];
+            videoMessage?: Parameters<typeof VideoMessage.fromObject>[0];
+            call?: Parameters<typeof Call.fromObject>[0];
+            chat?: Parameters<typeof Chat.fromObject>[0];
+            protocolMessage?: Parameters<typeof ProtocolMessage.fromObject>[0];
+            contactsArrayMessage?: Parameters<typeof ContactsArrayMessage.fromObject>[0];
+            highlyStructuredMessage?: Parameters<typeof HighlyStructuredMessage.fromObject>[0];
+            fastRatchetKeySenderKeyDistributionMessage?: Parameters<typeof SenderKeyDistributionMessage.fromObject>[0];
+            sendPaymentMessage?: Parameters<typeof SendPaymentMessage.fromObject>[0];
+            liveLocationMessage?: Parameters<typeof LiveLocationMessage.fromObject>[0];
+            requestPaymentMessage?: Parameters<typeof RequestPaymentMessage.fromObject>[0];
+            declinePaymentRequestMessage?: Parameters<typeof DeclinePaymentRequestMessage.fromObject>[0];
+            cancelPaymentRequestMessage?: Parameters<typeof CancelPaymentRequestMessage.fromObject>[0];
+            templateMessage?: Parameters<typeof TemplateMessage.fromObject>[0];
+            stickerMessage?: Parameters<typeof StickerMessage.fromObject>[0];
+            groupInviteMessage?: Parameters<typeof GroupInviteMessage.fromObject>[0];
+            templateButtonReplyMessage?: Parameters<typeof TemplateButtonReplyMessage.fromObject>[0];
+            productMessage?: Parameters<typeof ProductMessage.fromObject>[0];
+            deviceSentMessage?: Parameters<typeof DeviceSentMessage.fromObject>[0];
+        } = {
+            conversation: this.conversation
+        };
         if (this.senderKeyDistributionMessage != null) {
             data.senderKeyDistributionMessage = this.senderKeyDistributionMessage.toObject();
         }
@@ -10058,23 +9680,16 @@ export class MessageKey extends pb_1.Message {
     }
     toObject() {
         const data: {
-            remoteJid?: string;
-            fromMe?: boolean;
-            id?: string;
-            participant?: string;
-        } = {};
-        if (this.remoteJid != null) {
-            data.remoteJid = this.remoteJid;
-        }
-        if (this.fromMe != null) {
-            data.fromMe = this.fromMe;
-        }
-        if (this.id != null) {
-            data.id = this.id;
-        }
-        if (this.participant != null) {
-            data.participant = this.participant;
-        }
+            remoteJid: string;
+            fromMe: boolean;
+            id: string;
+            participant: string;
+        } = {
+            remoteJid: this.remoteJid,
+            fromMe: this.fromMe,
+            id: this.id,
+            participant: this.participant
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -10699,139 +10314,74 @@ export class WebFeatures extends pb_1.Message {
     }
     toObject() {
         const data: {
-            labelsDisplay?: WebFeatures.WEB_FEATURES_FLAG;
-            voipIndividualOutgoing?: WebFeatures.WEB_FEATURES_FLAG;
-            groupsV3?: WebFeatures.WEB_FEATURES_FLAG;
-            groupsV3Create?: WebFeatures.WEB_FEATURES_FLAG;
-            changeNumberV2?: WebFeatures.WEB_FEATURES_FLAG;
-            queryStatusV3Thumbnail?: WebFeatures.WEB_FEATURES_FLAG;
-            liveLocations?: WebFeatures.WEB_FEATURES_FLAG;
-            queryVname?: WebFeatures.WEB_FEATURES_FLAG;
-            voipIndividualIncoming?: WebFeatures.WEB_FEATURES_FLAG;
-            quickRepliesQuery?: WebFeatures.WEB_FEATURES_FLAG;
-            payments?: WebFeatures.WEB_FEATURES_FLAG;
-            stickerPackQuery?: WebFeatures.WEB_FEATURES_FLAG;
-            liveLocationsFinal?: WebFeatures.WEB_FEATURES_FLAG;
-            labelsEdit?: WebFeatures.WEB_FEATURES_FLAG;
-            mediaUpload?: WebFeatures.WEB_FEATURES_FLAG;
-            mediaUploadRichQuickReplies?: WebFeatures.WEB_FEATURES_FLAG;
-            vnameV2?: WebFeatures.WEB_FEATURES_FLAG;
-            videoPlaybackUrl?: WebFeatures.WEB_FEATURES_FLAG;
-            statusRanking?: WebFeatures.WEB_FEATURES_FLAG;
-            voipIndividualVideo?: WebFeatures.WEB_FEATURES_FLAG;
-            thirdPartyStickers?: WebFeatures.WEB_FEATURES_FLAG;
-            frequentlyForwardedSetting?: WebFeatures.WEB_FEATURES_FLAG;
-            groupsV4JoinPermission?: WebFeatures.WEB_FEATURES_FLAG;
-            recentStickers?: WebFeatures.WEB_FEATURES_FLAG;
-            catalog?: WebFeatures.WEB_FEATURES_FLAG;
-            starredStickers?: WebFeatures.WEB_FEATURES_FLAG;
-            voipGroupCall?: WebFeatures.WEB_FEATURES_FLAG;
-            templateMessage?: WebFeatures.WEB_FEATURES_FLAG;
-            templateMessageInteractivity?: WebFeatures.WEB_FEATURES_FLAG;
-            ephemeralMessages?: WebFeatures.WEB_FEATURES_FLAG;
-            e2ENotificationSync?: WebFeatures.WEB_FEATURES_FLAG;
-            recentStickersV2?: WebFeatures.WEB_FEATURES_FLAG;
-            syncdRelease1?: WebFeatures.WEB_FEATURES_FLAG;
-        } = {};
-        if (this.labelsDisplay != null) {
-            data.labelsDisplay = this.labelsDisplay;
-        }
-        if (this.voipIndividualOutgoing != null) {
-            data.voipIndividualOutgoing = this.voipIndividualOutgoing;
-        }
-        if (this.groupsV3 != null) {
-            data.groupsV3 = this.groupsV3;
-        }
-        if (this.groupsV3Create != null) {
-            data.groupsV3Create = this.groupsV3Create;
-        }
-        if (this.changeNumberV2 != null) {
-            data.changeNumberV2 = this.changeNumberV2;
-        }
-        if (this.queryStatusV3Thumbnail != null) {
-            data.queryStatusV3Thumbnail = this.queryStatusV3Thumbnail;
-        }
-        if (this.liveLocations != null) {
-            data.liveLocations = this.liveLocations;
-        }
-        if (this.queryVname != null) {
-            data.queryVname = this.queryVname;
-        }
-        if (this.voipIndividualIncoming != null) {
-            data.voipIndividualIncoming = this.voipIndividualIncoming;
-        }
-        if (this.quickRepliesQuery != null) {
-            data.quickRepliesQuery = this.quickRepliesQuery;
-        }
-        if (this.payments != null) {
-            data.payments = this.payments;
-        }
-        if (this.stickerPackQuery != null) {
-            data.stickerPackQuery = this.stickerPackQuery;
-        }
-        if (this.liveLocationsFinal != null) {
-            data.liveLocationsFinal = this.liveLocationsFinal;
-        }
-        if (this.labelsEdit != null) {
-            data.labelsEdit = this.labelsEdit;
-        }
-        if (this.mediaUpload != null) {
-            data.mediaUpload = this.mediaUpload;
-        }
-        if (this.mediaUploadRichQuickReplies != null) {
-            data.mediaUploadRichQuickReplies = this.mediaUploadRichQuickReplies;
-        }
-        if (this.vnameV2 != null) {
-            data.vnameV2 = this.vnameV2;
-        }
-        if (this.videoPlaybackUrl != null) {
-            data.videoPlaybackUrl = this.videoPlaybackUrl;
-        }
-        if (this.statusRanking != null) {
-            data.statusRanking = this.statusRanking;
-        }
-        if (this.voipIndividualVideo != null) {
-            data.voipIndividualVideo = this.voipIndividualVideo;
-        }
-        if (this.thirdPartyStickers != null) {
-            data.thirdPartyStickers = this.thirdPartyStickers;
-        }
-        if (this.frequentlyForwardedSetting != null) {
-            data.frequentlyForwardedSetting = this.frequentlyForwardedSetting;
-        }
-        if (this.groupsV4JoinPermission != null) {
-            data.groupsV4JoinPermission = this.groupsV4JoinPermission;
-        }
-        if (this.recentStickers != null) {
-            data.recentStickers = this.recentStickers;
-        }
-        if (this.catalog != null) {
-            data.catalog = this.catalog;
-        }
-        if (this.starredStickers != null) {
-            data.starredStickers = this.starredStickers;
-        }
-        if (this.voipGroupCall != null) {
-            data.voipGroupCall = this.voipGroupCall;
-        }
-        if (this.templateMessage != null) {
-            data.templateMessage = this.templateMessage;
-        }
-        if (this.templateMessageInteractivity != null) {
-            data.templateMessageInteractivity = this.templateMessageInteractivity;
-        }
-        if (this.ephemeralMessages != null) {
-            data.ephemeralMessages = this.ephemeralMessages;
-        }
-        if (this.e2ENotificationSync != null) {
-            data.e2ENotificationSync = this.e2ENotificationSync;
-        }
-        if (this.recentStickersV2 != null) {
-            data.recentStickersV2 = this.recentStickersV2;
-        }
-        if (this.syncdRelease1 != null) {
-            data.syncdRelease1 = this.syncdRelease1;
-        }
+            labelsDisplay: WebFeatures.WEB_FEATURES_FLAG;
+            voipIndividualOutgoing: WebFeatures.WEB_FEATURES_FLAG;
+            groupsV3: WebFeatures.WEB_FEATURES_FLAG;
+            groupsV3Create: WebFeatures.WEB_FEATURES_FLAG;
+            changeNumberV2: WebFeatures.WEB_FEATURES_FLAG;
+            queryStatusV3Thumbnail: WebFeatures.WEB_FEATURES_FLAG;
+            liveLocations: WebFeatures.WEB_FEATURES_FLAG;
+            queryVname: WebFeatures.WEB_FEATURES_FLAG;
+            voipIndividualIncoming: WebFeatures.WEB_FEATURES_FLAG;
+            quickRepliesQuery: WebFeatures.WEB_FEATURES_FLAG;
+            payments: WebFeatures.WEB_FEATURES_FLAG;
+            stickerPackQuery: WebFeatures.WEB_FEATURES_FLAG;
+            liveLocationsFinal: WebFeatures.WEB_FEATURES_FLAG;
+            labelsEdit: WebFeatures.WEB_FEATURES_FLAG;
+            mediaUpload: WebFeatures.WEB_FEATURES_FLAG;
+            mediaUploadRichQuickReplies: WebFeatures.WEB_FEATURES_FLAG;
+            vnameV2: WebFeatures.WEB_FEATURES_FLAG;
+            videoPlaybackUrl: WebFeatures.WEB_FEATURES_FLAG;
+            statusRanking: WebFeatures.WEB_FEATURES_FLAG;
+            voipIndividualVideo: WebFeatures.WEB_FEATURES_FLAG;
+            thirdPartyStickers: WebFeatures.WEB_FEATURES_FLAG;
+            frequentlyForwardedSetting: WebFeatures.WEB_FEATURES_FLAG;
+            groupsV4JoinPermission: WebFeatures.WEB_FEATURES_FLAG;
+            recentStickers: WebFeatures.WEB_FEATURES_FLAG;
+            catalog: WebFeatures.WEB_FEATURES_FLAG;
+            starredStickers: WebFeatures.WEB_FEATURES_FLAG;
+            voipGroupCall: WebFeatures.WEB_FEATURES_FLAG;
+            templateMessage: WebFeatures.WEB_FEATURES_FLAG;
+            templateMessageInteractivity: WebFeatures.WEB_FEATURES_FLAG;
+            ephemeralMessages: WebFeatures.WEB_FEATURES_FLAG;
+            e2ENotificationSync: WebFeatures.WEB_FEATURES_FLAG;
+            recentStickersV2: WebFeatures.WEB_FEATURES_FLAG;
+            syncdRelease1: WebFeatures.WEB_FEATURES_FLAG;
+        } = {
+            labelsDisplay: this.labelsDisplay,
+            voipIndividualOutgoing: this.voipIndividualOutgoing,
+            groupsV3: this.groupsV3,
+            groupsV3Create: this.groupsV3Create,
+            changeNumberV2: this.changeNumberV2,
+            queryStatusV3Thumbnail: this.queryStatusV3Thumbnail,
+            liveLocations: this.liveLocations,
+            queryVname: this.queryVname,
+            voipIndividualIncoming: this.voipIndividualIncoming,
+            quickRepliesQuery: this.quickRepliesQuery,
+            payments: this.payments,
+            stickerPackQuery: this.stickerPackQuery,
+            liveLocationsFinal: this.liveLocationsFinal,
+            labelsEdit: this.labelsEdit,
+            mediaUpload: this.mediaUpload,
+            mediaUploadRichQuickReplies: this.mediaUploadRichQuickReplies,
+            vnameV2: this.vnameV2,
+            videoPlaybackUrl: this.videoPlaybackUrl,
+            statusRanking: this.statusRanking,
+            voipIndividualVideo: this.voipIndividualVideo,
+            thirdPartyStickers: this.thirdPartyStickers,
+            frequentlyForwardedSetting: this.frequentlyForwardedSetting,
+            groupsV4JoinPermission: this.groupsV4JoinPermission,
+            recentStickers: this.recentStickers,
+            catalog: this.catalog,
+            starredStickers: this.starredStickers,
+            voipGroupCall: this.voipGroupCall,
+            templateMessage: this.templateMessage,
+            templateMessageInteractivity: this.templateMessageInteractivity,
+            ephemeralMessages: this.ephemeralMessages,
+            e2ENotificationSync: this.e2ENotificationSync,
+            recentStickersV2: this.recentStickersV2,
+            syncdRelease1: this.syncdRelease1
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -11092,7 +10642,7 @@ export class TabletNotificationsInfo extends pb_1.Message {
         timestamp?: number;
         unreadChats?: number;
         notifyMessageCount?: number;
-        notifyMessage?: ReturnType<typeof NotificationMessageInfo.prototype.toObject>[];
+        notifyMessage?: Parameters<typeof NotificationMessageInfo.fromObject>[0][];
     }): TabletNotificationsInfo {
         const message = new TabletNotificationsInfo({
             notifyMessage: data.notifyMessage.map(item => NotificationMessageInfo.fromObject(item))
@@ -11110,23 +10660,16 @@ export class TabletNotificationsInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            timestamp?: number;
-            unreadChats?: number;
-            notifyMessageCount?: number;
-            notifyMessage?: ReturnType<typeof NotificationMessageInfo.prototype.toObject>[];
-        } = {};
-        if (this.timestamp != null) {
-            data.timestamp = this.timestamp;
-        }
-        if (this.unreadChats != null) {
-            data.unreadChats = this.unreadChats;
-        }
-        if (this.notifyMessageCount != null) {
-            data.notifyMessageCount = this.notifyMessageCount;
-        }
-        if (this.notifyMessage != null) {
-            data.notifyMessage = this.notifyMessage.map((item: NotificationMessageInfo) => item.toObject());
-        }
+            timestamp: number;
+            unreadChats: number;
+            notifyMessageCount: number;
+            notifyMessage: Parameters<typeof NotificationMessageInfo.fromObject>[0][];
+        } = {
+            timestamp: this.timestamp,
+            unreadChats: this.unreadChats,
+            notifyMessageCount: this.notifyMessageCount,
+            notifyMessage: this.notifyMessage.map((item: NotificationMessageInfo) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -11236,8 +10779,8 @@ export class NotificationMessageInfo extends pb_1.Message {
         return pb_1.Message.getField(this, 4) != null;
     }
     static fromObject(data: {
-        key?: ReturnType<typeof MessageKey.prototype.toObject>;
-        message?: ReturnType<typeof Message.prototype.toObject>;
+        key?: Parameters<typeof MessageKey.fromObject>[0];
+        message?: Parameters<typeof Message.fromObject>[0];
         messageTimestamp?: number;
         participant?: string;
     }): NotificationMessageInfo {
@@ -11258,22 +10801,19 @@ export class NotificationMessageInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            key?: ReturnType<typeof MessageKey.prototype.toObject>;
-            message?: ReturnType<typeof Message.prototype.toObject>;
-            messageTimestamp?: number;
-            participant?: string;
-        } = {};
+            key?: Parameters<typeof MessageKey.fromObject>[0];
+            message?: Parameters<typeof Message.fromObject>[0];
+            messageTimestamp: number;
+            participant: string;
+        } = {
+            messageTimestamp: this.messageTimestamp,
+            participant: this.participant
+        };
         if (this.key != null) {
             data.key = this.key.toObject();
         }
         if (this.message != null) {
             data.message = this.message.toObject();
-        }
-        if (this.messageTimestamp != null) {
-            data.messageTimestamp = this.messageTimestamp;
-        }
-        if (this.participant != null) {
-            data.participant = this.participant;
         }
         return data;
     }
@@ -11382,7 +10922,7 @@ export class WebNotificationsInfo extends pb_1.Message {
         timestamp?: number;
         unreadChats?: number;
         notifyMessageCount?: number;
-        notifyMessages?: ReturnType<typeof WebMessageInfo.prototype.toObject>[];
+        notifyMessages?: Parameters<typeof WebMessageInfo.fromObject>[0][];
     }): WebNotificationsInfo {
         const message = new WebNotificationsInfo({
             notifyMessages: data.notifyMessages.map(item => WebMessageInfo.fromObject(item))
@@ -11400,23 +10940,16 @@ export class WebNotificationsInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            timestamp?: number;
-            unreadChats?: number;
-            notifyMessageCount?: number;
-            notifyMessages?: ReturnType<typeof WebMessageInfo.prototype.toObject>[];
-        } = {};
-        if (this.timestamp != null) {
-            data.timestamp = this.timestamp;
-        }
-        if (this.unreadChats != null) {
-            data.unreadChats = this.unreadChats;
-        }
-        if (this.notifyMessageCount != null) {
-            data.notifyMessageCount = this.notifyMessageCount;
-        }
-        if (this.notifyMessages != null) {
-            data.notifyMessages = this.notifyMessages.map((item: WebMessageInfo) => item.toObject());
-        }
+            timestamp: number;
+            unreadChats: number;
+            notifyMessageCount: number;
+            notifyMessages: Parameters<typeof WebMessageInfo.fromObject>[0][];
+        } = {
+            timestamp: this.timestamp,
+            unreadChats: this.unreadChats,
+            notifyMessageCount: this.notifyMessageCount,
+            notifyMessages: this.notifyMessages.map((item: WebMessageInfo) => item.toObject())
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -11609,7 +11142,7 @@ export class PaymentInfo extends pb_1.Message {
         receiverJid?: string;
         status?: PaymentInfo.PAYMENT_INFO_STATUS;
         transactionTimestamp?: number;
-        requestMessageKey?: ReturnType<typeof MessageKey.prototype.toObject>;
+        requestMessageKey?: Parameters<typeof MessageKey.fromObject>[0];
         expiryTimestamp?: number;
         futureproofed?: boolean;
         currency?: string;
@@ -11650,46 +11183,29 @@ export class PaymentInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            currencyDeprecated?: PaymentInfo.PAYMENT_INFO_CURRENCY;
-            amount1000?: number;
-            receiverJid?: string;
-            status?: PaymentInfo.PAYMENT_INFO_STATUS;
-            transactionTimestamp?: number;
-            requestMessageKey?: ReturnType<typeof MessageKey.prototype.toObject>;
-            expiryTimestamp?: number;
-            futureproofed?: boolean;
-            currency?: string;
-            txnStatus?: PaymentInfo.PAYMENT_INFO_TXNSTATUS;
-        } = {};
-        if (this.currencyDeprecated != null) {
-            data.currencyDeprecated = this.currencyDeprecated;
-        }
-        if (this.amount1000 != null) {
-            data.amount1000 = this.amount1000;
-        }
-        if (this.receiverJid != null) {
-            data.receiverJid = this.receiverJid;
-        }
-        if (this.status != null) {
-            data.status = this.status;
-        }
-        if (this.transactionTimestamp != null) {
-            data.transactionTimestamp = this.transactionTimestamp;
-        }
+            currencyDeprecated: PaymentInfo.PAYMENT_INFO_CURRENCY;
+            amount1000: number;
+            receiverJid: string;
+            status: PaymentInfo.PAYMENT_INFO_STATUS;
+            transactionTimestamp: number;
+            requestMessageKey?: Parameters<typeof MessageKey.fromObject>[0];
+            expiryTimestamp: number;
+            futureproofed: boolean;
+            currency: string;
+            txnStatus: PaymentInfo.PAYMENT_INFO_TXNSTATUS;
+        } = {
+            currencyDeprecated: this.currencyDeprecated,
+            amount1000: this.amount1000,
+            receiverJid: this.receiverJid,
+            status: this.status,
+            transactionTimestamp: this.transactionTimestamp,
+            expiryTimestamp: this.expiryTimestamp,
+            futureproofed: this.futureproofed,
+            currency: this.currency,
+            txnStatus: this.txnStatus
+        };
         if (this.requestMessageKey != null) {
             data.requestMessageKey = this.requestMessageKey.toObject();
-        }
-        if (this.expiryTimestamp != null) {
-            data.expiryTimestamp = this.expiryTimestamp;
-        }
-        if (this.futureproofed != null) {
-            data.futureproofed = this.futureproofed;
-        }
-        if (this.currency != null) {
-            data.currency = this.currency;
-        }
-        if (this.txnStatus != null) {
-            data.txnStatus = this.txnStatus;
         }
         return data;
     }
@@ -12128,8 +11644,8 @@ export class WebMessageInfo extends pb_1.Message {
         return pb_1.Message.getField(this, 34) != null;
     }
     static fromObject(data: {
-        key?: ReturnType<typeof MessageKey.prototype.toObject>;
-        message?: ReturnType<typeof Message.prototype.toObject>;
+        key?: Parameters<typeof MessageKey.fromObject>[0];
+        message?: Parameters<typeof Message.fromObject>[0];
         messageTimestamp?: number;
         status?: WebMessageInfo.WEB_MESSAGE_INFO_STATUS;
         participant?: string;
@@ -12143,12 +11659,12 @@ export class WebMessageInfo extends pb_1.Message {
         urlNumber?: boolean;
         messageStubType?: WebMessageInfo.WEB_MESSAGE_INFO_STUBTYPE;
         clearMedia?: boolean;
-        messageStubParameters: string[];
+        messageStubParameters?: string[];
         duration?: number;
-        labels: string[];
-        paymentInfo?: ReturnType<typeof PaymentInfo.prototype.toObject>;
-        finalLiveLocation?: ReturnType<typeof LiveLocationMessage.prototype.toObject>;
-        quotedPaymentInfo?: ReturnType<typeof PaymentInfo.prototype.toObject>;
+        labels?: string[];
+        paymentInfo?: Parameters<typeof PaymentInfo.fromObject>[0];
+        finalLiveLocation?: Parameters<typeof LiveLocationMessage.fromObject>[0];
+        quotedPaymentInfo?: Parameters<typeof PaymentInfo.fromObject>[0];
         ephemeralStartTimestamp?: number;
         ephemeralDuration?: number;
         ephemeralOffToOn?: boolean;
@@ -12225,81 +11741,56 @@ export class WebMessageInfo extends pb_1.Message {
     }
     toObject() {
         const data: {
-            key?: ReturnType<typeof MessageKey.prototype.toObject>;
-            message?: ReturnType<typeof Message.prototype.toObject>;
-            messageTimestamp?: number;
-            status?: WebMessageInfo.WEB_MESSAGE_INFO_STATUS;
-            participant?: string;
-            ignore?: boolean;
-            starred?: boolean;
-            broadcast?: boolean;
-            pushName?: string;
-            mediaCiphertextSha256?: Uint8Array;
-            multicast?: boolean;
-            urlText?: boolean;
-            urlNumber?: boolean;
-            messageStubType?: WebMessageInfo.WEB_MESSAGE_INFO_STUBTYPE;
-            clearMedia?: boolean;
+            key?: Parameters<typeof MessageKey.fromObject>[0];
+            message?: Parameters<typeof Message.fromObject>[0];
+            messageTimestamp: number;
+            status: WebMessageInfo.WEB_MESSAGE_INFO_STATUS;
+            participant: string;
+            ignore: boolean;
+            starred: boolean;
+            broadcast: boolean;
+            pushName: string;
+            mediaCiphertextSha256: Uint8Array;
+            multicast: boolean;
+            urlText: boolean;
+            urlNumber: boolean;
+            messageStubType: WebMessageInfo.WEB_MESSAGE_INFO_STUBTYPE;
+            clearMedia: boolean;
             messageStubParameters: string[];
-            duration?: number;
+            duration: number;
             labels: string[];
-            paymentInfo?: ReturnType<typeof PaymentInfo.prototype.toObject>;
-            finalLiveLocation?: ReturnType<typeof LiveLocationMessage.prototype.toObject>;
-            quotedPaymentInfo?: ReturnType<typeof PaymentInfo.prototype.toObject>;
-            ephemeralStartTimestamp?: number;
-            ephemeralDuration?: number;
-            ephemeralOffToOn?: boolean;
+            paymentInfo?: Parameters<typeof PaymentInfo.fromObject>[0];
+            finalLiveLocation?: Parameters<typeof LiveLocationMessage.fromObject>[0];
+            quotedPaymentInfo?: Parameters<typeof PaymentInfo.fromObject>[0];
+            ephemeralStartTimestamp: number;
+            ephemeralDuration: number;
+            ephemeralOffToOn: boolean;
         } = {
+            messageTimestamp: this.messageTimestamp,
+            status: this.status,
+            participant: this.participant,
+            ignore: this.ignore,
+            starred: this.starred,
+            broadcast: this.broadcast,
+            pushName: this.pushName,
+            mediaCiphertextSha256: this.mediaCiphertextSha256,
+            multicast: this.multicast,
+            urlText: this.urlText,
+            urlNumber: this.urlNumber,
+            messageStubType: this.messageStubType,
+            clearMedia: this.clearMedia,
             messageStubParameters: this.messageStubParameters,
-            labels: this.labels
+            duration: this.duration,
+            labels: this.labels,
+            ephemeralStartTimestamp: this.ephemeralStartTimestamp,
+            ephemeralDuration: this.ephemeralDuration,
+            ephemeralOffToOn: this.ephemeralOffToOn
         };
         if (this.key != null) {
             data.key = this.key.toObject();
         }
         if (this.message != null) {
             data.message = this.message.toObject();
-        }
-        if (this.messageTimestamp != null) {
-            data.messageTimestamp = this.messageTimestamp;
-        }
-        if (this.status != null) {
-            data.status = this.status;
-        }
-        if (this.participant != null) {
-            data.participant = this.participant;
-        }
-        if (this.ignore != null) {
-            data.ignore = this.ignore;
-        }
-        if (this.starred != null) {
-            data.starred = this.starred;
-        }
-        if (this.broadcast != null) {
-            data.broadcast = this.broadcast;
-        }
-        if (this.pushName != null) {
-            data.pushName = this.pushName;
-        }
-        if (this.mediaCiphertextSha256 != null) {
-            data.mediaCiphertextSha256 = this.mediaCiphertextSha256;
-        }
-        if (this.multicast != null) {
-            data.multicast = this.multicast;
-        }
-        if (this.urlText != null) {
-            data.urlText = this.urlText;
-        }
-        if (this.urlNumber != null) {
-            data.urlNumber = this.urlNumber;
-        }
-        if (this.messageStubType != null) {
-            data.messageStubType = this.messageStubType;
-        }
-        if (this.clearMedia != null) {
-            data.clearMedia = this.clearMedia;
-        }
-        if (this.duration != null) {
-            data.duration = this.duration;
         }
         if (this.paymentInfo != null) {
             data.paymentInfo = this.paymentInfo.toObject();
@@ -12309,15 +11800,6 @@ export class WebMessageInfo extends pb_1.Message {
         }
         if (this.quotedPaymentInfo != null) {
             data.quotedPaymentInfo = this.quotedPaymentInfo.toObject();
-        }
-        if (this.ephemeralStartTimestamp != null) {
-            data.ephemeralStartTimestamp = this.ephemeralStartTimestamp;
-        }
-        if (this.ephemeralDuration != null) {
-            data.ephemeralDuration = this.ephemeralDuration;
-        }
-        if (this.ephemeralOffToOn != null) {
-            data.ephemeralOffToOn = this.ephemeralOffToOn;
         }
         return data;
     }

--- a/test/conformance/packedproto2/packedproto2.spec.ts
+++ b/test/conformance/packedproto2/packedproto2.spec.ts
@@ -6,9 +6,9 @@ describe("packed proto 2", () => {
     const bin = fs.readFileSync(path.join(__dirname, "packedproto2.bin"));
     it("should not pack scanLengths", () => {
         const info = WebMessageInfo.deserialize(bin);
-        expect(info.message.imageMessage.scanLengths).toEqual([5453]);
-        expect(info.message.imageMessage.url).toBe("https://mmg-fna.whatsapp.net/d/f/Ao80b2eZH8ojxMdwrIs2z2LCjMrIHaMSiNkdfJXe1Pjs.enc");
-        expect(info.message.imageMessage.height).toBe(1280);
-        expect(info.message.imageMessage.width).toBe(720);
+        expect(info.message!.imageMessage!.scanLengths).toEqual([5453]);
+        expect(info.message!.imageMessage!.url).toBe("https://mmg-fna.whatsapp.net/d/f/Ao80b2eZH8ojxMdwrIs2z2LCjMrIHaMSiNkdfJXe1Pjs.enc");
+        expect(info.message!.imageMessage!.height).toBe(1280);
+        expect(info.message!.imageMessage!.width).toBe(720);
     })
 })

--- a/test/default/BUILD.bazel
+++ b/test/default/BUILD.bazel
@@ -18,11 +18,8 @@ ts_project(
     name = "default",
     srcs = glob(["*.ts"]),
     tsconfig = {
-        "compilerOptions": {
-            "target": "ES2020",
-            "module": "CommonJS"
-        },
-    },
+    }, # no special options
+    extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/test/default/BUILD.bazel
+++ b/test/default/BUILD.bazel
@@ -17,8 +17,7 @@ diff_and_update(
 ts_project(
     name = "default",
     srcs = glob(["*.ts"]),
-    tsconfig = {
-    }, # no special options
+    tsconfig = {}, # no special options
     extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",

--- a/test/default/default.spec.ts
+++ b/test/default/default.spec.ts
@@ -433,4 +433,39 @@ describe("defaults", () => {
         expect(explicitlyProvidedDefaults16.serialize().length).toBeGreaterThan(0);
         expect(explicitlyProvidedDefaults17.serialize().length).toBeGreaterThan(0);
     });
+    it('should create message from empty object via constructor and fromObject', () => {
+        // test the existence of AsObjectPartial type
+        const withDefaultBlank: MessageWithDefault.AsObjectPartial = {}
+        const withDefaultFromObject = MessageWithDefault.fromObject(withDefaultBlank)
+        // if there are no nested messages, AsObjectPartial can be used in the constructor
+        const withDefaultConstructed = new MessageWithDefault(withDefaultBlank);
+        // test the existence of AsObject type
+        const withDefaultObject: MessageWithDefault.AsObject = {
+            bool_field: true,
+            string_field: 'default value',
+            int32_field: 12
+        }
+        expect(withDefaultFromObject.toObject())
+          .toEqual(withDefaultObject)
+        expect(withDefaultConstructed.toObject())
+          .toEqual(withDefaultObject)
+
+        const withImplicitDefaultBlank: MessageWithImplicitDefault.AsObjectPartial = {}
+        const withImplicitDefaultFromObject = MessageWithImplicitDefault.fromObject(
+          withImplicitDefaultBlank
+        );
+        // if there are no nested messages, AsObjectPartial can be used in the constructor
+        const withImplicitDefaultConstructed = new MessageWithImplicitDefault(
+          withDefaultBlank
+        );
+        const withImplicitDefaultObject: MessageWithDefault.AsObject = {
+            bool_field: false,
+            string_field: '',
+            int32_field: 0,
+        }
+        expect(withImplicitDefaultFromObject.toObject())
+          .toEqual(withImplicitDefaultObject)
+        expect(withImplicitDefaultConstructed.toObject())
+          .toEqual(withImplicitDefaultObject)
+    })
 });

--- a/test/default/default.spec.ts
+++ b/test/default/default.spec.ts
@@ -10,7 +10,7 @@ function toObjectPreservingUndefined(message: Object): Object {
     const classPropertyDescriptors = Object.getOwnPropertyDescriptors(message.constructor.prototype);
     const getters = Object.keys(classPropertyDescriptors)
         .filter((k) => classPropertyDescriptors[k].get != null && classPropertyDescriptors[k].set != null);
-    return Object.fromEntries(getters.map((g) => [g, correctFieldValue(message[g])]));
+    return Object.fromEntries(getters.map((g) => [g, correctFieldValue((message as any)[g])]));
 }
 
 describe("defaults", () => {

--- a/test/default/default.spec.ts
+++ b/test/default/default.spec.ts
@@ -111,6 +111,10 @@ describe("defaults", () => {
         });
 
         expect(new DefaultMessageV2WithoutDefault().toObject()).toEqual({
+            // maps are not required
+            map_string_string: {},
+            map_string_message: {},
+
             array_int32: [],
             array_message: [],
             one_of_int32: 0, // scalar oneof fields have implicit defaults
@@ -271,6 +275,9 @@ describe("defaults", () => {
             double: 0,
 
             int_but_string: "0",
+
+            map_string_string: {},
+            map_string_message: {},
 
             array_int32: [],
             array_message: [],

--- a/test/default/default.ts
+++ b/test/default/default.ts
@@ -4,9 +4,6 @@
  * source: test/_/default/default.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class MessageWithDefault extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -55,7 +52,7 @@ export class MessageWithDefault extends pb_1.Message {
     get has_int32_field() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<MessageWithDefault.AsObject>): MessageWithDefault {
+    static fromObject(data: MessageWithDefault.AsObjectPartial): MessageWithDefault {
         const message = new MessageWithDefault({});
         if (data.bool_field != null) {
             message.bool_field = data.bool_field;
@@ -82,7 +79,7 @@ export class MessageWithDefault extends pb_1.Message {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_bool_field)
             writer.writeBool(1, this.bool_field);
-        if (this.has_string_field && this.string_field.length)
+        if (this.has_string_field && this.string_field!.length)
             writer.writeString(2, this.string_field);
         if (this.has_int32_field)
             writer.writeInt32(3, this.int32_field);
@@ -121,6 +118,11 @@ export namespace MessageWithDefault {
         bool_field: boolean;
         string_field: string;
         int32_field: number;
+    };
+    export type AsObjectPartial = {
+        bool_field?: boolean;
+        string_field?: string;
+        int32_field?: number;
     };
 }
 export class MessageWithImplicitDefault extends pb_1.Message {
@@ -171,7 +173,7 @@ export class MessageWithImplicitDefault extends pb_1.Message {
     get has_int32_field() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<MessageWithImplicitDefault.AsObject>): MessageWithImplicitDefault {
+    static fromObject(data: MessageWithImplicitDefault.AsObjectPartial): MessageWithImplicitDefault {
         const message = new MessageWithImplicitDefault({});
         if (data.bool_field != null) {
             message.bool_field = data.bool_field;
@@ -198,7 +200,7 @@ export class MessageWithImplicitDefault extends pb_1.Message {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_bool_field)
             writer.writeBool(1, this.bool_field);
-        if (this.has_string_field && this.string_field.length)
+        if (this.has_string_field && this.string_field!.length)
             writer.writeString(2, this.string_field);
         if (this.has_int32_field)
             writer.writeInt32(3, this.int32_field);
@@ -237,5 +239,10 @@ export namespace MessageWithImplicitDefault {
         bool_field: boolean;
         string_field: string;
         int32_field: number;
+    };
+    export type AsObjectPartial = {
+        bool_field?: boolean;
+        string_field?: string;
+        int32_field?: number;
     };
 }

--- a/test/default/default.ts
+++ b/test/default/default.ts
@@ -71,19 +71,14 @@ export class MessageWithDefault extends pb_1.Message {
     }
     toObject() {
         const data: {
-            bool_field?: boolean;
-            string_field?: string;
-            int32_field?: number;
-        } = {};
-        if (this.bool_field != null) {
-            data.bool_field = this.bool_field;
-        }
-        if (this.string_field != null) {
-            data.string_field = this.string_field;
-        }
-        if (this.int32_field != null) {
-            data.int32_field = this.int32_field;
-        }
+            bool_field: boolean;
+            string_field: string;
+            int32_field: number;
+        } = {
+            bool_field: this.bool_field,
+            string_field: this.string_field,
+            int32_field: this.int32_field
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -193,19 +188,14 @@ export class MessageWithImplicitDefault extends pb_1.Message {
     }
     toObject() {
         const data: {
-            bool_field?: boolean;
-            string_field?: string;
-            int32_field?: number;
-        } = {};
-        if (this.bool_field != null) {
-            data.bool_field = this.bool_field;
-        }
-        if (this.string_field != null) {
-            data.string_field = this.string_field;
-        }
-        if (this.int32_field != null) {
-            data.int32_field = this.int32_field;
-        }
+            bool_field: boolean;
+            string_field: string;
+            int32_field: number;
+        } = {
+            bool_field: this.bool_field,
+            string_field: this.string_field,
+            int32_field: this.int32_field
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/default/default.ts
+++ b/test/default/default.ts
@@ -4,6 +4,9 @@
  * source: test/_/default/default.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class MessageWithDefault extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -52,11 +55,7 @@ export class MessageWithDefault extends pb_1.Message {
     get has_int32_field() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        bool_field?: boolean;
-        string_field?: string;
-        int32_field?: number;
-    }): MessageWithDefault {
+    static fromObject(data: RecursivePartial<MessageWithDefault.AsObject>): MessageWithDefault {
         const message = new MessageWithDefault({});
         if (data.bool_field != null) {
             message.bool_field = data.bool_field;
@@ -70,11 +69,7 @@ export class MessageWithDefault extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            bool_field: boolean;
-            string_field: string;
-            int32_field: number;
-        } = {
+        const data: MessageWithDefault.AsObject = {
             bool_field: this.bool_field,
             string_field: this.string_field,
             int32_field: this.int32_field
@@ -120,6 +115,13 @@ export class MessageWithDefault extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): MessageWithDefault {
         return MessageWithDefault.deserialize(bytes);
     }
+}
+export namespace MessageWithDefault {
+    export type AsObject = {
+        bool_field: boolean;
+        string_field: string;
+        int32_field: number;
+    };
 }
 export class MessageWithImplicitDefault extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -169,11 +171,7 @@ export class MessageWithImplicitDefault extends pb_1.Message {
     get has_int32_field() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        bool_field?: boolean;
-        string_field?: string;
-        int32_field?: number;
-    }): MessageWithImplicitDefault {
+    static fromObject(data: RecursivePartial<MessageWithImplicitDefault.AsObject>): MessageWithImplicitDefault {
         const message = new MessageWithImplicitDefault({});
         if (data.bool_field != null) {
             message.bool_field = data.bool_field;
@@ -187,11 +185,7 @@ export class MessageWithImplicitDefault extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            bool_field: boolean;
-            string_field: string;
-            int32_field: number;
-        } = {
+        const data: MessageWithImplicitDefault.AsObject = {
             bool_field: this.bool_field,
             string_field: this.string_field,
             int32_field: this.int32_field
@@ -237,4 +231,11 @@ export class MessageWithImplicitDefault extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): MessageWithImplicitDefault {
         return MessageWithImplicitDefault.deserialize(bytes);
     }
+}
+export namespace MessageWithImplicitDefault {
+    export type AsObject = {
+        bool_field: boolean;
+        string_field: string;
+        int32_field: number;
+    };
 }

--- a/test/default/default_common.ts
+++ b/test/default/default_common.ts
@@ -4,9 +4,6 @@
  * source: test/_/default/default_common.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export enum DefaultCommonEnum {
     ZERO = 0,
     ONE = 1,
@@ -31,7 +28,7 @@ export class DefaultCommonMessage extends pb_1.Message {
     set message(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<DefaultCommonMessage.AsObject>): DefaultCommonMessage {
+    static fromObject(data: DefaultCommonMessage.AsObjectPartial): DefaultCommonMessage {
         const message = new DefaultCommonMessage({});
         if (data.message != null) {
             message.message = data.message;
@@ -78,6 +75,9 @@ export namespace DefaultCommonMessage {
     export type AsObject = {
         message: string;
     };
+    export type AsObjectPartial = {
+        message?: string;
+    };
 }
 export class DefaultCommonMessageOneOf extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2, 3]];
@@ -118,9 +118,9 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, DefaultCommonMessage, 2) as DefaultCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, DefaultCommonMessage, 2) as DefaultCommonMessage | undefined;
     }
-    set message(value: DefaultCommonMessage | undefined | null) {
+    set message(value: DefaultCommonMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_message() {
@@ -146,7 +146,7 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3])];
     }
-    static fromObject(data: RecursivePartial<DefaultCommonMessageOneOf.AsObject>): DefaultCommonMessageOneOf {
+    static fromObject(data: DefaultCommonMessageOneOf.AsObjectPartial): DefaultCommonMessageOneOf {
         const message = new DefaultCommonMessageOneOf({});
         if (data.int32 != null) {
             message.int32 = data.int32;
@@ -176,7 +176,7 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
         if (this.has_int32)
             writer.writeInt32(1, this.int32);
         if (this.has_message)
-            writer.writeMessage(2, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(2, this.message, () => this.message!.serialize(writer));
         if (this.has_string)
             writer.writeString(3, this.string);
         if (!w)
@@ -214,5 +214,10 @@ export namespace DefaultCommonMessageOneOf {
         int32: number;
         message?: DefaultCommonMessage.AsObject;
         string: string;
+    };
+    export type AsObjectPartial = {
+        int32?: number;
+        message?: DefaultCommonMessage.AsObjectPartial;
+        string?: string;
     };
 }

--- a/test/default/default_common.ts
+++ b/test/default/default_common.ts
@@ -39,11 +39,10 @@ export class DefaultCommonMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            message?: string;
-        } = {};
-        if (this.message != null) {
-            data.message = this.message;
-        }
+            message: string;
+        } = {
+            message: this.message
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -145,7 +144,7 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
     }
     static fromObject(data: {
         int32?: number;
-        message?: ReturnType<typeof DefaultCommonMessage.prototype.toObject>;
+        message?: Parameters<typeof DefaultCommonMessage.fromObject>[0];
         string?: string;
     }): DefaultCommonMessageOneOf {
         const message = new DefaultCommonMessageOneOf({});
@@ -162,18 +161,15 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
     }
     toObject() {
         const data: {
-            int32?: number;
-            message?: ReturnType<typeof DefaultCommonMessage.prototype.toObject>;
-            string?: string;
-        } = {};
-        if (this.int32 != null) {
-            data.int32 = this.int32;
-        }
+            int32: number;
+            message?: Parameters<typeof DefaultCommonMessage.fromObject>[0];
+            string: string;
+        } = {
+            int32: this.int32,
+            string: this.string
+        };
         if (this.message != null) {
             data.message = this.message.toObject();
-        }
-        if (this.string != null) {
-            data.string = this.string;
         }
         return data;
     }

--- a/test/default/default_common.ts
+++ b/test/default/default_common.ts
@@ -4,6 +4,9 @@
  * source: test/_/default/default_common.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export enum DefaultCommonEnum {
     ZERO = 0,
     ONE = 1,
@@ -28,9 +31,7 @@ export class DefaultCommonMessage extends pb_1.Message {
     set message(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        message?: string;
-    }): DefaultCommonMessage {
+    static fromObject(data: RecursivePartial<DefaultCommonMessage.AsObject>): DefaultCommonMessage {
         const message = new DefaultCommonMessage({});
         if (data.message != null) {
             message.message = data.message;
@@ -38,9 +39,7 @@ export class DefaultCommonMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            message: string;
-        } = {
+        const data: DefaultCommonMessage.AsObject = {
             message: this.message
         };
         return data;
@@ -74,6 +73,11 @@ export class DefaultCommonMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): DefaultCommonMessage {
         return DefaultCommonMessage.deserialize(bytes);
     }
+}
+export namespace DefaultCommonMessage {
+    export type AsObject = {
+        message: string;
+    };
 }
 export class DefaultCommonMessageOneOf extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2, 3]];
@@ -142,11 +146,7 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2, 3])];
     }
-    static fromObject(data: {
-        int32?: number;
-        message?: Parameters<typeof DefaultCommonMessage.fromObject>[0];
-        string?: string;
-    }): DefaultCommonMessageOneOf {
+    static fromObject(data: RecursivePartial<DefaultCommonMessageOneOf.AsObject>): DefaultCommonMessageOneOf {
         const message = new DefaultCommonMessageOneOf({});
         if (data.int32 != null) {
             message.int32 = data.int32;
@@ -160,11 +160,7 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            int32: number;
-            message?: Parameters<typeof DefaultCommonMessage.fromObject>[0];
-            string: string;
-        } = {
+        const data: DefaultCommonMessageOneOf.AsObject = {
             int32: this.int32,
             string: this.string
         };
@@ -212,4 +208,11 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): DefaultCommonMessageOneOf {
         return DefaultCommonMessageOneOf.deserialize(bytes);
     }
+}
+export namespace DefaultCommonMessageOneOf {
+    export type AsObject = {
+        int32: number;
+        message?: DefaultCommonMessage.AsObject;
+        string: string;
+    };
 }

--- a/test/default/default_common.ts
+++ b/test/default/default_common.ts
@@ -118,9 +118,9 @@ export class DefaultCommonMessageOneOf extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, DefaultCommonMessage, 2) as DefaultCommonMessage;
+        return pb_1.Message.getWrapperField(this, DefaultCommonMessage, 2) as DefaultCommonMessage | undefined | null;
     }
-    set message(value: DefaultCommonMessage) {
+    set message(value: DefaultCommonMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_message() {

--- a/test/default/default_proto2.ts
+++ b/test/default/default_proto2.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./default_common";
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class DefaultMessageV2WithoutDefault extends pb_1.Message {
     #one_of_decls: number[][] = [[22, 23]];
     constructor(data?: any[] | ({
@@ -78,153 +75,153 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
             this.map_string_message = new Map();
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined;
     }
-    set message(value: dependency_1.DefaultCommonMessage | undefined | null) {
+    set message(value: dependency_1.DefaultCommonMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_message() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get enum() {
-        return pb_1.Message.getField(this, 2) as dependency_1.DefaultCommonEnum | undefined | null;
+        return pb_1.Message.getField(this, 2) as dependency_1.DefaultCommonEnum | undefined;
     }
-    set enum(value: dependency_1.DefaultCommonEnum | undefined | null) {
+    set enum(value: dependency_1.DefaultCommonEnum | undefined) {
         pb_1.Message.setField(this, 2, value);
     }
     get has_enum() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get bool() {
-        return pb_1.Message.getField(this, 3) as boolean | undefined | null;
+        return pb_1.Message.getField(this, 3) as boolean | undefined;
     }
-    set bool(value: boolean | undefined | null) {
+    set bool(value: boolean | undefined) {
         pb_1.Message.setField(this, 3, value);
     }
     get has_bool() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get string() {
-        return pb_1.Message.getField(this, 4) as string | undefined | null;
+        return pb_1.Message.getField(this, 4) as string | undefined;
     }
-    set string(value: string | undefined | null) {
+    set string(value: string | undefined) {
         pb_1.Message.setField(this, 4, value);
     }
     get has_string() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get int32() {
-        return pb_1.Message.getField(this, 5) as number | undefined | null;
+        return pb_1.Message.getField(this, 5) as number | undefined;
     }
-    set int32(value: number | undefined | null) {
+    set int32(value: number | undefined) {
         pb_1.Message.setField(this, 5, value);
     }
     get has_int32() {
         return pb_1.Message.getField(this, 5) != null;
     }
     get fixed32() {
-        return pb_1.Message.getField(this, 6) as number | undefined | null;
+        return pb_1.Message.getField(this, 6) as number | undefined;
     }
-    set fixed32(value: number | undefined | null) {
+    set fixed32(value: number | undefined) {
         pb_1.Message.setField(this, 6, value);
     }
     get has_fixed32() {
         return pb_1.Message.getField(this, 6) != null;
     }
     get sfixed32() {
-        return pb_1.Message.getField(this, 7) as number | undefined | null;
+        return pb_1.Message.getField(this, 7) as number | undefined;
     }
-    set sfixed32(value: number | undefined | null) {
+    set sfixed32(value: number | undefined) {
         pb_1.Message.setField(this, 7, value);
     }
     get has_sfixed32() {
         return pb_1.Message.getField(this, 7) != null;
     }
     get uint32() {
-        return pb_1.Message.getField(this, 8) as number | undefined | null;
+        return pb_1.Message.getField(this, 8) as number | undefined;
     }
-    set uint32(value: number | undefined | null) {
+    set uint32(value: number | undefined) {
         pb_1.Message.setField(this, 8, value);
     }
     get has_uint32() {
         return pb_1.Message.getField(this, 8) != null;
     }
     get sint32() {
-        return pb_1.Message.getField(this, 9) as number | undefined | null;
+        return pb_1.Message.getField(this, 9) as number | undefined;
     }
-    set sint32(value: number | undefined | null) {
+    set sint32(value: number | undefined) {
         pb_1.Message.setField(this, 9, value);
     }
     get has_sint32() {
         return pb_1.Message.getField(this, 9) != null;
     }
     get int64() {
-        return pb_1.Message.getField(this, 10) as number | undefined | null;
+        return pb_1.Message.getField(this, 10) as number | undefined;
     }
-    set int64(value: number | undefined | null) {
+    set int64(value: number | undefined) {
         pb_1.Message.setField(this, 10, value);
     }
     get has_int64() {
         return pb_1.Message.getField(this, 10) != null;
     }
     get fixed64() {
-        return pb_1.Message.getField(this, 11) as number | undefined | null;
+        return pb_1.Message.getField(this, 11) as number | undefined;
     }
-    set fixed64(value: number | undefined | null) {
+    set fixed64(value: number | undefined) {
         pb_1.Message.setField(this, 11, value);
     }
     get has_fixed64() {
         return pb_1.Message.getField(this, 11) != null;
     }
     get sfixed64() {
-        return pb_1.Message.getField(this, 12) as number | undefined | null;
+        return pb_1.Message.getField(this, 12) as number | undefined;
     }
-    set sfixed64(value: number | undefined | null) {
+    set sfixed64(value: number | undefined) {
         pb_1.Message.setField(this, 12, value);
     }
     get has_sfixed64() {
         return pb_1.Message.getField(this, 12) != null;
     }
     get uint64() {
-        return pb_1.Message.getField(this, 13) as number | undefined | null;
+        return pb_1.Message.getField(this, 13) as number | undefined;
     }
-    set uint64(value: number | undefined | null) {
+    set uint64(value: number | undefined) {
         pb_1.Message.setField(this, 13, value);
     }
     get has_uint64() {
         return pb_1.Message.getField(this, 13) != null;
     }
     get sint64() {
-        return pb_1.Message.getField(this, 14) as number | undefined | null;
+        return pb_1.Message.getField(this, 14) as number | undefined;
     }
-    set sint64(value: number | undefined | null) {
+    set sint64(value: number | undefined) {
         pb_1.Message.setField(this, 14, value);
     }
     get has_sint64() {
         return pb_1.Message.getField(this, 14) != null;
     }
     get float() {
-        return pb_1.Message.getField(this, 15) as number | undefined | null;
+        return pb_1.Message.getField(this, 15) as number | undefined;
     }
-    set float(value: number | undefined | null) {
+    set float(value: number | undefined) {
         pb_1.Message.setField(this, 15, value);
     }
     get has_float() {
         return pb_1.Message.getField(this, 15) != null;
     }
     get double() {
-        return pb_1.Message.getField(this, 16) as number | undefined | null;
+        return pb_1.Message.getField(this, 16) as number | undefined;
     }
-    set double(value: number | undefined | null) {
+    set double(value: number | undefined) {
         pb_1.Message.setField(this, 16, value);
     }
     get has_double() {
         return pb_1.Message.getField(this, 16) != null;
     }
     get int_but_string() {
-        return pb_1.Message.getField(this, 17) as string | undefined | null;
+        return pb_1.Message.getField(this, 17) as string | undefined;
     }
-    set int_but_string(value: string | undefined | null) {
+    set int_but_string(value: string | undefined) {
         pb_1.Message.setField(this, 17, value);
     }
     get has_int_but_string() {
@@ -264,18 +261,18 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         return pb_1.Message.getField(this, 22) != null;
     }
     get one_of_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 23) as dependency_1.DefaultCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 23) as dependency_1.DefaultCommonMessage | undefined;
     }
-    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined | null) {
+    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 23, this.#one_of_decls[0], value);
     }
     get has_one_of_message() {
         return pb_1.Message.getField(this, 23) != null;
     }
     get bytes() {
-        return pb_1.Message.getField(this, 24) as Uint8Array | undefined | null;
+        return pb_1.Message.getField(this, 24) as Uint8Array | undefined;
     }
-    set bytes(value: Uint8Array | undefined | null) {
+    set bytes(value: Uint8Array | undefined) {
         pb_1.Message.setField(this, 24, value);
     }
     get has_bytes() {
@@ -291,7 +288,7 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [22, 23])];
     }
-    static fromObject(data: RecursivePartial<DefaultMessageV2WithoutDefault.AsObject>): DefaultMessageV2WithoutDefault {
+    static fromObject(data: DefaultMessageV2WithoutDefault.AsObjectPartial): DefaultMessageV2WithoutDefault {
         const message = new DefaultMessageV2WithoutDefault({
             message: dependency_1.DefaultCommonMessage.fromObject(data.message),
             enum: data.enum,
@@ -396,12 +393,12 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_message)
-            writer.writeMessage(1, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(1, this.message, () => this.message!.serialize(writer));
         if (this.has_enum)
             writer.writeEnum(2, this.enum);
         if (this.has_bool)
             writer.writeBool(3, this.bool);
-        if (this.has_string && this.string.length)
+        if (this.has_string && this.string!.length)
             writer.writeString(4, this.string);
         if (this.has_int32)
             writer.writeInt32(5, this.int32);
@@ -438,18 +435,18 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         for (const [key, value] of this.map_string_message) {
             writer.writeMessage(19, this.map_string_message, () => {
                 writer.writeString(1, key);
-                writer.writeMessage(2, value, () => value.serialize(writer));
+                writer.writeMessage(2, value, () => value!.serialize(writer));
             });
         }
         if (this.array_int32.length)
             writer.writeRepeatedInt32(20, this.array_int32);
         if (this.array_message.length)
-            writer.writeRepeatedMessage(21, this.array_message, (item: dependency_1.DefaultCommonMessage) => item.serialize(writer));
+            writer.writeRepeatedMessage(21, this.array_message, (item: dependency_1.DefaultCommonMessage) => item!.serialize(writer));
         if (this.has_one_of_int32)
             writer.writeInt32(22, this.one_of_int32);
         if (this.has_one_of_message)
-            writer.writeMessage(23, this.one_of_message, () => this.one_of_message.serialize(writer));
-        if (this.has_bytes && this.bytes.length)
+            writer.writeMessage(23, this.one_of_message, () => this.one_of_message!.serialize(writer));
+        if (this.has_bytes && this.bytes!.length)
             writer.writeBytes(24, this.bytes);
         if (!w)
             return writer.getResultBuffer();
@@ -579,6 +576,36 @@ export namespace DefaultMessageV2WithoutDefault {
         one_of_message?: dependency_1.DefaultCommonMessage.AsObject;
         bytes?: Uint8Array;
     };
+    export type AsObjectPartial = {
+        message: dependency_1.DefaultCommonMessage.AsObjectPartial;
+        enum: dependency_1.DefaultCommonEnum;
+        bool: boolean;
+        string: string;
+        int32: number;
+        fixed32: number;
+        sfixed32: number;
+        uint32: number;
+        sint32: number;
+        int64: number;
+        fixed64: number;
+        sfixed64: number;
+        uint64: number;
+        sint64: number;
+        float: number;
+        double: number;
+        int_but_string: string;
+        map_string_string: {
+            [key: string]: string;
+        };
+        map_string_message: {
+            [key: string]: dependency_1.DefaultCommonMessage.AsObject;
+        };
+        array_int32: number[];
+        array_message: dependency_1.DefaultCommonMessage.AsObjectPartial[];
+        one_of_int32?: number;
+        one_of_message?: dependency_1.DefaultCommonMessage.AsObjectPartial;
+        bytes: Uint8Array;
+    };
 }
 export class DefaultMessageV2WithDefault extends pb_1.Message {
     #one_of_decls: number[][] = [[18, 19]];
@@ -636,9 +663,9 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         }
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined;
     }
-    set message(value: dependency_1.DefaultCommonMessage | undefined | null) {
+    set message(value: dependency_1.DefaultCommonMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_message() {
@@ -798,9 +825,9 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         return pb_1.Message.getField(this, 18) != null;
     }
     get one_of_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 19) as dependency_1.DefaultCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 19) as dependency_1.DefaultCommonMessage | undefined;
     }
-    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined | null) {
+    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 19, this.#one_of_decls[0], value);
     }
     get has_one_of_message() {
@@ -816,7 +843,7 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [18, 19])];
     }
-    static fromObject(data: RecursivePartial<DefaultMessageV2WithDefault.AsObject>): DefaultMessageV2WithDefault {
+    static fromObject(data: DefaultMessageV2WithDefault.AsObjectPartial): DefaultMessageV2WithDefault {
         const message = new DefaultMessageV2WithDefault({
             message: dependency_1.DefaultCommonMessage.fromObject(data.message),
             enum: data.enum,
@@ -877,12 +904,12 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_message)
-            writer.writeMessage(1, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(1, this.message, () => this.message!.serialize(writer));
         if (this.has_enum)
             writer.writeEnum(2, this.enum);
         if (this.has_bool)
             writer.writeBool(3, this.bool);
-        if (this.has_string && this.string.length)
+        if (this.has_string && this.string!.length)
             writer.writeString(4, this.string);
         if (this.has_int32)
             writer.writeInt32(5, this.int32);
@@ -913,7 +940,7 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         if (this.has_one_of_int32)
             writer.writeInt32(18, this.one_of_int32);
         if (this.has_one_of_message)
-            writer.writeMessage(19, this.one_of_message, () => this.one_of_message.serialize(writer));
+            writer.writeMessage(19, this.one_of_message, () => this.one_of_message!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -1013,5 +1040,26 @@ export namespace DefaultMessageV2WithDefault {
         int_but_string: string;
         one_of_int32: number;
         one_of_message?: dependency_1.DefaultCommonMessage.AsObject;
+    };
+    export type AsObjectPartial = {
+        message: dependency_1.DefaultCommonMessage.AsObjectPartial;
+        enum: dependency_1.DefaultCommonEnum;
+        bool: boolean;
+        string: string;
+        int32: number;
+        fixed32: number;
+        sfixed32: number;
+        uint32: number;
+        sint32: number;
+        int64: number;
+        fixed64: number;
+        sfixed64: number;
+        uint64: number;
+        sint64: number;
+        float: number;
+        double: number;
+        int_but_string: string;
+        one_of_int32?: number;
+        one_of_message?: dependency_1.DefaultCommonMessage.AsObjectPartial;
     };
 }

--- a/test/default/default_proto2.ts
+++ b/test/default/default_proto2.ts
@@ -78,153 +78,153 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
             this.map_string_message = new Map();
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined | null;
     }
-    set message(value: dependency_1.DefaultCommonMessage) {
+    set message(value: dependency_1.DefaultCommonMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_message() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get enum() {
-        return pb_1.Message.getField(this, 2) as dependency_1.DefaultCommonEnum;
+        return pb_1.Message.getField(this, 2) as dependency_1.DefaultCommonEnum | undefined | null;
     }
-    set enum(value: dependency_1.DefaultCommonEnum) {
+    set enum(value: dependency_1.DefaultCommonEnum | undefined | null) {
         pb_1.Message.setField(this, 2, value);
     }
     get has_enum() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get bool() {
-        return pb_1.Message.getField(this, 3) as boolean;
+        return pb_1.Message.getField(this, 3) as boolean | undefined | null;
     }
-    set bool(value: boolean) {
+    set bool(value: boolean | undefined | null) {
         pb_1.Message.setField(this, 3, value);
     }
     get has_bool() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get string() {
-        return pb_1.Message.getField(this, 4) as string;
+        return pb_1.Message.getField(this, 4) as string | undefined | null;
     }
-    set string(value: string) {
+    set string(value: string | undefined | null) {
         pb_1.Message.setField(this, 4, value);
     }
     get has_string() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get int32() {
-        return pb_1.Message.getField(this, 5) as number;
+        return pb_1.Message.getField(this, 5) as number | undefined | null;
     }
-    set int32(value: number) {
+    set int32(value: number | undefined | null) {
         pb_1.Message.setField(this, 5, value);
     }
     get has_int32() {
         return pb_1.Message.getField(this, 5) != null;
     }
     get fixed32() {
-        return pb_1.Message.getField(this, 6) as number;
+        return pb_1.Message.getField(this, 6) as number | undefined | null;
     }
-    set fixed32(value: number) {
+    set fixed32(value: number | undefined | null) {
         pb_1.Message.setField(this, 6, value);
     }
     get has_fixed32() {
         return pb_1.Message.getField(this, 6) != null;
     }
     get sfixed32() {
-        return pb_1.Message.getField(this, 7) as number;
+        return pb_1.Message.getField(this, 7) as number | undefined | null;
     }
-    set sfixed32(value: number) {
+    set sfixed32(value: number | undefined | null) {
         pb_1.Message.setField(this, 7, value);
     }
     get has_sfixed32() {
         return pb_1.Message.getField(this, 7) != null;
     }
     get uint32() {
-        return pb_1.Message.getField(this, 8) as number;
+        return pb_1.Message.getField(this, 8) as number | undefined | null;
     }
-    set uint32(value: number) {
+    set uint32(value: number | undefined | null) {
         pb_1.Message.setField(this, 8, value);
     }
     get has_uint32() {
         return pb_1.Message.getField(this, 8) != null;
     }
     get sint32() {
-        return pb_1.Message.getField(this, 9) as number;
+        return pb_1.Message.getField(this, 9) as number | undefined | null;
     }
-    set sint32(value: number) {
+    set sint32(value: number | undefined | null) {
         pb_1.Message.setField(this, 9, value);
     }
     get has_sint32() {
         return pb_1.Message.getField(this, 9) != null;
     }
     get int64() {
-        return pb_1.Message.getField(this, 10) as number;
+        return pb_1.Message.getField(this, 10) as number | undefined | null;
     }
-    set int64(value: number) {
+    set int64(value: number | undefined | null) {
         pb_1.Message.setField(this, 10, value);
     }
     get has_int64() {
         return pb_1.Message.getField(this, 10) != null;
     }
     get fixed64() {
-        return pb_1.Message.getField(this, 11) as number;
+        return pb_1.Message.getField(this, 11) as number | undefined | null;
     }
-    set fixed64(value: number) {
+    set fixed64(value: number | undefined | null) {
         pb_1.Message.setField(this, 11, value);
     }
     get has_fixed64() {
         return pb_1.Message.getField(this, 11) != null;
     }
     get sfixed64() {
-        return pb_1.Message.getField(this, 12) as number;
+        return pb_1.Message.getField(this, 12) as number | undefined | null;
     }
-    set sfixed64(value: number) {
+    set sfixed64(value: number | undefined | null) {
         pb_1.Message.setField(this, 12, value);
     }
     get has_sfixed64() {
         return pb_1.Message.getField(this, 12) != null;
     }
     get uint64() {
-        return pb_1.Message.getField(this, 13) as number;
+        return pb_1.Message.getField(this, 13) as number | undefined | null;
     }
-    set uint64(value: number) {
+    set uint64(value: number | undefined | null) {
         pb_1.Message.setField(this, 13, value);
     }
     get has_uint64() {
         return pb_1.Message.getField(this, 13) != null;
     }
     get sint64() {
-        return pb_1.Message.getField(this, 14) as number;
+        return pb_1.Message.getField(this, 14) as number | undefined | null;
     }
-    set sint64(value: number) {
+    set sint64(value: number | undefined | null) {
         pb_1.Message.setField(this, 14, value);
     }
     get has_sint64() {
         return pb_1.Message.getField(this, 14) != null;
     }
     get float() {
-        return pb_1.Message.getField(this, 15) as number;
+        return pb_1.Message.getField(this, 15) as number | undefined | null;
     }
-    set float(value: number) {
+    set float(value: number | undefined | null) {
         pb_1.Message.setField(this, 15, value);
     }
     get has_float() {
         return pb_1.Message.getField(this, 15) != null;
     }
     get double() {
-        return pb_1.Message.getField(this, 16) as number;
+        return pb_1.Message.getField(this, 16) as number | undefined | null;
     }
-    set double(value: number) {
+    set double(value: number | undefined | null) {
         pb_1.Message.setField(this, 16, value);
     }
     get has_double() {
         return pb_1.Message.getField(this, 16) != null;
     }
     get int_but_string() {
-        return pb_1.Message.getField(this, 17) as string;
+        return pb_1.Message.getField(this, 17) as string | undefined | null;
     }
-    set int_but_string(value: string) {
+    set int_but_string(value: string | undefined | null) {
         pb_1.Message.setField(this, 17, value);
     }
     get has_int_but_string() {
@@ -264,18 +264,18 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         return pb_1.Message.getField(this, 22) != null;
     }
     get one_of_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 23) as dependency_1.DefaultCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 23) as dependency_1.DefaultCommonMessage | undefined | null;
     }
-    set one_of_message(value: dependency_1.DefaultCommonMessage) {
+    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 23, this.#one_of_decls[0], value);
     }
     get has_one_of_message() {
         return pb_1.Message.getField(this, 23) != null;
     }
     get bytes() {
-        return pb_1.Message.getField(this, 24) as Uint8Array;
+        return pb_1.Message.getField(this, 24) as Uint8Array | undefined | null;
     }
-    set bytes(value: Uint8Array) {
+    set bytes(value: Uint8Array | undefined | null) {
         pb_1.Message.setField(this, 24, value);
     }
     get has_bytes() {
@@ -636,9 +636,9 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         }
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined | null;
     }
-    set message(value: dependency_1.DefaultCommonMessage) {
+    set message(value: dependency_1.DefaultCommonMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_message() {
@@ -798,9 +798,9 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         return pb_1.Message.getField(this, 18) != null;
     }
     get one_of_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 19) as dependency_1.DefaultCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 19) as dependency_1.DefaultCommonMessage | undefined | null;
     }
-    set one_of_message(value: dependency_1.DefaultCommonMessage) {
+    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 19, this.#one_of_decls[0], value);
     }
     get has_one_of_message() {

--- a/test/default/default_proto2.ts
+++ b/test/default/default_proto2.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./default_common";
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class DefaultMessageV2WithoutDefault extends pb_1.Message {
     #one_of_decls: number[][] = [[22, 23]];
     constructor(data?: any[] | ({
@@ -288,36 +291,7 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [22, 23])];
     }
-    static fromObject(data: {
-        message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-        enum?: dependency_1.DefaultCommonEnum;
-        bool?: boolean;
-        string?: string;
-        int32?: number;
-        fixed32?: number;
-        sfixed32?: number;
-        uint32?: number;
-        sint32?: number;
-        int64?: number;
-        fixed64?: number;
-        sfixed64?: number;
-        uint64?: number;
-        sint64?: number;
-        float?: number;
-        double?: number;
-        int_but_string?: string;
-        map_string_string?: {
-            [key: string]: string;
-        };
-        map_string_message?: {
-            [key: string]: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-        };
-        array_int32?: number[];
-        array_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0][];
-        one_of_int32?: number;
-        one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-        bytes?: Uint8Array;
-    }): DefaultMessageV2WithoutDefault {
+    static fromObject(data: RecursivePartial<DefaultMessageV2WithoutDefault.AsObject>): DefaultMessageV2WithoutDefault {
         const message = new DefaultMessageV2WithoutDefault({
             message: dependency_1.DefaultCommonMessage.fromObject(data.message),
             enum: data.enum,
@@ -351,36 +325,7 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-            enum?: dependency_1.DefaultCommonEnum;
-            bool?: boolean;
-            string?: string;
-            int32?: number;
-            fixed32?: number;
-            sfixed32?: number;
-            uint32?: number;
-            sint32?: number;
-            int64?: number;
-            fixed64?: number;
-            sfixed64?: number;
-            uint64?: number;
-            sint64?: number;
-            float?: number;
-            double?: number;
-            int_but_string?: string;
-            map_string_string: {
-                [key: string]: string;
-            };
-            map_string_message: {
-                [key: string]: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-            };
-            array_int32: number[];
-            array_message: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0][];
-            one_of_int32: number;
-            one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-            bytes?: Uint8Array;
-        } = {
+        const data: DefaultMessageV2WithoutDefault.AsObject = {
             map_string_string: Object.fromEntries(this.map_string_string),
             map_string_message: Object.fromEntries(Array.from(this.map_string_message).map(([key, value]) => [key, value.toObject()])),
             array_int32: this.array_int32,
@@ -602,6 +547,38 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): DefaultMessageV2WithoutDefault {
         return DefaultMessageV2WithoutDefault.deserialize(bytes);
     }
+}
+export namespace DefaultMessageV2WithoutDefault {
+    export type AsObject = {
+        message?: dependency_1.DefaultCommonMessage.AsObject;
+        enum?: dependency_1.DefaultCommonEnum;
+        bool?: boolean;
+        string?: string;
+        int32?: number;
+        fixed32?: number;
+        sfixed32?: number;
+        uint32?: number;
+        sint32?: number;
+        int64?: number;
+        fixed64?: number;
+        sfixed64?: number;
+        uint64?: number;
+        sint64?: number;
+        float?: number;
+        double?: number;
+        int_but_string?: string;
+        map_string_string: {
+            [key: string]: string;
+        };
+        map_string_message: {
+            [key: string]: dependency_1.DefaultCommonMessage.AsObject;
+        };
+        array_int32: number[];
+        array_message: dependency_1.DefaultCommonMessage.AsObject[];
+        one_of_int32: number;
+        one_of_message?: dependency_1.DefaultCommonMessage.AsObject;
+        bytes?: Uint8Array;
+    };
 }
 export class DefaultMessageV2WithDefault extends pb_1.Message {
     #one_of_decls: number[][] = [[18, 19]];
@@ -839,27 +816,7 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [18, 19])];
     }
-    static fromObject(data: {
-        message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-        enum?: dependency_1.DefaultCommonEnum;
-        bool?: boolean;
-        string?: string;
-        int32?: number;
-        fixed32?: number;
-        sfixed32?: number;
-        uint32?: number;
-        sint32?: number;
-        int64?: number;
-        fixed64?: number;
-        sfixed64?: number;
-        uint64?: number;
-        sint64?: number;
-        float?: number;
-        double?: number;
-        int_but_string?: string;
-        one_of_int32?: number;
-        one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-    }): DefaultMessageV2WithDefault {
+    static fromObject(data: RecursivePartial<DefaultMessageV2WithDefault.AsObject>): DefaultMessageV2WithDefault {
         const message = new DefaultMessageV2WithDefault({
             message: dependency_1.DefaultCommonMessage.fromObject(data.message),
             enum: data.enum,
@@ -888,27 +845,7 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-            enum: dependency_1.DefaultCommonEnum;
-            bool: boolean;
-            string: string;
-            int32: number;
-            fixed32: number;
-            sfixed32: number;
-            uint32: number;
-            sint32: number;
-            int64: number;
-            fixed64: number;
-            sfixed64: number;
-            uint64: number;
-            sint64: number;
-            float: number;
-            double: number;
-            int_but_string: string;
-            one_of_int32: number;
-            one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-        } = {
+        const data: DefaultMessageV2WithDefault.AsObject = {
             enum: this.enum,
             bool: this.bool,
             string: this.string,
@@ -1054,4 +991,27 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): DefaultMessageV2WithDefault {
         return DefaultMessageV2WithDefault.deserialize(bytes);
     }
+}
+export namespace DefaultMessageV2WithDefault {
+    export type AsObject = {
+        message?: dependency_1.DefaultCommonMessage.AsObject;
+        enum: dependency_1.DefaultCommonEnum;
+        bool: boolean;
+        string: string;
+        int32: number;
+        fixed32: number;
+        sfixed32: number;
+        uint32: number;
+        sint32: number;
+        int64: number;
+        fixed64: number;
+        sfixed64: number;
+        uint64: number;
+        sint64: number;
+        float: number;
+        double: number;
+        int_but_string: string;
+        one_of_int32: number;
+        one_of_message?: dependency_1.DefaultCommonMessage.AsObject;
+    };
 }

--- a/test/default/default_proto2.ts
+++ b/test/default/default_proto2.ts
@@ -434,10 +434,10 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         if (this.int_but_string != null) {
             data.int_but_string = this.int_but_string;
         }
-        if (this.map_string_string.size > 0) {
+        if (this.map_string_string != null) {
             data.map_string_string = Object.fromEntries(this.map_string_string);
         }
-        if (this.map_string_message.size > 0) {
+        if (this.map_string_message != null) {
             data.map_string_message = Object.fromEntries(Array.from(this.map_string_message).map(([key, value]) => [key, value.toObject()]));
         }
         if (this.array_message != null) {

--- a/test/default/default_proto2.ts
+++ b/test/default/default_proto2.ts
@@ -289,7 +289,7 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         return cases[pb_1.Message.computeOneofCase(this, [22, 23])];
     }
     static fromObject(data: {
-        message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+        message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
         enum?: dependency_1.DefaultCommonEnum;
         bool?: boolean;
         string?: string;
@@ -310,12 +310,12 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
             [key: string]: string;
         };
         map_string_message?: {
-            [key: string]: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+            [key: string]: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
         };
-        array_int32: number[];
-        array_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>[];
+        array_int32?: number[];
+        array_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0][];
         one_of_int32?: number;
-        one_of_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+        one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
         bytes?: Uint8Array;
     }): DefaultMessageV2WithoutDefault {
         const message = new DefaultMessageV2WithoutDefault({
@@ -352,7 +352,7 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
     }
     toObject() {
         const data: {
-            message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+            message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
             enum?: dependency_1.DefaultCommonEnum;
             bool?: boolean;
             string?: string;
@@ -369,19 +369,23 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
             float?: number;
             double?: number;
             int_but_string?: string;
-            map_string_string?: {
+            map_string_string: {
                 [key: string]: string;
             };
-            map_string_message?: {
-                [key: string]: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+            map_string_message: {
+                [key: string]: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
             };
             array_int32: number[];
-            array_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>[];
-            one_of_int32?: number;
-            one_of_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+            array_message: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0][];
+            one_of_int32: number;
+            one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
             bytes?: Uint8Array;
         } = {
-            array_int32: this.array_int32
+            map_string_string: Object.fromEntries(this.map_string_string),
+            map_string_message: Object.fromEntries(Array.from(this.map_string_message).map(([key, value]) => [key, value.toObject()])),
+            array_int32: this.array_int32,
+            array_message: this.array_message.map((item: dependency_1.DefaultCommonMessage) => item.toObject()),
+            one_of_int32: this.one_of_int32
         };
         if (this.message != null) {
             data.message = this.message.toObject();
@@ -433,18 +437,6 @@ export class DefaultMessageV2WithoutDefault extends pb_1.Message {
         }
         if (this.int_but_string != null) {
             data.int_but_string = this.int_but_string;
-        }
-        if (this.map_string_string != null) {
-            data.map_string_string = Object.fromEntries(this.map_string_string);
-        }
-        if (this.map_string_message != null) {
-            data.map_string_message = Object.fromEntries(Array.from(this.map_string_message).map(([key, value]) => [key, value.toObject()]));
-        }
-        if (this.array_message != null) {
-            data.array_message = this.array_message.map((item: dependency_1.DefaultCommonMessage) => item.toObject());
-        }
-        if (this.one_of_int32 != null) {
-            data.one_of_int32 = this.one_of_int32;
         }
         if (this.one_of_message != null) {
             data.one_of_message = this.one_of_message.toObject();
@@ -848,25 +840,25 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
         return cases[pb_1.Message.computeOneofCase(this, [18, 19])];
     }
     static fromObject(data: {
-        message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
-        enum: dependency_1.DefaultCommonEnum;
-        bool: boolean;
-        string: string;
-        int32: number;
-        fixed32: number;
-        sfixed32: number;
-        uint32: number;
-        sint32: number;
-        int64: number;
-        fixed64: number;
-        sfixed64: number;
-        uint64: number;
-        sint64: number;
-        float: number;
-        double: number;
-        int_but_string: string;
+        message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
+        enum?: dependency_1.DefaultCommonEnum;
+        bool?: boolean;
+        string?: string;
+        int32?: number;
+        fixed32?: number;
+        sfixed32?: number;
+        uint32?: number;
+        sint32?: number;
+        int64?: number;
+        fixed64?: number;
+        sfixed64?: number;
+        uint64?: number;
+        sint64?: number;
+        float?: number;
+        double?: number;
+        int_but_string?: string;
         one_of_int32?: number;
-        one_of_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+        one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
     }): DefaultMessageV2WithDefault {
         const message = new DefaultMessageV2WithDefault({
             message: dependency_1.DefaultCommonMessage.fromObject(data.message),
@@ -897,7 +889,7 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
     }
     toObject() {
         const data: {
-            message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+            message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
             enum: dependency_1.DefaultCommonEnum;
             bool: boolean;
             string: string;
@@ -914,8 +906,8 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
             float: number;
             double: number;
             int_but_string: string;
-            one_of_int32?: number;
-            one_of_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+            one_of_int32: number;
+            one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
         } = {
             enum: this.enum,
             bool: this.bool,
@@ -932,13 +924,11 @@ export class DefaultMessageV2WithDefault extends pb_1.Message {
             sint64: this.sint64,
             float: this.float,
             double: this.double,
-            int_but_string: this.int_but_string
+            int_but_string: this.int_but_string,
+            one_of_int32: this.one_of_int32
         };
         if (this.message != null) {
             data.message = this.message.toObject();
-        }
-        if (this.one_of_int32 != null) {
-            data.one_of_int32 = this.one_of_int32;
         }
         if (this.one_of_message != null) {
             data.one_of_message = this.one_of_message.toObject();

--- a/test/default/default_proto3.ts
+++ b/test/default/default_proto3.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./default_common";
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class DefaultMessageV3 extends pb_1.Message {
     #one_of_decls: number[][] = [[22, 23]];
     constructor(data?: any[] | ({
@@ -281,36 +284,7 @@ export class DefaultMessageV3 extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [22, 23])];
     }
-    static fromObject(data: {
-        message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-        enum?: dependency_1.DefaultCommonEnum;
-        bool?: boolean;
-        string?: string;
-        int32?: number;
-        fixed32?: number;
-        sfixed32?: number;
-        uint32?: number;
-        sint32?: number;
-        int64?: number;
-        fixed64?: number;
-        sfixed64?: number;
-        uint64?: number;
-        sint64?: number;
-        float?: number;
-        double?: number;
-        int_but_string?: string;
-        map_string_string?: {
-            [key: string]: string;
-        };
-        map_string_message?: {
-            [key: string]: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-        };
-        array_int32?: number[];
-        array_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0][];
-        one_of_int32?: number;
-        one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-        bytes?: Uint8Array;
-    }): DefaultMessageV3 {
+    static fromObject(data: RecursivePartial<DefaultMessageV3.AsObject>): DefaultMessageV3 {
         const message = new DefaultMessageV3({});
         if (data.message != null) {
             message.message = dependency_1.DefaultCommonMessage.fromObject(data.message);
@@ -387,36 +361,7 @@ export class DefaultMessageV3 extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-            enum: dependency_1.DefaultCommonEnum;
-            bool: boolean;
-            string: string;
-            int32: number;
-            fixed32: number;
-            sfixed32: number;
-            uint32: number;
-            sint32: number;
-            int64: number;
-            fixed64: number;
-            sfixed64: number;
-            uint64: number;
-            sint64: number;
-            float: number;
-            double: number;
-            int_but_string: string;
-            map_string_string: {
-                [key: string]: string;
-            };
-            map_string_message: {
-                [key: string]: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-            };
-            array_int32: number[];
-            array_message: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0][];
-            one_of_int32: number;
-            one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
-            bytes: Uint8Array;
-        } = {
+        const data: DefaultMessageV3.AsObject = {
             enum: this.enum,
             bool: this.bool,
             string: this.string,
@@ -604,6 +549,38 @@ export class DefaultMessageV3 extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): DefaultMessageV3 {
         return DefaultMessageV3.deserialize(bytes);
     }
+}
+export namespace DefaultMessageV3 {
+    export type AsObject = {
+        message?: dependency_1.DefaultCommonMessage.AsObject;
+        enum: dependency_1.DefaultCommonEnum;
+        bool: boolean;
+        string: string;
+        int32: number;
+        fixed32: number;
+        sfixed32: number;
+        uint32: number;
+        sint32: number;
+        int64: number;
+        fixed64: number;
+        sfixed64: number;
+        uint64: number;
+        sint64: number;
+        float: number;
+        double: number;
+        int_but_string: string;
+        map_string_string: {
+            [key: string]: string;
+        };
+        map_string_message: {
+            [key: string]: dependency_1.DefaultCommonMessage.AsObject;
+        };
+        array_int32: number[];
+        array_message: dependency_1.DefaultCommonMessage.AsObject[];
+        one_of_int32: number;
+        one_of_message?: dependency_1.DefaultCommonMessage.AsObject;
+        bytes: Uint8Array;
+    };
 }
 export class DefaultMessageOptionalV3 extends pb_1.Message {
     #one_of_decls: number[][] = [[2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15], [16], [17], [24]];
@@ -1004,25 +981,7 @@ export class DefaultMessageOptionalV3 extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [24])];
     }
-    static fromObject(data: {
-        enum?: dependency_1.DefaultCommonEnum;
-        bool?: boolean;
-        string?: string;
-        int32?: number;
-        fixed32?: number;
-        sfixed32?: number;
-        uint32?: number;
-        sint32?: number;
-        int64?: number;
-        fixed64?: number;
-        sfixed64?: number;
-        uint64?: number;
-        sint64?: number;
-        float?: number;
-        double?: number;
-        int_but_string?: string;
-        bytes?: Uint8Array;
-    }): DefaultMessageOptionalV3 {
+    static fromObject(data: RecursivePartial<DefaultMessageOptionalV3.AsObject>): DefaultMessageOptionalV3 {
         const message = new DefaultMessageOptionalV3({});
         if (data.enum != null) {
             message.enum = data.enum;
@@ -1078,25 +1037,7 @@ export class DefaultMessageOptionalV3 extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            enum: dependency_1.DefaultCommonEnum;
-            bool: boolean;
-            string: string;
-            int32: number;
-            fixed32: number;
-            sfixed32: number;
-            uint32: number;
-            sint32: number;
-            int64: number;
-            fixed64: number;
-            sfixed64: number;
-            uint64: number;
-            sint64: number;
-            float: number;
-            double: number;
-            int_but_string: string;
-            bytes: Uint8Array;
-        } = {
+        const data: DefaultMessageOptionalV3.AsObject = {
             enum: this.enum,
             bool: this.bool,
             string: this.string,
@@ -1226,4 +1167,25 @@ export class DefaultMessageOptionalV3 extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): DefaultMessageOptionalV3 {
         return DefaultMessageOptionalV3.deserialize(bytes);
     }
+}
+export namespace DefaultMessageOptionalV3 {
+    export type AsObject = {
+        enum: dependency_1.DefaultCommonEnum;
+        bool: boolean;
+        string: string;
+        int32: number;
+        fixed32: number;
+        sfixed32: number;
+        uint32: number;
+        sint32: number;
+        int64: number;
+        fixed64: number;
+        sfixed64: number;
+        uint64: number;
+        sint64: number;
+        float: number;
+        double: number;
+        int_but_string: string;
+        bytes: Uint8Array;
+    };
 }

--- a/test/default/default_proto3.ts
+++ b/test/default/default_proto3.ts
@@ -468,10 +468,10 @@ export class DefaultMessageV3 extends pb_1.Message {
         if (this.int_but_string != null) {
             data.int_but_string = this.int_but_string;
         }
-        if (this.map_string_string.size > 0) {
+        if (this.map_string_string != null) {
             data.map_string_string = Object.fromEntries(this.map_string_string);
         }
-        if (this.map_string_message.size > 0) {
+        if (this.map_string_message != null) {
             data.map_string_message = Object.fromEntries(Array.from(this.map_string_message).map(([key, value]) => [key, value.toObject()]));
         }
         if (this.array_int32 != null) {

--- a/test/default/default_proto3.ts
+++ b/test/default/default_proto3.ts
@@ -282,7 +282,7 @@ export class DefaultMessageV3 extends pb_1.Message {
         return cases[pb_1.Message.computeOneofCase(this, [22, 23])];
     }
     static fromObject(data: {
-        message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+        message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
         enum?: dependency_1.DefaultCommonEnum;
         bool?: boolean;
         string?: string;
@@ -303,12 +303,12 @@ export class DefaultMessageV3 extends pb_1.Message {
             [key: string]: string;
         };
         map_string_message?: {
-            [key: string]: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+            [key: string]: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
         };
         array_int32?: number[];
-        array_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>[];
+        array_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0][];
         one_of_int32?: number;
-        one_of_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+        one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
         bytes?: Uint8Array;
     }): DefaultMessageV3 {
         const message = new DefaultMessageV3({});
@@ -388,106 +388,63 @@ export class DefaultMessageV3 extends pb_1.Message {
     }
     toObject() {
         const data: {
-            message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
-            enum?: dependency_1.DefaultCommonEnum;
-            bool?: boolean;
-            string?: string;
-            int32?: number;
-            fixed32?: number;
-            sfixed32?: number;
-            uint32?: number;
-            sint32?: number;
-            int64?: number;
-            fixed64?: number;
-            sfixed64?: number;
-            uint64?: number;
-            sint64?: number;
-            float?: number;
-            double?: number;
-            int_but_string?: string;
-            map_string_string?: {
+            message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
+            enum: dependency_1.DefaultCommonEnum;
+            bool: boolean;
+            string: string;
+            int32: number;
+            fixed32: number;
+            sfixed32: number;
+            uint32: number;
+            sint32: number;
+            int64: number;
+            fixed64: number;
+            sfixed64: number;
+            uint64: number;
+            sint64: number;
+            float: number;
+            double: number;
+            int_but_string: string;
+            map_string_string: {
                 [key: string]: string;
             };
-            map_string_message?: {
-                [key: string]: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
+            map_string_message: {
+                [key: string]: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
             };
-            array_int32?: number[];
-            array_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>[];
-            one_of_int32?: number;
-            one_of_message?: ReturnType<typeof dependency_1.DefaultCommonMessage.prototype.toObject>;
-            bytes?: Uint8Array;
-        } = {};
+            array_int32: number[];
+            array_message: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0][];
+            one_of_int32: number;
+            one_of_message?: Parameters<typeof dependency_1.DefaultCommonMessage.fromObject>[0];
+            bytes: Uint8Array;
+        } = {
+            enum: this.enum,
+            bool: this.bool,
+            string: this.string,
+            int32: this.int32,
+            fixed32: this.fixed32,
+            sfixed32: this.sfixed32,
+            uint32: this.uint32,
+            sint32: this.sint32,
+            int64: this.int64,
+            fixed64: this.fixed64,
+            sfixed64: this.sfixed64,
+            uint64: this.uint64,
+            sint64: this.sint64,
+            float: this.float,
+            double: this.double,
+            int_but_string: this.int_but_string,
+            map_string_string: Object.fromEntries(this.map_string_string),
+            map_string_message: Object.fromEntries(Array.from(this.map_string_message).map(([key, value]) => [key, value.toObject()])),
+            array_int32: this.array_int32,
+            array_message: this.array_message.map((item: dependency_1.DefaultCommonMessage) => item.toObject()),
+            one_of_int32: this.one_of_int32,
+            bytes: this.bytes
+        };
         if (this.message != null) {
             data.message = this.message.toObject();
         }
-        if (this.enum != null) {
-            data.enum = this.enum;
-        }
-        if (this.bool != null) {
-            data.bool = this.bool;
-        }
-        if (this.string != null) {
-            data.string = this.string;
-        }
-        if (this.int32 != null) {
-            data.int32 = this.int32;
-        }
-        if (this.fixed32 != null) {
-            data.fixed32 = this.fixed32;
-        }
-        if (this.sfixed32 != null) {
-            data.sfixed32 = this.sfixed32;
-        }
-        if (this.uint32 != null) {
-            data.uint32 = this.uint32;
-        }
-        if (this.sint32 != null) {
-            data.sint32 = this.sint32;
-        }
-        if (this.int64 != null) {
-            data.int64 = this.int64;
-        }
-        if (this.fixed64 != null) {
-            data.fixed64 = this.fixed64;
-        }
-        if (this.sfixed64 != null) {
-            data.sfixed64 = this.sfixed64;
-        }
-        if (this.uint64 != null) {
-            data.uint64 = this.uint64;
-        }
-        if (this.sint64 != null) {
-            data.sint64 = this.sint64;
-        }
-        if (this.float != null) {
-            data.float = this.float;
-        }
-        if (this.double != null) {
-            data.double = this.double;
-        }
-        if (this.int_but_string != null) {
-            data.int_but_string = this.int_but_string;
-        }
-        if (this.map_string_string != null) {
-            data.map_string_string = Object.fromEntries(this.map_string_string);
-        }
-        if (this.map_string_message != null) {
-            data.map_string_message = Object.fromEntries(Array.from(this.map_string_message).map(([key, value]) => [key, value.toObject()]));
-        }
-        if (this.array_int32 != null) {
-            data.array_int32 = this.array_int32;
-        }
-        if (this.array_message != null) {
-            data.array_message = this.array_message.map((item: dependency_1.DefaultCommonMessage) => item.toObject());
-        }
-        if (this.one_of_int32 != null) {
-            data.one_of_int32 = this.one_of_int32;
-        }
         if (this.one_of_message != null) {
             data.one_of_message = this.one_of_message.toObject();
-        }
-        if (this.bytes != null) {
-            data.bytes = this.bytes;
         }
         return data;
     }
@@ -1122,75 +1079,42 @@ export class DefaultMessageOptionalV3 extends pb_1.Message {
     }
     toObject() {
         const data: {
-            enum?: dependency_1.DefaultCommonEnum;
-            bool?: boolean;
-            string?: string;
-            int32?: number;
-            fixed32?: number;
-            sfixed32?: number;
-            uint32?: number;
-            sint32?: number;
-            int64?: number;
-            fixed64?: number;
-            sfixed64?: number;
-            uint64?: number;
-            sint64?: number;
-            float?: number;
-            double?: number;
-            int_but_string?: string;
-            bytes?: Uint8Array;
-        } = {};
-        if (this.enum != null) {
-            data.enum = this.enum;
-        }
-        if (this.bool != null) {
-            data.bool = this.bool;
-        }
-        if (this.string != null) {
-            data.string = this.string;
-        }
-        if (this.int32 != null) {
-            data.int32 = this.int32;
-        }
-        if (this.fixed32 != null) {
-            data.fixed32 = this.fixed32;
-        }
-        if (this.sfixed32 != null) {
-            data.sfixed32 = this.sfixed32;
-        }
-        if (this.uint32 != null) {
-            data.uint32 = this.uint32;
-        }
-        if (this.sint32 != null) {
-            data.sint32 = this.sint32;
-        }
-        if (this.int64 != null) {
-            data.int64 = this.int64;
-        }
-        if (this.fixed64 != null) {
-            data.fixed64 = this.fixed64;
-        }
-        if (this.sfixed64 != null) {
-            data.sfixed64 = this.sfixed64;
-        }
-        if (this.uint64 != null) {
-            data.uint64 = this.uint64;
-        }
-        if (this.sint64 != null) {
-            data.sint64 = this.sint64;
-        }
-        if (this.float != null) {
-            data.float = this.float;
-        }
-        if (this.double != null) {
-            data.double = this.double;
-        }
-        if (this.int_but_string != null) {
-            data.int_but_string = this.int_but_string;
-        }
-        if (this.bytes != null) {
-            data.bytes = this.bytes;
-        }
+            enum: dependency_1.DefaultCommonEnum;
+            bool: boolean;
+            string: string;
+            int32: number;
+            fixed32: number;
+            sfixed32: number;
+            uint32: number;
+            sint32: number;
+            int64: number;
+            fixed64: number;
+            sfixed64: number;
+            uint64: number;
+            sint64: number;
+            float: number;
+            double: number;
+            int_but_string: string;
+            bytes: Uint8Array;
+        } = {
+            enum: this.enum,
+            bool: this.bool,
+            string: this.string,
+            int32: this.int32,
+            fixed32: this.fixed32,
+            sfixed32: this.sfixed32,
+            uint32: this.uint32,
+            sint32: this.sint32,
+            int64: this.int64,
+            fixed64: this.fixed64,
+            sfixed64: this.sfixed64,
+            uint64: this.uint64,
+            sint64: this.sint64,
+            float: this.float,
+            double: this.double,
+            int_but_string: this.int_but_string,
+            bytes: this.bytes
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/default/default_proto3.ts
+++ b/test/default/default_proto3.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./default_common";
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class DefaultMessageV3 extends pb_1.Message {
     #one_of_decls: number[][] = [[22, 23]];
     constructor(data?: any[] | ({
@@ -122,9 +119,9 @@ export class DefaultMessageV3 extends pb_1.Message {
             this.map_string_message = new Map();
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined;
     }
-    set message(value: dependency_1.DefaultCommonMessage | undefined | null) {
+    set message(value: dependency_1.DefaultCommonMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_message() {
@@ -260,9 +257,9 @@ export class DefaultMessageV3 extends pb_1.Message {
         return pb_1.Message.getField(this, 22) != null;
     }
     get one_of_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 23) as dependency_1.DefaultCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 23) as dependency_1.DefaultCommonMessage | undefined;
     }
-    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined | null) {
+    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 23, this.#one_of_decls[0], value);
     }
     get has_one_of_message() {
@@ -284,7 +281,7 @@ export class DefaultMessageV3 extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [22, 23])];
     }
-    static fromObject(data: RecursivePartial<DefaultMessageV3.AsObject>): DefaultMessageV3 {
+    static fromObject(data: DefaultMessageV3.AsObjectPartial): DefaultMessageV3 {
         const message = new DefaultMessageV3({});
         if (data.message != null) {
             message.message = dependency_1.DefaultCommonMessage.fromObject(data.message);
@@ -398,7 +395,7 @@ export class DefaultMessageV3 extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_message)
-            writer.writeMessage(1, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(1, this.message, () => this.message!.serialize(writer));
         if (this.enum != dependency_1.DefaultCommonEnum.ZERO)
             writer.writeEnum(2, this.enum);
         if (this.bool != false)
@@ -440,17 +437,17 @@ export class DefaultMessageV3 extends pb_1.Message {
         for (const [key, value] of this.map_string_message) {
             writer.writeMessage(19, this.map_string_message, () => {
                 writer.writeString(1, key);
-                writer.writeMessage(2, value, () => value.serialize(writer));
+                writer.writeMessage(2, value, () => value!.serialize(writer));
             });
         }
         if (this.array_int32.length)
             writer.writePackedInt32(20, this.array_int32);
         if (this.array_message.length)
-            writer.writeRepeatedMessage(21, this.array_message, (item: dependency_1.DefaultCommonMessage) => item.serialize(writer));
+            writer.writeRepeatedMessage(21, this.array_message, (item: dependency_1.DefaultCommonMessage) => item!.serialize(writer));
         if (this.has_one_of_int32)
             writer.writeInt32(22, this.one_of_int32);
         if (this.has_one_of_message)
-            writer.writeMessage(23, this.one_of_message, () => this.one_of_message.serialize(writer));
+            writer.writeMessage(23, this.one_of_message, () => this.one_of_message!.serialize(writer));
         if (this.bytes.length)
             writer.writeBytes(24, this.bytes);
         if (!w)
@@ -580,6 +577,36 @@ export namespace DefaultMessageV3 {
         one_of_int32: number;
         one_of_message?: dependency_1.DefaultCommonMessage.AsObject;
         bytes: Uint8Array;
+    };
+    export type AsObjectPartial = {
+        message?: dependency_1.DefaultCommonMessage.AsObjectPartial;
+        enum?: dependency_1.DefaultCommonEnum;
+        bool?: boolean;
+        string?: string;
+        int32?: number;
+        fixed32?: number;
+        sfixed32?: number;
+        uint32?: number;
+        sint32?: number;
+        int64?: number;
+        fixed64?: number;
+        sfixed64?: number;
+        uint64?: number;
+        sint64?: number;
+        float?: number;
+        double?: number;
+        int_but_string?: string;
+        map_string_string?: {
+            [key: string]: string;
+        };
+        map_string_message?: {
+            [key: string]: dependency_1.DefaultCommonMessage.AsObject;
+        };
+        array_int32?: number[];
+        array_message?: dependency_1.DefaultCommonMessage.AsObjectPartial[];
+        one_of_int32?: number;
+        one_of_message?: dependency_1.DefaultCommonMessage.AsObjectPartial;
+        bytes?: Uint8Array;
     };
 }
 export class DefaultMessageOptionalV3 extends pb_1.Message {
@@ -981,7 +1008,7 @@ export class DefaultMessageOptionalV3 extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [24])];
     }
-    static fromObject(data: RecursivePartial<DefaultMessageOptionalV3.AsObject>): DefaultMessageOptionalV3 {
+    static fromObject(data: DefaultMessageOptionalV3.AsObjectPartial): DefaultMessageOptionalV3 {
         const message = new DefaultMessageOptionalV3({});
         if (data.enum != null) {
             message.enum = data.enum;
@@ -1187,5 +1214,24 @@ export namespace DefaultMessageOptionalV3 {
         double: number;
         int_but_string: string;
         bytes: Uint8Array;
+    };
+    export type AsObjectPartial = {
+        enum?: dependency_1.DefaultCommonEnum;
+        bool?: boolean;
+        string?: string;
+        int32?: number;
+        fixed32?: number;
+        sfixed32?: number;
+        uint32?: number;
+        sint32?: number;
+        int64?: number;
+        fixed64?: number;
+        sfixed64?: number;
+        uint64?: number;
+        sint64?: number;
+        float?: number;
+        double?: number;
+        int_but_string?: string;
+        bytes?: Uint8Array;
     };
 }

--- a/test/default/default_proto3.ts
+++ b/test/default/default_proto3.ts
@@ -122,9 +122,9 @@ export class DefaultMessageV3 extends pb_1.Message {
             this.map_string_message = new Map();
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 1) as dependency_1.DefaultCommonMessage | undefined | null;
     }
-    set message(value: dependency_1.DefaultCommonMessage) {
+    set message(value: dependency_1.DefaultCommonMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_message() {
@@ -260,9 +260,9 @@ export class DefaultMessageV3 extends pb_1.Message {
         return pb_1.Message.getField(this, 22) != null;
     }
     get one_of_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 23) as dependency_1.DefaultCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.DefaultCommonMessage, 23) as dependency_1.DefaultCommonMessage | undefined | null;
     }
-    set one_of_message(value: dependency_1.DefaultCommonMessage) {
+    set one_of_message(value: dependency_1.DefaultCommonMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 23, this.#one_of_decls[0], value);
     }
     get has_one_of_message() {

--- a/test/deprecated.ts
+++ b/test/deprecated.ts
@@ -244,7 +244,7 @@ export class ServiceNameClient extends grpc_1.makeGenericClientConstructor(Unimp
     }
     /** @deprecated*/
     MethodName: GrpcUnaryServiceInterface<MessageName, MessageName2> = (message: MessageName, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<MessageName2>, options?: grpc_1.CallOptions | grpc_1.requestCallback<MessageName2>, callback?: grpc_1.requestCallback<MessageName2>): grpc_1.ClientUnaryCall => {
-        return super.MethodName(message, metadata, options, callback);
+        return super["MethodName"](message, metadata, options, callback);
     };
 }
 /** @deprecated*/
@@ -269,6 +269,6 @@ export class ServiceName2Client extends grpc_1.makeGenericClientConstructor(Unim
         super(address, credentials, options);
     }
     MethodName: GrpcUnaryServiceInterface<MessageName, MessageName2> = (message: MessageName, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<MessageName2>, options?: grpc_1.CallOptions | grpc_1.requestCallback<MessageName2>, callback?: grpc_1.requestCallback<MessageName2>): grpc_1.ClientUnaryCall => {
-        return super.MethodName(message, metadata, options, callback);
+        return super["MethodName"](message, metadata, options, callback);
     };
 }

--- a/test/deprecated.ts
+++ b/test/deprecated.ts
@@ -6,9 +6,6 @@
  * @deprecated */
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export enum EnumName {
     FIRST = 0,
     /** @deprecated*/
@@ -84,7 +81,7 @@ export class MessageName extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [2, 3])];
     }
-    static fromObject(data: RecursivePartial<MessageName.AsObject>): MessageName {
+    static fromObject(data: MessageName.AsObjectPartial): MessageName {
         const message = new MessageName({});
         if (data.deprecated_field != null) {
             message.deprecated_field = data.deprecated_field;
@@ -151,6 +148,11 @@ export namespace MessageName {
         me: string;
         me_deprecated: string;
     };
+    export type AsObjectPartial = {
+        deprecated_field?: string;
+        me?: string;
+        me_deprecated?: string;
+    };
 }
 /** @deprecated*/
 export class MessageName2 extends pb_1.Message {
@@ -160,7 +162,7 @@ export class MessageName2 extends pb_1.Message {
         pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
         if (!Array.isArray(data) && typeof data == "object") { }
     }
-    static fromObject(data: RecursivePartial<MessageName2.AsObject>): MessageName2 {
+    static fromObject(data: MessageName2.AsObjectPartial): MessageName2 {
         const message = new MessageName2({});
         return message;
     }
@@ -195,6 +197,7 @@ export class MessageName2 extends pb_1.Message {
 }
 export namespace MessageName2 {
     export type AsObject = {};
+    export type AsObjectPartial = {};
 }
 interface GrpcUnaryServiceInterface<P, R> {
     (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/deprecated.ts
+++ b/test/deprecated.ts
@@ -100,19 +100,14 @@ export class MessageName extends pb_1.Message {
     }
     toObject() {
         const data: {
-            deprecated_field?: string;
-            me?: string;
-            me_deprecated?: string;
-        } = {};
-        if (this.deprecated_field != null) {
-            data.deprecated_field = this.deprecated_field;
-        }
-        if (this.me != null) {
-            data.me = this.me;
-        }
-        if (this.me_deprecated != null) {
-            data.me_deprecated = this.me_deprecated;
-        }
+            deprecated_field: string;
+            me: string;
+            me_deprecated: string;
+        } = {
+            deprecated_field: this.deprecated_field,
+            me: this.me,
+            me_deprecated: this.me_deprecated
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/deprecated.ts
+++ b/test/deprecated.ts
@@ -6,6 +6,9 @@
  * @deprecated */
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export enum EnumName {
     FIRST = 0,
     /** @deprecated*/
@@ -81,11 +84,7 @@ export class MessageName extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [2, 3])];
     }
-    static fromObject(data: {
-        deprecated_field?: string;
-        me?: string;
-        me_deprecated?: string;
-    }): MessageName {
+    static fromObject(data: RecursivePartial<MessageName.AsObject>): MessageName {
         const message = new MessageName({});
         if (data.deprecated_field != null) {
             message.deprecated_field = data.deprecated_field;
@@ -99,11 +98,7 @@ export class MessageName extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            deprecated_field: string;
-            me: string;
-            me_deprecated: string;
-        } = {
+        const data: MessageName.AsObject = {
             deprecated_field: this.deprecated_field,
             me: this.me,
             me_deprecated: this.me_deprecated
@@ -150,6 +145,13 @@ export class MessageName extends pb_1.Message {
         return MessageName.deserialize(bytes);
     }
 }
+export namespace MessageName {
+    export type AsObject = {
+        deprecated_field: string;
+        me: string;
+        me_deprecated: string;
+    };
+}
 /** @deprecated*/
 export class MessageName2 extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -158,12 +160,12 @@ export class MessageName2 extends pb_1.Message {
         pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
         if (!Array.isArray(data) && typeof data == "object") { }
     }
-    static fromObject(data: {}): MessageName2 {
+    static fromObject(data: RecursivePartial<MessageName2.AsObject>): MessageName2 {
         const message = new MessageName2({});
         return message;
     }
     toObject() {
-        const data: {} = {};
+        const data: MessageName2.AsObject = {};
         return data;
     }
     serialize(): Uint8Array;
@@ -190,6 +192,9 @@ export class MessageName2 extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): MessageName2 {
         return MessageName2.deserialize(bytes);
     }
+}
+export namespace MessageName2 {
+    export type AsObject = {};
 }
 interface GrpcUnaryServiceInterface<P, R> {
     (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/dot.in.filenames.ts
+++ b/test/dot.in.filenames.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace dot {
-    type RecursivePartial<T> = {
-        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-    };
     export class Message extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -27,7 +24,7 @@ export namespace dot {
         set name(value: string[]) {
             pb_1.Message.setField(this, 1, value);
         }
-        static fromObject(data: RecursivePartial<Message.AsObject>): Message {
+        static fromObject(data: Message.AsObjectPartial): Message {
             const message = new Message({});
             if (data.name != null) {
                 message.name = data.name;
@@ -73,6 +70,9 @@ export namespace dot {
     export namespace Message {
         export type AsObject = {
             name: string[];
+        };
+        export type AsObjectPartial = {
+            name?: string[];
         };
     }
 }

--- a/test/dot.in.filenames.ts
+++ b/test/dot.in.filenames.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace dot {
+    type RecursivePartial<T> = {
+        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+    };
     export class Message extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -24,9 +27,7 @@ export namespace dot {
         set name(value: string[]) {
             pb_1.Message.setField(this, 1, value);
         }
-        static fromObject(data: {
-            name?: string[];
-        }): Message {
+        static fromObject(data: RecursivePartial<Message.AsObject>): Message {
             const message = new Message({});
             if (data.name != null) {
                 message.name = data.name;
@@ -34,9 +35,7 @@ export namespace dot {
             return message;
         }
         toObject() {
-            const data: {
-                name: string[];
-            } = {
+            const data: Message.AsObject = {
                 name: this.name
             };
             return data;
@@ -70,5 +69,10 @@ export namespace dot {
         static deserializeBinary(bytes: Uint8Array): Message {
             return Message.deserialize(bytes);
         }
+    }
+    export namespace Message {
+        export type AsObject = {
+            name: string[];
+        };
     }
 }

--- a/test/dot.in.filenames.ts
+++ b/test/dot.in.filenames.ts
@@ -35,11 +35,10 @@ export namespace dot {
         }
         toObject() {
             const data: {
-                name?: string[];
-            } = {};
-            if (this.name != null) {
-                data.name = this.name;
-            }
+                name: string[];
+            } = {
+                name: this.name
+            };
             return data;
         }
         serialize(): Uint8Array;

--- a/test/enum_within_message.ts
+++ b/test/enum_within_message.ts
@@ -49,15 +49,12 @@ export namespace main {
         }
         toObject() {
             const data: {
-                language?: Code.Language;
-                lines?: number;
-            } = {};
-            if (this.language != null) {
-                data.language = this.language;
-            }
-            if (this.lines != null) {
-                data.lines = this.lines;
-            }
+                language: Code.Language;
+                lines: number;
+            } = {
+                language: this.language,
+                lines: this.lines
+            };
             return data;
         }
         serialize(): Uint8Array;

--- a/test/enum_within_message.ts
+++ b/test/enum_within_message.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace main {
-    type RecursivePartial<T> = {
-        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-    };
     export class Code extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -37,7 +34,7 @@ export namespace main {
         set lines(value: number) {
             pb_1.Message.setField(this, 2, value);
         }
-        static fromObject(data: RecursivePartial<Code.AsObject>): Code {
+        static fromObject(data: Code.AsObjectPartial): Code {
             const message = new Code({});
             if (data.language != null) {
                 message.language = data.language;
@@ -93,6 +90,10 @@ export namespace main {
         export type AsObject = {
             language: Code.Language;
             lines: number;
+        };
+        export type AsObjectPartial = {
+            language?: Code.Language;
+            lines?: number;
         };
         export enum Language {
             UNKNOWN = 0,

--- a/test/enum_within_message.ts
+++ b/test/enum_within_message.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace main {
+    type RecursivePartial<T> = {
+        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+    };
     export class Code extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -34,10 +37,7 @@ export namespace main {
         set lines(value: number) {
             pb_1.Message.setField(this, 2, value);
         }
-        static fromObject(data: {
-            language?: Code.Language;
-            lines?: number;
-        }): Code {
+        static fromObject(data: RecursivePartial<Code.AsObject>): Code {
             const message = new Code({});
             if (data.language != null) {
                 message.language = data.language;
@@ -48,10 +48,7 @@ export namespace main {
             return message;
         }
         toObject() {
-            const data: {
-                language: Code.Language;
-                lines: number;
-            } = {
+            const data: Code.AsObject = {
                 language: this.language,
                 lines: this.lines
             };
@@ -93,6 +90,10 @@ export namespace main {
         }
     }
     export namespace Code {
+        export type AsObject = {
+            language: Code.Language;
+            lines: number;
+        };
         export enum Language {
             UNKNOWN = 0,
             C = 1,

--- a/test/experimental/BUILD.bazel
+++ b/test/experimental/BUILD.bazel
@@ -16,12 +16,7 @@ diff_and_update(
 ts_project(
     name = "experimental",
     srcs = glob(["*.ts"]),
-    tsconfig = {
-        "compilerOptions": {
-            "target": "ES2020",
-            "module": "CommonJS",
-        },
-    },
+    tsconfig = {}, # no special options
     extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",

--- a/test/experimental/BUILD.bazel
+++ b/test/experimental/BUILD.bazel
@@ -20,9 +20,9 @@ ts_project(
         "compilerOptions": {
             "target": "ES2020",
             "module": "CommonJS",
-            "noImplicitAny": True
         },
     },
+    extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/test/experimental/rpc.ts
+++ b/test/experimental/rpc.ts
@@ -192,7 +192,7 @@ export class StorageClient extends grpc_1.makeGenericClientConstructor(Unimpleme
         metadata = new grpc_1.Metadata;
     } if (!options) {
         options = {};
-    } return new Promise((resolve, reject) => super.put(message, metadata, options, (error: grpc_1.ServiceError, response: Result) => {
+    } return new Promise((resolve, reject) => super["put"](message, metadata, options, (error: grpc_1.ServiceError, response: Result) => {
         if (error) {
             reject(error);
         }

--- a/test/experimental/rpc.ts
+++ b/test/experimental/rpc.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class Chunk extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -24,9 +27,7 @@ export class Chunk extends pb_1.Message {
     set data(value: Uint8Array) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        data?: Uint8Array;
-    }): Chunk {
+    static fromObject(data: RecursivePartial<Chunk.AsObject>): Chunk {
         const message = new Chunk({});
         if (data.data != null) {
             message.data = data.data;
@@ -34,9 +35,7 @@ export class Chunk extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            data: Uint8Array;
-        } = {
+        const data: Chunk.AsObject = {
             data: this.data
         };
         return data;
@@ -71,6 +70,11 @@ export class Chunk extends pb_1.Message {
         return Chunk.deserialize(bytes);
     }
 }
+export namespace Chunk {
+    export type AsObject = {
+        data: Uint8Array;
+    };
+}
 export class Result extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -90,9 +94,7 @@ export class Result extends pb_1.Message {
     set id(value: number) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        id?: number;
-    }): Result {
+    static fromObject(data: RecursivePartial<Result.AsObject>): Result {
         const message = new Result({});
         if (data.id != null) {
             message.id = data.id;
@@ -100,9 +102,7 @@ export class Result extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: number;
-        } = {
+        const data: Result.AsObject = {
             id: this.id
         };
         return data;
@@ -136,6 +136,11 @@ export class Result extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Result {
         return Result.deserialize(bytes);
     }
+}
+export namespace Result {
+    export type AsObject = {
+        id: number;
+    };
 }
 interface GrpcUnaryServiceInterface<P, R> {
     (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/experimental/rpc.ts
+++ b/test/experimental/rpc.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class Chunk extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -27,7 +24,7 @@ export class Chunk extends pb_1.Message {
     set data(value: Uint8Array) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<Chunk.AsObject>): Chunk {
+    static fromObject(data: Chunk.AsObjectPartial): Chunk {
         const message = new Chunk({});
         if (data.data != null) {
             message.data = data.data;
@@ -74,6 +71,9 @@ export namespace Chunk {
     export type AsObject = {
         data: Uint8Array;
     };
+    export type AsObjectPartial = {
+        data?: Uint8Array;
+    };
 }
 export class Result extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -94,7 +94,7 @@ export class Result extends pb_1.Message {
     set id(value: number) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<Result.AsObject>): Result {
+    static fromObject(data: Result.AsObjectPartial): Result {
         const message = new Result({});
         if (data.id != null) {
             message.id = data.id;
@@ -140,6 +140,9 @@ export class Result extends pb_1.Message {
 export namespace Result {
     export type AsObject = {
         id: number;
+    };
+    export type AsObjectPartial = {
+        id?: number;
     };
 }
 interface GrpcUnaryServiceInterface<P, R> {

--- a/test/experimental/rpc.ts
+++ b/test/experimental/rpc.ts
@@ -35,11 +35,10 @@ export class Chunk extends pb_1.Message {
     }
     toObject() {
         const data: {
-            data?: Uint8Array;
-        } = {};
-        if (this.data != null) {
-            data.data = this.data;
-        }
+            data: Uint8Array;
+        } = {
+            data: this.data
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -102,11 +101,10 @@ export class Result extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: number;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
+            id: number;
+        } = {
+            id: this.id
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/explicit_override/BUILD.bazel
+++ b/test/explicit_override/BUILD.bazel
@@ -15,7 +15,6 @@ ts_project(
     srcs = glob(["*.ts"]),
     tsconfig = {
         "compilerOptions": {
-            "noImplicitAny": True,
             "noImplicitOverride": True
         },
     },

--- a/test/explicit_override/BUILD.bazel
+++ b/test/explicit_override/BUILD.bazel
@@ -15,12 +15,11 @@ ts_project(
     srcs = glob(["*.ts"]),
     tsconfig = {
         "compilerOptions": {
-            "target": "ES2020",
-            "module": "CommonJS",
             "noImplicitAny": True,
             "noImplicitOverride": True
         },
     },
+    extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/test/explicit_override/explicit_override.ts
+++ b/test/explicit_override/explicit_override.ts
@@ -34,11 +34,10 @@ export class ExplicitOverrideMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            example?: number;
-        } = {};
-        if (this.example != null) {
-            data.example = this.example;
-        }
+            example: number;
+        } = {
+            example: this.example
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/explicit_override/explicit_override.ts
+++ b/test/explicit_override/explicit_override.ts
@@ -4,6 +4,9 @@
  * source: test/_/explicit_override/explicit_override.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class ExplicitOverrideMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -23,9 +26,7 @@ export class ExplicitOverrideMessage extends pb_1.Message {
     set example(value: number) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        example?: number;
-    }): ExplicitOverrideMessage {
+    static fromObject(data: RecursivePartial<ExplicitOverrideMessage.AsObject>): ExplicitOverrideMessage {
         const message = new ExplicitOverrideMessage({});
         if (data.example != null) {
             message.example = data.example;
@@ -33,9 +34,7 @@ export class ExplicitOverrideMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            example: number;
-        } = {
+        const data: ExplicitOverrideMessage.AsObject = {
             example: this.example
         };
         return data;
@@ -69,4 +68,9 @@ export class ExplicitOverrideMessage extends pb_1.Message {
     static override deserializeBinary(bytes: Uint8Array): ExplicitOverrideMessage {
         return ExplicitOverrideMessage.deserialize(bytes);
     }
+}
+export namespace ExplicitOverrideMessage {
+    export type AsObject = {
+        example: number;
+    };
 }

--- a/test/explicit_override/explicit_override.ts
+++ b/test/explicit_override/explicit_override.ts
@@ -4,9 +4,6 @@
  * source: test/_/explicit_override/explicit_override.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class ExplicitOverrideMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -26,7 +23,7 @@ export class ExplicitOverrideMessage extends pb_1.Message {
     set example(value: number) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<ExplicitOverrideMessage.AsObject>): ExplicitOverrideMessage {
+    static fromObject(data: ExplicitOverrideMessage.AsObjectPartial): ExplicitOverrideMessage {
         const message = new ExplicitOverrideMessage({});
         if (data.example != null) {
             message.example = data.example;
@@ -72,5 +69,8 @@ export class ExplicitOverrideMessage extends pb_1.Message {
 export namespace ExplicitOverrideMessage {
     export type AsObject = {
         example: number;
+    };
+    export type AsObjectPartial = {
+        example?: number;
     };
 }

--- a/test/importdirective.ts
+++ b/test/importdirective.ts
@@ -173,7 +173,7 @@ export namespace importdirective {
             super(address, credentials, options);
         }
         ImportedServiceTest: GrpcUnaryServiceInterface<dependency_1.importdirective.Imported, dependency_1.importdirective.Imported.SubMessage> = (message: dependency_1.importdirective.Imported, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<dependency_1.importdirective.Imported.SubMessage>, options?: grpc_1.CallOptions | grpc_1.requestCallback<dependency_1.importdirective.Imported.SubMessage>, callback?: grpc_1.requestCallback<dependency_1.importdirective.Imported.SubMessage>): grpc_1.ClientUnaryCall => {
-            return super.ImportedServiceTest(message, metadata, options, callback);
+            return super["ImportedServiceTest"](message, metadata, options, callback);
         };
     }
 }

--- a/test/importdirective.ts
+++ b/test/importdirective.ts
@@ -32,18 +32,18 @@ export namespace importdirective {
             }
         }
         get importedField() {
-            return pb_1.Message.getWrapperField(this, dependency_1.importdirective.Imported, 1) as dependency_1.importdirective.Imported;
+            return pb_1.Message.getWrapperField(this, dependency_1.importdirective.Imported, 1) as dependency_1.importdirective.Imported | undefined | null;
         }
-        set importedField(value: dependency_1.importdirective.Imported) {
+        set importedField(value: dependency_1.importdirective.Imported | undefined | null) {
             pb_1.Message.setWrapperField(this, 1, value);
         }
         get has_importedField() {
             return pb_1.Message.getField(this, 1) != null;
         }
         get submessageField() {
-            return pb_1.Message.getWrapperField(this, dependency_1.importdirective.Imported.SubMessage, 2) as dependency_1.importdirective.Imported.SubMessage;
+            return pb_1.Message.getWrapperField(this, dependency_1.importdirective.Imported.SubMessage, 2) as dependency_1.importdirective.Imported.SubMessage | undefined | null;
         }
-        set submessageField(value: dependency_1.importdirective.Imported.SubMessage) {
+        set submessageField(value: dependency_1.importdirective.Imported.SubMessage | undefined | null) {
             pb_1.Message.setWrapperField(this, 2, value);
         }
         get has_submessageField() {

--- a/test/importdirective.ts
+++ b/test/importdirective.ts
@@ -7,6 +7,9 @@ import * as dependency_1 from "./imported";
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
 export namespace importdirective {
+    type RecursivePartial<T> = {
+        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+    };
     export class Message extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -52,11 +55,7 @@ export namespace importdirective {
         set enumField(value: dependency_1.importdirective.Imported.SubMessage.MyEnum) {
             pb_1.Message.setField(this, 3, value);
         }
-        static fromObject(data: {
-            importedField?: Parameters<typeof dependency_1.importdirective.Imported.fromObject>[0];
-            submessageField?: Parameters<typeof dependency_1.importdirective.Imported.SubMessage.fromObject>[0];
-            enumField?: dependency_1.importdirective.Imported.SubMessage.MyEnum;
-        }): Message {
+        static fromObject(data: RecursivePartial<Message.AsObject>): Message {
             const message = new Message({});
             if (data.importedField != null) {
                 message.importedField = dependency_1.importdirective.Imported.fromObject(data.importedField);
@@ -70,11 +69,7 @@ export namespace importdirective {
             return message;
         }
         toObject() {
-            const data: {
-                importedField?: Parameters<typeof dependency_1.importdirective.Imported.fromObject>[0];
-                submessageField?: Parameters<typeof dependency_1.importdirective.Imported.SubMessage.fromObject>[0];
-                enumField: dependency_1.importdirective.Imported.SubMessage.MyEnum;
-            } = {
+            const data: Message.AsObject = {
                 enumField: this.enumField
             };
             if (this.importedField != null) {
@@ -124,6 +119,13 @@ export namespace importdirective {
         static deserializeBinary(bytes: Uint8Array): Message {
             return Message.deserialize(bytes);
         }
+    }
+    export namespace Message {
+        export type AsObject = {
+            importedField?: dependency_1.importdirective.Imported.AsObject;
+            submessageField?: dependency_1.importdirective.Imported.SubMessage.AsObject;
+            enumField: dependency_1.importdirective.Imported.SubMessage.MyEnum;
+        };
     }
     interface GrpcUnaryServiceInterface<P, R> {
         (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/importdirective.ts
+++ b/test/importdirective.ts
@@ -53,8 +53,8 @@ export namespace importdirective {
             pb_1.Message.setField(this, 3, value);
         }
         static fromObject(data: {
-            importedField?: ReturnType<typeof dependency_1.importdirective.Imported.prototype.toObject>;
-            submessageField?: ReturnType<typeof dependency_1.importdirective.Imported.SubMessage.prototype.toObject>;
+            importedField?: Parameters<typeof dependency_1.importdirective.Imported.fromObject>[0];
+            submessageField?: Parameters<typeof dependency_1.importdirective.Imported.SubMessage.fromObject>[0];
             enumField?: dependency_1.importdirective.Imported.SubMessage.MyEnum;
         }): Message {
             const message = new Message({});
@@ -71,18 +71,17 @@ export namespace importdirective {
         }
         toObject() {
             const data: {
-                importedField?: ReturnType<typeof dependency_1.importdirective.Imported.prototype.toObject>;
-                submessageField?: ReturnType<typeof dependency_1.importdirective.Imported.SubMessage.prototype.toObject>;
-                enumField?: dependency_1.importdirective.Imported.SubMessage.MyEnum;
-            } = {};
+                importedField?: Parameters<typeof dependency_1.importdirective.Imported.fromObject>[0];
+                submessageField?: Parameters<typeof dependency_1.importdirective.Imported.SubMessage.fromObject>[0];
+                enumField: dependency_1.importdirective.Imported.SubMessage.MyEnum;
+            } = {
+                enumField: this.enumField
+            };
             if (this.importedField != null) {
                 data.importedField = this.importedField.toObject();
             }
             if (this.submessageField != null) {
                 data.submessageField = this.submessageField.toObject();
-            }
-            if (this.enumField != null) {
-                data.enumField = this.enumField;
             }
             return data;
         }

--- a/test/importdirective.ts
+++ b/test/importdirective.ts
@@ -7,9 +7,6 @@ import * as dependency_1 from "./imported";
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
 export namespace importdirective {
-    type RecursivePartial<T> = {
-        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-    };
     export class Message extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -32,18 +29,18 @@ export namespace importdirective {
             }
         }
         get importedField() {
-            return pb_1.Message.getWrapperField(this, dependency_1.importdirective.Imported, 1) as dependency_1.importdirective.Imported | undefined | null;
+            return pb_1.Message.getWrapperField(this, dependency_1.importdirective.Imported, 1) as dependency_1.importdirective.Imported | undefined;
         }
-        set importedField(value: dependency_1.importdirective.Imported | undefined | null) {
+        set importedField(value: dependency_1.importdirective.Imported | undefined) {
             pb_1.Message.setWrapperField(this, 1, value);
         }
         get has_importedField() {
             return pb_1.Message.getField(this, 1) != null;
         }
         get submessageField() {
-            return pb_1.Message.getWrapperField(this, dependency_1.importdirective.Imported.SubMessage, 2) as dependency_1.importdirective.Imported.SubMessage | undefined | null;
+            return pb_1.Message.getWrapperField(this, dependency_1.importdirective.Imported.SubMessage, 2) as dependency_1.importdirective.Imported.SubMessage | undefined;
         }
-        set submessageField(value: dependency_1.importdirective.Imported.SubMessage | undefined | null) {
+        set submessageField(value: dependency_1.importdirective.Imported.SubMessage | undefined) {
             pb_1.Message.setWrapperField(this, 2, value);
         }
         get has_submessageField() {
@@ -55,7 +52,7 @@ export namespace importdirective {
         set enumField(value: dependency_1.importdirective.Imported.SubMessage.MyEnum) {
             pb_1.Message.setField(this, 3, value);
         }
-        static fromObject(data: RecursivePartial<Message.AsObject>): Message {
+        static fromObject(data: Message.AsObjectPartial): Message {
             const message = new Message({});
             if (data.importedField != null) {
                 message.importedField = dependency_1.importdirective.Imported.fromObject(data.importedField);
@@ -85,9 +82,9 @@ export namespace importdirective {
         serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
             const writer = w || new pb_1.BinaryWriter();
             if (this.has_importedField)
-                writer.writeMessage(1, this.importedField, () => this.importedField.serialize(writer));
+                writer.writeMessage(1, this.importedField, () => this.importedField!.serialize(writer));
             if (this.has_submessageField)
-                writer.writeMessage(2, this.submessageField, () => this.submessageField.serialize(writer));
+                writer.writeMessage(2, this.submessageField, () => this.submessageField!.serialize(writer));
             if (this.enumField != dependency_1.importdirective.Imported.SubMessage.MyEnum.VALUE)
                 writer.writeEnum(3, this.enumField);
             if (!w)
@@ -125,6 +122,11 @@ export namespace importdirective {
             importedField?: dependency_1.importdirective.Imported.AsObject;
             submessageField?: dependency_1.importdirective.Imported.SubMessage.AsObject;
             enumField: dependency_1.importdirective.Imported.SubMessage.MyEnum;
+        };
+        export type AsObjectPartial = {
+            importedField?: dependency_1.importdirective.Imported.AsObjectPartial;
+            submessageField?: dependency_1.importdirective.Imported.SubMessage.AsObjectPartial;
+            enumField?: dependency_1.importdirective.Imported.SubMessage.MyEnum;
         };
     }
     interface GrpcUnaryServiceInterface<P, R> {

--- a/test/imported.ts
+++ b/test/imported.ts
@@ -76,11 +76,10 @@ export namespace importdirective {
             }
             toObject() {
                 const data: {
-                    key?: Imported.SubMessage.MyEnum;
-                } = {};
-                if (this.key != null) {
-                    data.key = this.key;
-                }
+                    key: Imported.SubMessage.MyEnum;
+                } = {
+                    key: this.key
+                };
                 return data;
             }
             serialize(): Uint8Array;

--- a/test/imported.ts
+++ b/test/imported.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace importdirective {
-    type RecursivePartial<T> = {
-        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-    };
     export class Imported extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {}) {
@@ -15,7 +12,7 @@ export namespace importdirective {
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
             if (!Array.isArray(data) && typeof data == "object") { }
         }
-        static fromObject(data: RecursivePartial<Imported.AsObject>): Imported {
+        static fromObject(data: Imported.AsObjectPartial): Imported {
             const message = new Imported({});
             return message;
         }
@@ -50,6 +47,7 @@ export namespace importdirective {
     }
     export namespace Imported {
         export type AsObject = {};
+        export type AsObjectPartial = {};
         export class SubMessage extends pb_1.Message {
             #one_of_decls: number[][] = [];
             constructor(data?: any[] | {
@@ -69,7 +67,7 @@ export namespace importdirective {
             set key(value: Imported.SubMessage.MyEnum) {
                 pb_1.Message.setField(this, 1, value);
             }
-            static fromObject(data: RecursivePartial<SubMessage.AsObject>): SubMessage {
+            static fromObject(data: SubMessage.AsObjectPartial): SubMessage {
                 const message = new SubMessage({});
                 if (data.key != null) {
                     message.key = data.key;
@@ -115,6 +113,9 @@ export namespace importdirective {
         export namespace SubMessage {
             export type AsObject = {
                 key: Imported.SubMessage.MyEnum;
+            };
+            export type AsObjectPartial = {
+                key?: Imported.SubMessage.MyEnum;
             };
             export enum MyEnum {
                 VALUE = 0,

--- a/test/imported.ts
+++ b/test/imported.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace importdirective {
+    type RecursivePartial<T> = {
+        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+    };
     export class Imported extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {}) {
@@ -12,12 +15,12 @@ export namespace importdirective {
             pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
             if (!Array.isArray(data) && typeof data == "object") { }
         }
-        static fromObject(data: {}): Imported {
+        static fromObject(data: RecursivePartial<Imported.AsObject>): Imported {
             const message = new Imported({});
             return message;
         }
         toObject() {
-            const data: {} = {};
+            const data: Imported.AsObject = {};
             return data;
         }
         serialize(): Uint8Array;
@@ -46,6 +49,7 @@ export namespace importdirective {
         }
     }
     export namespace Imported {
+        export type AsObject = {};
         export class SubMessage extends pb_1.Message {
             #one_of_decls: number[][] = [];
             constructor(data?: any[] | {
@@ -65,9 +69,7 @@ export namespace importdirective {
             set key(value: Imported.SubMessage.MyEnum) {
                 pb_1.Message.setField(this, 1, value);
             }
-            static fromObject(data: {
-                key?: Imported.SubMessage.MyEnum;
-            }): SubMessage {
+            static fromObject(data: RecursivePartial<SubMessage.AsObject>): SubMessage {
                 const message = new SubMessage({});
                 if (data.key != null) {
                     message.key = data.key;
@@ -75,9 +77,7 @@ export namespace importdirective {
                 return message;
             }
             toObject() {
-                const data: {
-                    key: Imported.SubMessage.MyEnum;
-                } = {
+                const data: SubMessage.AsObject = {
                     key: this.key
                 };
                 return data;
@@ -113,6 +113,9 @@ export namespace importdirective {
             }
         }
         export namespace SubMessage {
+            export type AsObject = {
+                key: Imported.SubMessage.MyEnum;
+            };
             export enum MyEnum {
                 VALUE = 0,
                 VALUE2 = 1

--- a/test/integers.ts
+++ b/test/integers.ts
@@ -4,6 +4,9 @@
  * source: test/_/integers.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class Integers extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -93,16 +96,7 @@ export class Integers extends pb_1.Message {
     set fixed64(value: number) {
         pb_1.Message.setField(this, 9, value);
     }
-    static fromObject(data: {
-        int32?: number;
-        int64?: number;
-        sint32?: number;
-        sint64?: number;
-        sfixed32?: number;
-        sfixed64?: number;
-        fixed32?: number;
-        fixed64?: number;
-    }): Integers {
+    static fromObject(data: RecursivePartial<Integers.AsObject>): Integers {
         const message = new Integers({});
         if (data.int32 != null) {
             message.int32 = data.int32;
@@ -131,16 +125,7 @@ export class Integers extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            int32: number;
-            int64: number;
-            sint32: number;
-            sint64: number;
-            sfixed32: number;
-            sfixed64: number;
-            fixed32: number;
-            fixed64: number;
-        } = {
+        const data: Integers.AsObject = {
             int32: this.int32,
             int64: this.int64,
             sint32: this.sint32,
@@ -216,4 +201,16 @@ export class Integers extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Integers {
         return Integers.deserialize(bytes);
     }
+}
+export namespace Integers {
+    export type AsObject = {
+        int32: number;
+        int64: number;
+        sint32: number;
+        sint64: number;
+        sfixed32: number;
+        sfixed64: number;
+        fixed32: number;
+        fixed64: number;
+    };
 }

--- a/test/integers.ts
+++ b/test/integers.ts
@@ -132,39 +132,24 @@ export class Integers extends pb_1.Message {
     }
     toObject() {
         const data: {
-            int32?: number;
-            int64?: number;
-            sint32?: number;
-            sint64?: number;
-            sfixed32?: number;
-            sfixed64?: number;
-            fixed32?: number;
-            fixed64?: number;
-        } = {};
-        if (this.int32 != null) {
-            data.int32 = this.int32;
-        }
-        if (this.int64 != null) {
-            data.int64 = this.int64;
-        }
-        if (this.sint32 != null) {
-            data.sint32 = this.sint32;
-        }
-        if (this.sint64 != null) {
-            data.sint64 = this.sint64;
-        }
-        if (this.sfixed32 != null) {
-            data.sfixed32 = this.sfixed32;
-        }
-        if (this.sfixed64 != null) {
-            data.sfixed64 = this.sfixed64;
-        }
-        if (this.fixed32 != null) {
-            data.fixed32 = this.fixed32;
-        }
-        if (this.fixed64 != null) {
-            data.fixed64 = this.fixed64;
-        }
+            int32: number;
+            int64: number;
+            sint32: number;
+            sint64: number;
+            sfixed32: number;
+            sfixed64: number;
+            fixed32: number;
+            fixed64: number;
+        } = {
+            int32: this.int32,
+            int64: this.int64,
+            sint32: this.sint32,
+            sint64: this.sint64,
+            sfixed32: this.sfixed32,
+            sfixed64: this.sfixed64,
+            fixed32: this.fixed32,
+            fixed64: this.fixed64
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/integers.ts
+++ b/test/integers.ts
@@ -4,9 +4,6 @@
  * source: test/_/integers.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class Integers extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -96,7 +93,7 @@ export class Integers extends pb_1.Message {
     set fixed64(value: number) {
         pb_1.Message.setField(this, 9, value);
     }
-    static fromObject(data: RecursivePartial<Integers.AsObject>): Integers {
+    static fromObject(data: Integers.AsObjectPartial): Integers {
         const message = new Integers({});
         if (data.int32 != null) {
             message.int32 = data.int32;
@@ -212,5 +209,15 @@ export namespace Integers {
         sfixed64: number;
         fixed32: number;
         fixed64: number;
+    };
+    export type AsObjectPartial = {
+        int32?: number;
+        int64?: number;
+        sint32?: number;
+        sint64?: number;
+        sfixed32?: number;
+        sfixed64?: number;
+        fixed32?: number;
+        fixed64?: number;
     };
 }

--- a/test/json_names/BUILD.bazel
+++ b/test/json_names/BUILD.bazel
@@ -15,11 +15,10 @@ ts_project(
     srcs = glob(["*.ts"]),
     tsconfig = {
         "compilerOptions": {
-            "target": "ES2020",
-            "module": "CommonJS",
             "noImplicitAny": True
         },
     },
+    extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/test/json_names/BUILD.bazel
+++ b/test/json_names/BUILD.bazel
@@ -13,11 +13,7 @@ diff_and_update(
 ts_project(
     name = "experimental",
     srcs = glob(["*.ts"]),
-    tsconfig = {
-        "compilerOptions": {
-            "noImplicitAny": True
-        },
-    },
+    tsconfig = {}, # no special options
     extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",

--- a/test/json_names/json_names.spec.ts
+++ b/test/json_names/json_names.spec.ts
@@ -14,7 +14,7 @@ describe('JSON Names', () => {
 
     expect(message.someStrings).toEqual(['a', 'b', 'c']);
     expect(message.anInteger).toEqual(123);
-    expect(message.aNestedMessage.aNestedInteger).toEqual(456);
+    expect(message.aNestedMessage?.aNestedInteger).toEqual(456);
     expect(message.colorSpace).toEqual(ColorSpace.RED_GREEN_BLUE);
     expect(message.aSingleString).toEqual('spam');
     expect(ColorSpace[message.colorSpace]).toEqual('RED_GREEN_BLUE');
@@ -33,7 +33,7 @@ describe('JSON Names', () => {
 
     expect(message.someStrings).toEqual(['a', 'b', 'c']);
     expect(message.anInteger).toEqual(123);
-    expect(message.aNestedMessage.aNestedInteger).toEqual(456);
+    expect(message.aNestedMessage?.aNestedInteger).toEqual(456);
     expect(message.colorSpace).toEqual(ColorSpace.RED_GREEN_BLUE);
     expect(message.aSingleString).toEqual('spam');
     expect(ColorSpace[message.colorSpace]).toEqual('RED_GREEN_BLUE');
@@ -99,7 +99,7 @@ describe('JSON Names', () => {
     expect(message.hasASingleString).toBe(false);
     message.aSingleString = 'abcdef';
     expect(message.hasASingleString).toBe(true);
-    message.aSingleString = undefined;
+    message.aSingleString = undefined!;
     expect(message.hasASingleString).toBe(false);
   });
 });

--- a/test/json_names/json_names.ts
+++ b/test/json_names/json_names.ts
@@ -66,9 +66,9 @@ export class JsonNamesMessage extends pb_1.Message {
         pb_1.Message.setField(this, 2, value);
     }
     get aNestedMessage() {
-        return pb_1.Message.getWrapperField(this, JsonNamesMessage.NestedMessage, 3) as JsonNamesMessage.NestedMessage;
+        return pb_1.Message.getWrapperField(this, JsonNamesMessage.NestedMessage, 3) as JsonNamesMessage.NestedMessage | undefined | null;
     }
-    set aNestedMessage(value: JsonNamesMessage.NestedMessage) {
+    set aNestedMessage(value: JsonNamesMessage.NestedMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get hasANestedMessage() {

--- a/test/json_names/json_names.ts
+++ b/test/json_names/json_names.ts
@@ -4,9 +4,6 @@
  * source: test/_/json_names/json_names.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export enum ColorSpace {
     RED_GREEN_BLUE = 0,
     CYAN_YELLOW_MAGENTA_BLACK = 1
@@ -66,9 +63,9 @@ export class JsonNamesMessage extends pb_1.Message {
         pb_1.Message.setField(this, 2, value);
     }
     get aNestedMessage() {
-        return pb_1.Message.getWrapperField(this, JsonNamesMessage.NestedMessage, 3) as JsonNamesMessage.NestedMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, JsonNamesMessage.NestedMessage, 3) as JsonNamesMessage.NestedMessage | undefined;
     }
-    set aNestedMessage(value: JsonNamesMessage.NestedMessage | undefined | null) {
+    set aNestedMessage(value: JsonNamesMessage.NestedMessage | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get hasANestedMessage() {
@@ -126,7 +123,7 @@ export class JsonNamesMessage extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [5])];
     }
-    static fromObject(data: RecursivePartial<JsonNamesMessage.AsObject>): JsonNamesMessage {
+    static fromObject(data: JsonNamesMessage.AsObjectPartial): JsonNamesMessage {
         const message = new JsonNamesMessage({});
         if (data.someStrings != null) {
             message.someStrings = data.someStrings;
@@ -174,7 +171,7 @@ export class JsonNamesMessage extends pb_1.Message {
         if (this.anInteger != 0)
             writer.writeInt32(2, this.anInteger);
         if (this.hasANestedMessage)
-            writer.writeMessage(3, this.aNestedMessage, () => this.aNestedMessage.serialize(writer));
+            writer.writeMessage(3, this.aNestedMessage, () => this.aNestedMessage!.serialize(writer));
         if (this.colorSpace != ColorSpace.RED_GREEN_BLUE)
             writer.writeEnum(4, this.colorSpace);
         if (this.hasAnOptionalString)
@@ -235,6 +232,15 @@ export namespace JsonNamesMessage {
         aSingleString: string;
         aSingleNumber: number;
     };
+    export type AsObjectPartial = {
+        someStrings?: string[];
+        anInteger?: number;
+        aNestedMessage?: JsonNamesMessage.NestedMessage.AsObjectPartial;
+        colorSpace?: ColorSpace;
+        anOptionalString?: string;
+        aSingleString?: string;
+        aSingleNumber?: number;
+    };
     export class NestedMessage extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -254,7 +260,7 @@ export namespace JsonNamesMessage {
         set aNestedInteger(value: number) {
             pb_1.Message.setField(this, 1, value);
         }
-        static fromObject(data: RecursivePartial<NestedMessage.AsObject>): NestedMessage {
+        static fromObject(data: NestedMessage.AsObjectPartial): NestedMessage {
             const message = new NestedMessage({});
             if (data.aNestedInteger != null) {
                 message.aNestedInteger = data.aNestedInteger;
@@ -300,6 +306,9 @@ export namespace JsonNamesMessage {
     export namespace NestedMessage {
         export type AsObject = {
             aNestedInteger: number;
+        };
+        export type AsObjectPartial = {
+            aNestedInteger?: number;
         };
     }
 }

--- a/test/json_names/json_names.ts
+++ b/test/json_names/json_names.ts
@@ -126,7 +126,7 @@ export class JsonNamesMessage extends pb_1.Message {
     static fromObject(data: {
         someStrings?: string[];
         anInteger?: number;
-        aNestedMessage?: ReturnType<typeof JsonNamesMessage.NestedMessage.prototype.toObject>;
+        aNestedMessage?: Parameters<typeof JsonNamesMessage.NestedMessage.fromObject>[0];
         colorSpace?: ColorSpace;
         anOptionalString?: string;
         aSingleString?: string;
@@ -158,34 +158,23 @@ export class JsonNamesMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            someStrings?: string[];
-            anInteger?: number;
-            aNestedMessage?: ReturnType<typeof JsonNamesMessage.NestedMessage.prototype.toObject>;
-            colorSpace?: ColorSpace;
-            anOptionalString?: string;
-            aSingleString?: string;
-            aSingleNumber?: number;
-        } = {};
-        if (this.someStrings != null) {
-            data.someStrings = this.someStrings;
-        }
-        if (this.anInteger != null) {
-            data.anInteger = this.anInteger;
-        }
+            someStrings: string[];
+            anInteger: number;
+            aNestedMessage?: Parameters<typeof JsonNamesMessage.NestedMessage.fromObject>[0];
+            colorSpace: ColorSpace;
+            anOptionalString: string;
+            aSingleString: string;
+            aSingleNumber: number;
+        } = {
+            someStrings: this.someStrings,
+            anInteger: this.anInteger,
+            colorSpace: this.colorSpace,
+            anOptionalString: this.anOptionalString,
+            aSingleString: this.aSingleString,
+            aSingleNumber: this.aSingleNumber
+        };
         if (this.aNestedMessage != null) {
             data.aNestedMessage = this.aNestedMessage.toObject();
-        }
-        if (this.colorSpace != null) {
-            data.colorSpace = this.colorSpace;
-        }
-        if (this.anOptionalString != null) {
-            data.anOptionalString = this.anOptionalString;
-        }
-        if (this.aSingleString != null) {
-            data.aSingleString = this.aSingleString;
-        }
-        if (this.aSingleNumber != null) {
-            data.aSingleNumber = this.aSingleNumber;
         }
         return data;
     }
@@ -280,11 +269,10 @@ export namespace JsonNamesMessage {
         }
         toObject() {
             const data: {
-                aNestedInteger?: number;
-            } = {};
-            if (this.aNestedInteger != null) {
-                data.aNestedInteger = this.aNestedInteger;
-            }
+                aNestedInteger: number;
+            } = {
+                aNestedInteger: this.aNestedInteger
+            };
             return data;
         }
         serialize(): Uint8Array;

--- a/test/json_names/json_names.ts
+++ b/test/json_names/json_names.ts
@@ -4,6 +4,9 @@
  * source: test/_/json_names/json_names.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export enum ColorSpace {
     RED_GREEN_BLUE = 0,
     CYAN_YELLOW_MAGENTA_BLACK = 1
@@ -123,15 +126,7 @@ export class JsonNamesMessage extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [5])];
     }
-    static fromObject(data: {
-        someStrings?: string[];
-        anInteger?: number;
-        aNestedMessage?: Parameters<typeof JsonNamesMessage.NestedMessage.fromObject>[0];
-        colorSpace?: ColorSpace;
-        anOptionalString?: string;
-        aSingleString?: string;
-        aSingleNumber?: number;
-    }): JsonNamesMessage {
+    static fromObject(data: RecursivePartial<JsonNamesMessage.AsObject>): JsonNamesMessage {
         const message = new JsonNamesMessage({});
         if (data.someStrings != null) {
             message.someStrings = data.someStrings;
@@ -157,15 +152,7 @@ export class JsonNamesMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            someStrings: string[];
-            anInteger: number;
-            aNestedMessage?: Parameters<typeof JsonNamesMessage.NestedMessage.fromObject>[0];
-            colorSpace: ColorSpace;
-            anOptionalString: string;
-            aSingleString: string;
-            aSingleNumber: number;
-        } = {
+        const data: JsonNamesMessage.AsObject = {
             someStrings: this.someStrings,
             anInteger: this.anInteger,
             colorSpace: this.colorSpace,
@@ -239,6 +226,15 @@ export class JsonNamesMessage extends pb_1.Message {
     }
 }
 export namespace JsonNamesMessage {
+    export type AsObject = {
+        someStrings: string[];
+        anInteger: number;
+        aNestedMessage?: JsonNamesMessage.NestedMessage.AsObject;
+        colorSpace: ColorSpace;
+        anOptionalString: string;
+        aSingleString: string;
+        aSingleNumber: number;
+    };
     export class NestedMessage extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -258,9 +254,7 @@ export namespace JsonNamesMessage {
         set aNestedInteger(value: number) {
             pb_1.Message.setField(this, 1, value);
         }
-        static fromObject(data: {
-            aNestedInteger?: number;
-        }): NestedMessage {
+        static fromObject(data: RecursivePartial<NestedMessage.AsObject>): NestedMessage {
             const message = new NestedMessage({});
             if (data.aNestedInteger != null) {
                 message.aNestedInteger = data.aNestedInteger;
@@ -268,9 +262,7 @@ export namespace JsonNamesMessage {
             return message;
         }
         toObject() {
-            const data: {
-                aNestedInteger: number;
-            } = {
+            const data: NestedMessage.AsObject = {
                 aNestedInteger: this.aNestedInteger
             };
             return data;
@@ -304,5 +296,10 @@ export namespace JsonNamesMessage {
         static deserializeBinary(bytes: Uint8Array): NestedMessage {
             return NestedMessage.deserialize(bytes);
         }
+    }
+    export namespace NestedMessage {
+        export type AsObject = {
+            aNestedInteger: number;
+        };
     }
 }

--- a/test/jstype.ts
+++ b/test/jstype.ts
@@ -62,19 +62,14 @@ export class JSType extends pb_1.Message {
     }
     toObject() {
         const data: {
-            int_but_string?: string;
-            int_and_normal?: number;
-            int_and_number?: number;
-        } = {};
-        if (this.int_but_string != null) {
-            data.int_but_string = this.int_but_string;
-        }
-        if (this.int_and_normal != null) {
-            data.int_and_normal = this.int_and_normal;
-        }
-        if (this.int_and_number != null) {
-            data.int_and_number = this.int_and_number;
-        }
+            int_but_string: string;
+            int_and_normal: number;
+            int_and_number: number;
+        } = {
+            int_but_string: this.int_but_string,
+            int_and_normal: this.int_and_normal,
+            int_and_number: this.int_and_number
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/jstype.ts
+++ b/test/jstype.ts
@@ -4,6 +4,9 @@
  * source: test/_/jstype.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class JSType extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -43,11 +46,7 @@ export class JSType extends pb_1.Message {
     set int_and_number(value: number) {
         pb_1.Message.setField(this, 3, value);
     }
-    static fromObject(data: {
-        int_but_string?: string;
-        int_and_normal?: number;
-        int_and_number?: number;
-    }): JSType {
+    static fromObject(data: RecursivePartial<JSType.AsObject>): JSType {
         const message = new JSType({});
         if (data.int_but_string != null) {
             message.int_but_string = data.int_but_string;
@@ -61,11 +60,7 @@ export class JSType extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            int_but_string: string;
-            int_and_normal: number;
-            int_and_number: number;
-        } = {
+        const data: JSType.AsObject = {
             int_but_string: this.int_but_string,
             int_and_normal: this.int_and_normal,
             int_and_number: this.int_and_number
@@ -111,4 +106,11 @@ export class JSType extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): JSType {
         return JSType.deserialize(bytes);
     }
+}
+export namespace JSType {
+    export type AsObject = {
+        int_but_string: string;
+        int_and_normal: number;
+        int_and_number: number;
+    };
 }

--- a/test/jstype.ts
+++ b/test/jstype.ts
@@ -4,9 +4,6 @@
  * source: test/_/jstype.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class JSType extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -46,7 +43,7 @@ export class JSType extends pb_1.Message {
     set int_and_number(value: number) {
         pb_1.Message.setField(this, 3, value);
     }
-    static fromObject(data: RecursivePartial<JSType.AsObject>): JSType {
+    static fromObject(data: JSType.AsObjectPartial): JSType {
         const message = new JSType({});
         if (data.int_but_string != null) {
             message.int_but_string = data.int_but_string;
@@ -112,5 +109,10 @@ export namespace JSType {
         int_but_string: string;
         int_and_normal: number;
         int_and_number: number;
+    };
+    export type AsObjectPartial = {
+        int_but_string?: string;
+        int_and_normal?: number;
+        int_and_number?: number;
     };
 }

--- a/test/map.spec.ts
+++ b/test/map.spec.ts
@@ -3,6 +3,14 @@ import { Tags, Topic } from "./map";
 import { importdirective } from "./imported";
 
 describe("maps", () => {
+    // toObject() method sets the default values
+    const tagsObjectDefaultValues: ReturnType<typeof Tags.prototype.toObject> = {
+        key: "",
+        keys: {},
+        topics: {},
+        imported: {},
+        imported2: {},
+    }
     it("should serialize as map", () => {
         const tags = new Tags({});
 
@@ -12,7 +20,10 @@ describe("maps", () => {
         const gotTags = Tags.deserialize(bytes);
 
         expect(tags.keys).toBeInstanceOf(Map);
-        expect(gotTags.toObject()).toEqual({ key: "", keys: { see: 'working' } })
+        expect(gotTags.toObject()).toEqual({
+            ...tagsObjectDefaultValues,
+            keys: { see: 'working' }
+        })
     });
 
     it("should take the last seen", () => {
@@ -20,7 +31,10 @@ describe("maps", () => {
         tags.keys.set("see", "not_working");
         tags.keys.set("see", "working");
 
-        expect(Tags.deserialize(tags.serialize()).toObject()).toEqual({ key: "", keys: { see: 'working' } })
+        expect(Tags.deserialize(tags.serialize()).toObject()).toEqual({
+          ...tagsObjectDefaultValues,
+          keys: { see: 'working' }
+        })
     });
 
 
@@ -31,7 +45,10 @@ describe("maps", () => {
                 ["see", "working"],
             ])
         });
-        expect(Tags.deserialize(tags.serialize()).toObject()).toEqual({ key: "", keys: { see: 'working' } })
+        expect(Tags.deserialize(tags.serialize()).toObject()).toEqual({
+          ...tagsObjectDefaultValues,
+          keys: { see: 'working' }
+        })
     });
 
 
@@ -44,11 +61,11 @@ describe("maps", () => {
         });
         const transferredTags = Tags.deserialize(tags.serialize());
         expect(transferredTags.toObject()).toEqual({
-            key: "",
+            ...tagsObjectDefaultValues,
             topics: {
                 first: { link: "example1" },
                 second: { link: "example2" }
-            }
+            },
         })
     });
 
@@ -65,7 +82,7 @@ describe("maps", () => {
         });
         const transferredTags = Tags.deserialize(tags.serialize());
         expect(transferredTags.toObject()).toEqual({
-            key: "",
+            ...tagsObjectDefaultValues,
             imported: {
                 1: { key: importdirective.Imported.SubMessage.MyEnum.VALUE },
                 2: { key: importdirective.Imported.SubMessage.MyEnum.VALUE2 }
@@ -73,7 +90,7 @@ describe("maps", () => {
             imported2: {
                 1: importdirective.Imported.SubMessage.MyEnum.VALUE,
                 3: importdirective.Imported.SubMessage.MyEnum.VALUE2
-            }
+            },
         })
     });
 
@@ -91,7 +108,7 @@ describe("maps", () => {
         });
         const transferredTags = Tags.deserialize(tags.serialize());
         expect(transferredTags.toObject()).toEqual({
-            key: "",
+            ...tagsObjectDefaultValues,
             imported: {
                 1: { key: importdirective.Imported.SubMessage.MyEnum.VALUE },
                 2: { key: importdirective.Imported.SubMessage.MyEnum.VALUE2 }

--- a/test/map.ts
+++ b/test/map.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./imported";
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class Topic extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -24,9 +27,7 @@ export class Topic extends pb_1.Message {
     set link(value: string) {
         pb_1.Message.setField(this, 2, value);
     }
-    static fromObject(data: {
-        link?: string;
-    }): Topic {
+    static fromObject(data: RecursivePartial<Topic.AsObject>): Topic {
         const message = new Topic({});
         if (data.link != null) {
             message.link = data.link;
@@ -34,9 +35,7 @@ export class Topic extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            link: string;
-        } = {
+        const data: Topic.AsObject = {
             link: this.link
         };
         return data;
@@ -70,6 +69,11 @@ export class Topic extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Topic {
         return Topic.deserialize(bytes);
     }
+}
+export namespace Topic {
+    export type AsObject = {
+        link: string;
+    };
 }
 export class Tags extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -138,21 +142,7 @@ export class Tags extends pb_1.Message {
     set imported2(value: Map<number, dependency_1.importdirective.Imported.SubMessage.MyEnum>) {
         pb_1.Message.setField(this, 5, value as any);
     }
-    static fromObject(data: {
-        key?: string;
-        keys?: {
-            [key: string]: string;
-        };
-        topics?: {
-            [key: string]: Parameters<typeof Topic.fromObject>[0];
-        };
-        imported?: {
-            [key: number]: Parameters<typeof dependency_1.importdirective.Imported.SubMessage.fromObject>[0];
-        };
-        imported2?: {
-            [key: number]: dependency_1.importdirective.Imported.SubMessage.MyEnum;
-        };
-    }): Tags {
+    static fromObject(data: RecursivePartial<Tags.AsObject>): Tags {
         const message = new Tags({});
         if (data.key != null) {
             message.key = data.key;
@@ -172,21 +162,7 @@ export class Tags extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            key: string;
-            keys: {
-                [key: string]: string;
-            };
-            topics: {
-                [key: string]: Parameters<typeof Topic.fromObject>[0];
-            };
-            imported: {
-                [key: number]: Parameters<typeof dependency_1.importdirective.Imported.SubMessage.fromObject>[0];
-            };
-            imported2: {
-                [key: number]: dependency_1.importdirective.Imported.SubMessage.MyEnum;
-            };
-        } = {
+        const data: Tags.AsObject = {
             key: this.key,
             keys: Object.fromEntries(this.keys),
             topics: Object.fromEntries(Array.from(this.topics).map(([key, value]) => [key, value.toObject()])),
@@ -268,4 +244,21 @@ export class Tags extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Tags {
         return Tags.deserialize(bytes);
     }
+}
+export namespace Tags {
+    export type AsObject = {
+        key: string;
+        keys: {
+            [key: string]: string;
+        };
+        topics: {
+            [key: string]: Topic.AsObject;
+        };
+        imported: {
+            [key: number]: dependency_1.importdirective.Imported.SubMessage.AsObject;
+        };
+        imported2: {
+            [key: number]: dependency_1.importdirective.Imported.SubMessage.MyEnum;
+        };
+    };
 }

--- a/test/map.ts
+++ b/test/map.ts
@@ -35,11 +35,10 @@ export class Topic extends pb_1.Message {
     }
     toObject() {
         const data: {
-            link?: string;
-        } = {};
-        if (this.link != null) {
-            data.link = this.link;
-        }
+            link: string;
+        } = {
+            link: this.link
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -145,10 +144,10 @@ export class Tags extends pb_1.Message {
             [key: string]: string;
         };
         topics?: {
-            [key: string]: ReturnType<typeof Topic.prototype.toObject>;
+            [key: string]: Parameters<typeof Topic.fromObject>[0];
         };
         imported?: {
-            [key: number]: ReturnType<typeof dependency_1.importdirective.Imported.SubMessage.prototype.toObject>;
+            [key: number]: Parameters<typeof dependency_1.importdirective.Imported.SubMessage.fromObject>[0];
         };
         imported2?: {
             [key: number]: dependency_1.importdirective.Imported.SubMessage.MyEnum;
@@ -174,35 +173,26 @@ export class Tags extends pb_1.Message {
     }
     toObject() {
         const data: {
-            key?: string;
-            keys?: {
+            key: string;
+            keys: {
                 [key: string]: string;
             };
-            topics?: {
-                [key: string]: ReturnType<typeof Topic.prototype.toObject>;
+            topics: {
+                [key: string]: Parameters<typeof Topic.fromObject>[0];
             };
-            imported?: {
-                [key: number]: ReturnType<typeof dependency_1.importdirective.Imported.SubMessage.prototype.toObject>;
+            imported: {
+                [key: number]: Parameters<typeof dependency_1.importdirective.Imported.SubMessage.fromObject>[0];
             };
-            imported2?: {
+            imported2: {
                 [key: number]: dependency_1.importdirective.Imported.SubMessage.MyEnum;
             };
-        } = {};
-        if (this.key != null) {
-            data.key = this.key;
-        }
-        if (this.keys != null) {
-            data.keys = Object.fromEntries(this.keys);
-        }
-        if (this.topics != null) {
-            data.topics = Object.fromEntries(Array.from(this.topics).map(([key, value]) => [key, value.toObject()]));
-        }
-        if (this.imported != null) {
-            data.imported = Object.fromEntries(Array.from(this.imported).map(([key, value]) => [key, value.toObject()]));
-        }
-        if (this.imported2 != null) {
-            data.imported2 = Object.fromEntries(this.imported2);
-        }
+        } = {
+            key: this.key,
+            keys: Object.fromEntries(this.keys),
+            topics: Object.fromEntries(Array.from(this.topics).map(([key, value]) => [key, value.toObject()])),
+            imported: Object.fromEntries(Array.from(this.imported).map(([key, value]) => [key, value.toObject()])),
+            imported2: Object.fromEntries(this.imported2)
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/map.ts
+++ b/test/map.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./imported";
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class Topic extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -27,7 +24,7 @@ export class Topic extends pb_1.Message {
     set link(value: string) {
         pb_1.Message.setField(this, 2, value);
     }
-    static fromObject(data: RecursivePartial<Topic.AsObject>): Topic {
+    static fromObject(data: Topic.AsObjectPartial): Topic {
         const message = new Topic({});
         if (data.link != null) {
             message.link = data.link;
@@ -73,6 +70,9 @@ export class Topic extends pb_1.Message {
 export namespace Topic {
     export type AsObject = {
         link: string;
+    };
+    export type AsObjectPartial = {
+        link?: string;
     };
 }
 export class Tags extends pb_1.Message {
@@ -142,7 +142,7 @@ export class Tags extends pb_1.Message {
     set imported2(value: Map<number, dependency_1.importdirective.Imported.SubMessage.MyEnum>) {
         pb_1.Message.setField(this, 5, value as any);
     }
-    static fromObject(data: RecursivePartial<Tags.AsObject>): Tags {
+    static fromObject(data: Tags.AsObjectPartial): Tags {
         const message = new Tags({});
         if (data.key != null) {
             message.key = data.key;
@@ -186,13 +186,13 @@ export class Tags extends pb_1.Message {
         for (const [key, value] of this.topics) {
             writer.writeMessage(3, this.topics, () => {
                 writer.writeString(1, key);
-                writer.writeMessage(2, value, () => value.serialize(writer));
+                writer.writeMessage(2, value, () => value!.serialize(writer));
             });
         }
         for (const [key, value] of this.imported) {
             writer.writeMessage(4, this.imported, () => {
                 writer.writeInt32(1, key);
-                writer.writeMessage(2, value, () => value.serialize(writer));
+                writer.writeMessage(2, value, () => value!.serialize(writer));
             });
         }
         for (const [key, value] of this.imported2) {
@@ -258,6 +258,21 @@ export namespace Tags {
             [key: number]: dependency_1.importdirective.Imported.SubMessage.AsObject;
         };
         imported2: {
+            [key: number]: dependency_1.importdirective.Imported.SubMessage.MyEnum;
+        };
+    };
+    export type AsObjectPartial = {
+        key?: string;
+        keys?: {
+            [key: string]: string;
+        };
+        topics?: {
+            [key: string]: Topic.AsObject;
+        };
+        imported?: {
+            [key: number]: dependency_1.importdirective.Imported.SubMessage.AsObject;
+        };
+        imported2?: {
             [key: number]: dependency_1.importdirective.Imported.SubMessage.MyEnum;
         };
     };

--- a/test/map.ts
+++ b/test/map.ts
@@ -191,16 +191,16 @@ export class Tags extends pb_1.Message {
         if (this.key != null) {
             data.key = this.key;
         }
-        if (this.keys.size > 0) {
+        if (this.keys != null) {
             data.keys = Object.fromEntries(this.keys);
         }
-        if (this.topics.size > 0) {
+        if (this.topics != null) {
             data.topics = Object.fromEntries(Array.from(this.topics).map(([key, value]) => [key, value.toObject()]));
         }
-        if (this.imported.size > 0) {
+        if (this.imported != null) {
             data.imported = Object.fromEntries(Array.from(this.imported).map(([key, value]) => [key, value.toObject()]));
         }
-        if (this.imported2.size > 0) {
+        if (this.imported2 != null) {
             data.imported2 = Object.fromEntries(this.imported2);
         }
         return data;

--- a/test/messagefields.spec.ts
+++ b/test/messagefields.spec.ts
@@ -14,8 +14,8 @@ describe("SubMessages", () => {
         const deserializedMessage = MessageFields.deserialize(mymsg.serialize());
 
         expect(deserializedMessage.sub_message instanceof SubMessage).toBe(true);
-        expect(deserializedMessage.sub_message.field_1).toBe("field_1_value");
-        expect(deserializedMessage.sub_message.field_2).toBe("field_2_value");
+        expect(deserializedMessage.sub_message!.field_1).toBe("field_1_value");
+        expect(deserializedMessage.sub_message!.field_2).toBe("field_2_value");
     })
 
     it("should be converted to plain object", () => {
@@ -120,8 +120,8 @@ describe("SubMessages", () => {
         expect(message.array_prop[1].field_2).toBe("test");
 
         expect(message.sub_message instanceof SubMessage).toBeTrue();
-        expect(message.sub_message.field_2).not.toBeTruthy();
-        expect(message.sub_message.field_1).not.toBeTruthy();
+        expect(message.sub_message!.field_2).not.toBeTruthy();
+        expect(message.sub_message!.field_1).not.toBeTruthy();
     })
 
 })

--- a/test/messagefields.ts
+++ b/test/messagefields.ts
@@ -4,6 +4,9 @@
  * source: test/_/messagefields.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class MessageFields extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -36,10 +39,7 @@ export class MessageFields extends pb_1.Message {
     set array_prop(value: SubMessage[]) {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
-    static fromObject(data: {
-        sub_message?: Parameters<typeof SubMessage.fromObject>[0];
-        array_prop?: Parameters<typeof SubMessage.fromObject>[0][];
-    }): MessageFields {
+    static fromObject(data: RecursivePartial<MessageFields.AsObject>): MessageFields {
         const message = new MessageFields({});
         if (data.sub_message != null) {
             message.sub_message = SubMessage.fromObject(data.sub_message);
@@ -50,10 +50,7 @@ export class MessageFields extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            sub_message?: Parameters<typeof SubMessage.fromObject>[0];
-            array_prop: Parameters<typeof SubMessage.fromObject>[0][];
-        } = {
+        const data: MessageFields.AsObject = {
             array_prop: this.array_prop.map((item: SubMessage) => item.toObject())
         };
         if (this.sub_message != null) {
@@ -96,6 +93,12 @@ export class MessageFields extends pb_1.Message {
         return MessageFields.deserialize(bytes);
     }
 }
+export namespace MessageFields {
+    export type AsObject = {
+        sub_message?: SubMessage.AsObject;
+        array_prop: SubMessage.AsObject[];
+    };
+}
 export class SubMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -125,10 +128,7 @@ export class SubMessage extends pb_1.Message {
     set field_2(value: string) {
         pb_1.Message.setField(this, 2, value);
     }
-    static fromObject(data: {
-        field_1?: string;
-        field_2?: string;
-    }): SubMessage {
+    static fromObject(data: RecursivePartial<SubMessage.AsObject>): SubMessage {
         const message = new SubMessage({});
         if (data.field_1 != null) {
             message.field_1 = data.field_1;
@@ -139,10 +139,7 @@ export class SubMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            field_1: string;
-            field_2: string;
-        } = {
+        const data: SubMessage.AsObject = {
             field_1: this.field_1,
             field_2: this.field_2
         };
@@ -182,4 +179,10 @@ export class SubMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): SubMessage {
         return SubMessage.deserialize(bytes);
     }
+}
+export namespace SubMessage {
+    export type AsObject = {
+        field_1: string;
+        field_2: string;
+    };
 }

--- a/test/messagefields.ts
+++ b/test/messagefields.ts
@@ -37,8 +37,8 @@ export class MessageFields extends pb_1.Message {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
     static fromObject(data: {
-        sub_message?: ReturnType<typeof SubMessage.prototype.toObject>;
-        array_prop?: ReturnType<typeof SubMessage.prototype.toObject>[];
+        sub_message?: Parameters<typeof SubMessage.fromObject>[0];
+        array_prop?: Parameters<typeof SubMessage.fromObject>[0][];
     }): MessageFields {
         const message = new MessageFields({});
         if (data.sub_message != null) {
@@ -51,14 +51,13 @@ export class MessageFields extends pb_1.Message {
     }
     toObject() {
         const data: {
-            sub_message?: ReturnType<typeof SubMessage.prototype.toObject>;
-            array_prop?: ReturnType<typeof SubMessage.prototype.toObject>[];
-        } = {};
+            sub_message?: Parameters<typeof SubMessage.fromObject>[0];
+            array_prop: Parameters<typeof SubMessage.fromObject>[0][];
+        } = {
+            array_prop: this.array_prop.map((item: SubMessage) => item.toObject())
+        };
         if (this.sub_message != null) {
             data.sub_message = this.sub_message.toObject();
-        }
-        if (this.array_prop != null) {
-            data.array_prop = this.array_prop.map((item: SubMessage) => item.toObject());
         }
         return data;
     }
@@ -141,15 +140,12 @@ export class SubMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            field_1?: string;
-            field_2?: string;
-        } = {};
-        if (this.field_1 != null) {
-            data.field_1 = this.field_1;
-        }
-        if (this.field_2 != null) {
-            data.field_2 = this.field_2;
-        }
+            field_1: string;
+            field_2: string;
+        } = {
+            field_1: this.field_1,
+            field_2: this.field_2
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/messagefields.ts
+++ b/test/messagefields.ts
@@ -25,9 +25,9 @@ export class MessageFields extends pb_1.Message {
         }
     }
     get sub_message() {
-        return pb_1.Message.getWrapperField(this, SubMessage, 1) as SubMessage;
+        return pb_1.Message.getWrapperField(this, SubMessage, 1) as SubMessage | undefined | null;
     }
-    set sub_message(value: SubMessage) {
+    set sub_message(value: SubMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_sub_message() {

--- a/test/messagefields.ts
+++ b/test/messagefields.ts
@@ -4,9 +4,6 @@
  * source: test/_/messagefields.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class MessageFields extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -25,9 +22,9 @@ export class MessageFields extends pb_1.Message {
         }
     }
     get sub_message() {
-        return pb_1.Message.getWrapperField(this, SubMessage, 1) as SubMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, SubMessage, 1) as SubMessage | undefined;
     }
-    set sub_message(value: SubMessage | undefined | null) {
+    set sub_message(value: SubMessage | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_sub_message() {
@@ -39,7 +36,7 @@ export class MessageFields extends pb_1.Message {
     set array_prop(value: SubMessage[]) {
         pb_1.Message.setRepeatedWrapperField(this, 2, value);
     }
-    static fromObject(data: RecursivePartial<MessageFields.AsObject>): MessageFields {
+    static fromObject(data: MessageFields.AsObjectPartial): MessageFields {
         const message = new MessageFields({});
         if (data.sub_message != null) {
             message.sub_message = SubMessage.fromObject(data.sub_message);
@@ -63,9 +60,9 @@ export class MessageFields extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_sub_message)
-            writer.writeMessage(1, this.sub_message, () => this.sub_message.serialize(writer));
+            writer.writeMessage(1, this.sub_message, () => this.sub_message!.serialize(writer));
         if (this.array_prop.length)
-            writer.writeRepeatedMessage(2, this.array_prop, (item: SubMessage) => item.serialize(writer));
+            writer.writeRepeatedMessage(2, this.array_prop, (item: SubMessage) => item!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -98,6 +95,10 @@ export namespace MessageFields {
         sub_message?: SubMessage.AsObject;
         array_prop: SubMessage.AsObject[];
     };
+    export type AsObjectPartial = {
+        sub_message?: SubMessage.AsObjectPartial;
+        array_prop?: SubMessage.AsObjectPartial[];
+    };
 }
 export class SubMessage extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -128,7 +129,7 @@ export class SubMessage extends pb_1.Message {
     set field_2(value: string) {
         pb_1.Message.setField(this, 2, value);
     }
-    static fromObject(data: RecursivePartial<SubMessage.AsObject>): SubMessage {
+    static fromObject(data: SubMessage.AsObjectPartial): SubMessage {
         const message = new SubMessage({});
         if (data.field_1 != null) {
             message.field_1 = data.field_1;
@@ -184,5 +185,9 @@ export namespace SubMessage {
     export type AsObject = {
         field_1: string;
         field_2: string;
+    };
+    export type AsObjectPartial = {
+        field_1?: string;
+        field_2?: string;
     };
 }

--- a/test/no_namespace/double_nested.ts
+++ b/test/no_namespace/double_nested.ts
@@ -34,11 +34,10 @@ export class MessageFields extends pb_1.Message {
     }
     toObject() {
         const data: {
-            field?: string[];
-        } = {};
-        if (this.field != null) {
-            data.field = this.field;
-        }
+            field: string[];
+        } = {
+            field: this.field
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/no_namespace/double_nested.ts
+++ b/test/no_namespace/double_nested.ts
@@ -4,6 +4,9 @@
  * source: test/_/no_namespace/double_nested.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class MessageFields extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -23,9 +26,7 @@ export class MessageFields extends pb_1.Message {
     set field(value: string[]) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        field?: string[];
-    }): MessageFields {
+    static fromObject(data: RecursivePartial<MessageFieldsAsObject>): MessageFields {
         const message = new MessageFields({});
         if (data.field != null) {
             message.field = data.field;
@@ -33,9 +34,7 @@ export class MessageFields extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            field: string[];
-        } = {
+        const data: MessageFieldsAsObject = {
             field: this.field
         };
         return data;
@@ -70,3 +69,6 @@ export class MessageFields extends pb_1.Message {
         return MessageFields.deserialize(bytes);
     }
 }
+export type MessageFieldsAsObject = {
+    field: string[];
+};

--- a/test/no_namespace/double_nested.ts
+++ b/test/no_namespace/double_nested.ts
@@ -4,9 +4,6 @@
  * source: test/_/no_namespace/double_nested.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class MessageFields extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -26,7 +23,7 @@ export class MessageFields extends pb_1.Message {
     set field(value: string[]) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<MessageFieldsAsObject>): MessageFields {
+    static fromObject(data: MessageFieldsAsObjectPartial): MessageFields {
         const message = new MessageFields({});
         if (data.field != null) {
             message.field = data.field;
@@ -71,4 +68,7 @@ export class MessageFields extends pb_1.Message {
 }
 export type MessageFieldsAsObject = {
     field: string[];
+};
+export type MessageFieldsAsObjectPartial = {
+    field?: string[];
 };

--- a/test/no_namespace/nested.ts
+++ b/test/no_namespace/nested.ts
@@ -883,9 +883,9 @@ export class QueueClient extends grpc_1.makeGenericClientConstructor(Unimplement
         super(address, credentials, options);
     }
     pop: GrpcUnaryServiceInterface<Pop, Event> = (message: Pop, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<Event>, options?: grpc_1.CallOptions | grpc_1.requestCallback<Event>, callback?: grpc_1.requestCallback<Event>): grpc_1.ClientUnaryCall => {
-        return super.pop(message, metadata, options, callback);
+        return super["pop"](message, metadata, options, callback);
     };
     complete: GrpcUnaryServiceInterface<Complete, CompleteResult> = (message: Complete, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<CompleteResult>, options?: grpc_1.CallOptions | grpc_1.requestCallback<CompleteResult>, callback?: grpc_1.requestCallback<CompleteResult>): grpc_1.ClientUnaryCall => {
-        return super.complete(message, metadata, options, callback);
+        return super["complete"](message, metadata, options, callback);
     };
 }

--- a/test/no_namespace/nested.ts
+++ b/test/no_namespace/nested.ts
@@ -56,9 +56,9 @@ export class SchedulingContext extends pb_1.Message {
         return pb_1.Message.getField(this, 4) != null;
     }
     static fromObject(data: {
-        env?: ReturnType<typeof SchedulingContextEnv.prototype.toObject>[];
+        env?: Parameters<typeof SchedulingContextEnv.fromObject>[0][];
         timeout?: number;
-        batch?: ReturnType<typeof SchedulingContextBatch.prototype.toObject>;
+        batch?: Parameters<typeof SchedulingContextBatch.fromObject>[0];
     }): SchedulingContext {
         const message = new SchedulingContext({});
         if (data.env != null) {
@@ -74,16 +74,13 @@ export class SchedulingContext extends pb_1.Message {
     }
     toObject() {
         const data: {
-            env?: ReturnType<typeof SchedulingContextEnv.prototype.toObject>[];
-            timeout?: number;
-            batch?: ReturnType<typeof SchedulingContextBatch.prototype.toObject>;
-        } = {};
-        if (this.env != null) {
-            data.env = this.env.map((item: SchedulingContextEnv) => item.toObject());
-        }
-        if (this.timeout != null) {
-            data.timeout = this.timeout;
-        }
+            env: Parameters<typeof SchedulingContextEnv.fromObject>[0][];
+            timeout: number;
+            batch?: Parameters<typeof SchedulingContextBatch.fromObject>[0];
+        } = {
+            env: this.env.map((item: SchedulingContextEnv) => item.toObject()),
+            timeout: this.timeout
+        };
         if (this.batch != null) {
             data.batch = this.batch.toObject();
         }
@@ -173,15 +170,12 @@ export class SchedulingContextEnv extends pb_1.Message {
     }
     toObject() {
         const data: {
-            key?: string;
-            value?: string;
-        } = {};
-        if (this.key != null) {
-            data.key = this.key;
-        }
-        if (this.value != null) {
-            data.value = this.value;
-        }
+            key: string;
+            value: string;
+        } = {
+            key: this.key,
+            value: this.value
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -264,7 +258,7 @@ export class SchedulingContextBatch extends pb_1.Message {
     static fromObject(data: {
         limit?: number;
         deadline?: number;
-        process?: ReturnType<typeof SchedulingContextBatchProcess.prototype.toObject>;
+        process?: Parameters<typeof SchedulingContextBatchProcess.fromObject>[0];
     }): SchedulingContextBatch {
         const message = new SchedulingContextBatch({});
         if (data.limit != null) {
@@ -280,16 +274,13 @@ export class SchedulingContextBatch extends pb_1.Message {
     }
     toObject() {
         const data: {
-            limit?: number;
-            deadline?: number;
-            process?: ReturnType<typeof SchedulingContextBatchProcess.prototype.toObject>;
-        } = {};
-        if (this.limit != null) {
-            data.limit = this.limit;
-        }
-        if (this.deadline != null) {
-            data.deadline = this.deadline;
-        }
+            limit: number;
+            deadline: number;
+            process?: Parameters<typeof SchedulingContextBatchProcess.fromObject>[0];
+        } = {
+            limit: this.limit,
+            deadline: this.deadline
+        };
         if (this.process != null) {
             data.process = this.process.toObject();
         }
@@ -365,11 +356,10 @@ export class SchedulingContextBatchProcess extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: string;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
+            id: string;
+        } = {
+            id: this.id
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -458,7 +448,7 @@ export class Target extends pb_1.Message {
         id?: string;
         cwd?: string;
         handler?: string;
-        context?: ReturnType<typeof SchedulingContext.prototype.toObject>;
+        context?: Parameters<typeof SchedulingContext.fromObject>[0];
     }): Target {
         const message = new Target({});
         if (data.id != null) {
@@ -477,20 +467,15 @@ export class Target extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: string;
-            cwd?: string;
-            handler?: string;
-            context?: ReturnType<typeof SchedulingContext.prototype.toObject>;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
-        if (this.cwd != null) {
-            data.cwd = this.cwd;
-        }
-        if (this.handler != null) {
-            data.handler = this.handler;
-        }
+            id: string;
+            cwd: string;
+            handler: string;
+            context?: Parameters<typeof SchedulingContext.fromObject>[0];
+        } = {
+            id: this.id,
+            cwd: this.cwd,
+            handler: this.handler
+        };
         if (this.context != null) {
             data.context = this.context.toObject();
         }
@@ -586,7 +571,7 @@ export class Event extends pb_1.Message {
     static fromObject(data: {
         id?: string;
         type?: Type;
-        target?: ReturnType<typeof Target.prototype.toObject>;
+        target?: Parameters<typeof Target.fromObject>[0];
     }): Event {
         const message = new Event({});
         if (data.id != null) {
@@ -602,16 +587,13 @@ export class Event extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: string;
-            type?: Type;
-            target?: ReturnType<typeof Target.prototype.toObject>;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
-        if (this.type != null) {
-            data.type = this.type;
-        }
+            id: string;
+            type: Type;
+            target?: Parameters<typeof Target.fromObject>[0];
+        } = {
+            id: this.id,
+            type: this.type
+        };
         if (this.target != null) {
             data.target = this.target.toObject();
         }
@@ -687,11 +669,10 @@ export class Pop extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: string;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
+            id: string;
+        } = {
+            id: this.id
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -754,11 +735,10 @@ export class Complete extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: string;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
+            id: string;
+        } = {
+            id: this.id
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/no_namespace/nested.ts
+++ b/test/no_namespace/nested.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export enum Type {
     HTTP = 0,
     DATABASE = 1,
@@ -55,11 +58,7 @@ export class SchedulingContext extends pb_1.Message {
     get has_batch() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: {
-        env?: Parameters<typeof SchedulingContextEnv.fromObject>[0][];
-        timeout?: number;
-        batch?: Parameters<typeof SchedulingContextBatch.fromObject>[0];
-    }): SchedulingContext {
+    static fromObject(data: RecursivePartial<SchedulingContextAsObject>): SchedulingContext {
         const message = new SchedulingContext({});
         if (data.env != null) {
             message.env = data.env.map(item => SchedulingContextEnv.fromObject(item));
@@ -73,11 +72,7 @@ export class SchedulingContext extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            env: Parameters<typeof SchedulingContextEnv.fromObject>[0][];
-            timeout: number;
-            batch?: Parameters<typeof SchedulingContextBatch.fromObject>[0];
-        } = {
+        const data: SchedulingContextAsObject = {
             env: this.env.map((item: SchedulingContextEnv) => item.toObject()),
             timeout: this.timeout
         };
@@ -126,6 +121,11 @@ export class SchedulingContext extends pb_1.Message {
         return SchedulingContext.deserialize(bytes);
     }
 }
+export type SchedulingContextAsObject = {
+    env: SchedulingContextEnvAsObject[];
+    timeout: number;
+    batch?: SchedulingContextBatchAsObject;
+};
 export class SchedulingContextEnv extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -155,10 +155,7 @@ export class SchedulingContextEnv extends pb_1.Message {
     set value(value: string) {
         pb_1.Message.setField(this, 2, value);
     }
-    static fromObject(data: {
-        key?: string;
-        value?: string;
-    }): SchedulingContextEnv {
+    static fromObject(data: RecursivePartial<SchedulingContextEnvAsObject>): SchedulingContextEnv {
         const message = new SchedulingContextEnv({});
         if (data.key != null) {
             message.key = data.key;
@@ -169,10 +166,7 @@ export class SchedulingContextEnv extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            key: string;
-            value: string;
-        } = {
+        const data: SchedulingContextEnvAsObject = {
             key: this.key,
             value: this.value
         };
@@ -213,6 +207,10 @@ export class SchedulingContextEnv extends pb_1.Message {
         return SchedulingContextEnv.deserialize(bytes);
     }
 }
+export type SchedulingContextEnvAsObject = {
+    key: string;
+    value: string;
+};
 export class SchedulingContextBatch extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -255,11 +253,7 @@ export class SchedulingContextBatch extends pb_1.Message {
     get has_process() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        limit?: number;
-        deadline?: number;
-        process?: Parameters<typeof SchedulingContextBatchProcess.fromObject>[0];
-    }): SchedulingContextBatch {
+    static fromObject(data: RecursivePartial<SchedulingContextBatchAsObject>): SchedulingContextBatch {
         const message = new SchedulingContextBatch({});
         if (data.limit != null) {
             message.limit = data.limit;
@@ -273,11 +267,7 @@ export class SchedulingContextBatch extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            limit: number;
-            deadline: number;
-            process?: Parameters<typeof SchedulingContextBatchProcess.fromObject>[0];
-        } = {
+        const data: SchedulingContextBatchAsObject = {
             limit: this.limit,
             deadline: this.deadline
         };
@@ -326,6 +316,11 @@ export class SchedulingContextBatch extends pb_1.Message {
         return SchedulingContextBatch.deserialize(bytes);
     }
 }
+export type SchedulingContextBatchAsObject = {
+    limit: number;
+    deadline: number;
+    process?: SchedulingContextBatchProcessAsObject;
+};
 export class SchedulingContextBatchProcess extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -345,9 +340,7 @@ export class SchedulingContextBatchProcess extends pb_1.Message {
     set id(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        id?: string;
-    }): SchedulingContextBatchProcess {
+    static fromObject(data: RecursivePartial<SchedulingContextBatchProcessAsObject>): SchedulingContextBatchProcess {
         const message = new SchedulingContextBatchProcess({});
         if (data.id != null) {
             message.id = data.id;
@@ -355,9 +348,7 @@ export class SchedulingContextBatchProcess extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: string;
-        } = {
+        const data: SchedulingContextBatchProcessAsObject = {
             id: this.id
         };
         return data;
@@ -392,6 +383,9 @@ export class SchedulingContextBatchProcess extends pb_1.Message {
         return SchedulingContextBatchProcess.deserialize(bytes);
     }
 }
+export type SchedulingContextBatchProcessAsObject = {
+    id: string;
+};
 export class Target extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -444,12 +438,7 @@ export class Target extends pb_1.Message {
     get has_context() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: {
-        id?: string;
-        cwd?: string;
-        handler?: string;
-        context?: Parameters<typeof SchedulingContext.fromObject>[0];
-    }): Target {
+    static fromObject(data: RecursivePartial<TargetAsObject>): Target {
         const message = new Target({});
         if (data.id != null) {
             message.id = data.id;
@@ -466,12 +455,7 @@ export class Target extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: string;
-            cwd: string;
-            handler: string;
-            context?: Parameters<typeof SchedulingContext.fromObject>[0];
-        } = {
+        const data: TargetAsObject = {
             id: this.id,
             cwd: this.cwd,
             handler: this.handler
@@ -526,6 +510,12 @@ export class Target extends pb_1.Message {
         return Target.deserialize(bytes);
     }
 }
+export type TargetAsObject = {
+    id: string;
+    cwd: string;
+    handler: string;
+    context?: SchedulingContextAsObject;
+};
 export class Event extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -568,11 +558,7 @@ export class Event extends pb_1.Message {
     get has_target() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        id?: string;
-        type?: Type;
-        target?: Parameters<typeof Target.fromObject>[0];
-    }): Event {
+    static fromObject(data: RecursivePartial<EventAsObject>): Event {
         const message = new Event({});
         if (data.id != null) {
             message.id = data.id;
@@ -586,11 +572,7 @@ export class Event extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: string;
-            type: Type;
-            target?: Parameters<typeof Target.fromObject>[0];
-        } = {
+        const data: EventAsObject = {
             id: this.id,
             type: this.type
         };
@@ -639,6 +621,11 @@ export class Event extends pb_1.Message {
         return Event.deserialize(bytes);
     }
 }
+export type EventAsObject = {
+    id: string;
+    type: Type;
+    target?: TargetAsObject;
+};
 export class Pop extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -658,9 +645,7 @@ export class Pop extends pb_1.Message {
     set id(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        id?: string;
-    }): Pop {
+    static fromObject(data: RecursivePartial<PopAsObject>): Pop {
         const message = new Pop({});
         if (data.id != null) {
             message.id = data.id;
@@ -668,9 +653,7 @@ export class Pop extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: string;
-        } = {
+        const data: PopAsObject = {
             id: this.id
         };
         return data;
@@ -705,6 +688,9 @@ export class Pop extends pb_1.Message {
         return Pop.deserialize(bytes);
     }
 }
+export type PopAsObject = {
+    id: string;
+};
 export class Complete extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -724,9 +710,7 @@ export class Complete extends pb_1.Message {
     set id(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        id?: string;
-    }): Complete {
+    static fromObject(data: RecursivePartial<CompleteAsObject>): Complete {
         const message = new Complete({});
         if (data.id != null) {
             message.id = data.id;
@@ -734,9 +718,7 @@ export class Complete extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: string;
-        } = {
+        const data: CompleteAsObject = {
             id: this.id
         };
         return data;
@@ -771,6 +753,9 @@ export class Complete extends pb_1.Message {
         return Complete.deserialize(bytes);
     }
 }
+export type CompleteAsObject = {
+    id: string;
+};
 export class CompleteResult extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {}) {
@@ -778,12 +763,12 @@ export class CompleteResult extends pb_1.Message {
         pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
         if (!Array.isArray(data) && typeof data == "object") { }
     }
-    static fromObject(data: {}): CompleteResult {
+    static fromObject(data: RecursivePartial<CompleteResultAsObject>): CompleteResult {
         const message = new CompleteResult({});
         return message;
     }
     toObject() {
-        const data: {} = {};
+        const data: CompleteResultAsObject = {};
         return data;
     }
     serialize(): Uint8Array;
@@ -811,6 +796,7 @@ export class CompleteResult extends pb_1.Message {
         return CompleteResult.deserialize(bytes);
     }
 }
+export type CompleteResultAsObject = {};
 interface GrpcUnaryServiceInterface<P, R> {
     (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;
     (message: P, metadata: grpc_1.Metadata, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/no_namespace/nested.ts
+++ b/test/no_namespace/nested.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export enum Type {
     HTTP = 0,
     DATABASE = 1,
@@ -50,15 +47,15 @@ export class SchedulingContext extends pb_1.Message {
         pb_1.Message.setField(this, 3, value);
     }
     get batch() {
-        return pb_1.Message.getWrapperField(this, SchedulingContextBatch, 4) as SchedulingContextBatch | undefined | null;
+        return pb_1.Message.getWrapperField(this, SchedulingContextBatch, 4) as SchedulingContextBatch | undefined;
     }
-    set batch(value: SchedulingContextBatch | undefined | null) {
+    set batch(value: SchedulingContextBatch | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_batch() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: RecursivePartial<SchedulingContextAsObject>): SchedulingContext {
+    static fromObject(data: SchedulingContextAsObjectPartial): SchedulingContext {
         const message = new SchedulingContext({});
         if (data.env != null) {
             message.env = data.env.map(item => SchedulingContextEnv.fromObject(item));
@@ -86,11 +83,11 @@ export class SchedulingContext extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.env.length)
-            writer.writeRepeatedMessage(2, this.env, (item: SchedulingContextEnv) => item.serialize(writer));
+            writer.writeRepeatedMessage(2, this.env, (item: SchedulingContextEnv) => item!.serialize(writer));
         if (this.timeout != 0)
             writer.writeInt32(3, this.timeout);
         if (this.has_batch)
-            writer.writeMessage(4, this.batch, () => this.batch.serialize(writer));
+            writer.writeMessage(4, this.batch, () => this.batch!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -126,6 +123,11 @@ export type SchedulingContextAsObject = {
     timeout: number;
     batch?: SchedulingContextBatchAsObject;
 };
+export type SchedulingContextAsObjectPartial = {
+    env?: SchedulingContextEnvAsObjectPartial[];
+    timeout?: number;
+    batch?: SchedulingContextBatchAsObjectPartial;
+};
 export class SchedulingContextEnv extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -155,7 +157,7 @@ export class SchedulingContextEnv extends pb_1.Message {
     set value(value: string) {
         pb_1.Message.setField(this, 2, value);
     }
-    static fromObject(data: RecursivePartial<SchedulingContextEnvAsObject>): SchedulingContextEnv {
+    static fromObject(data: SchedulingContextEnvAsObjectPartial): SchedulingContextEnv {
         const message = new SchedulingContextEnv({});
         if (data.key != null) {
             message.key = data.key;
@@ -211,6 +213,10 @@ export type SchedulingContextEnvAsObject = {
     key: string;
     value: string;
 };
+export type SchedulingContextEnvAsObjectPartial = {
+    key?: string;
+    value?: string;
+};
 export class SchedulingContextBatch extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -245,15 +251,15 @@ export class SchedulingContextBatch extends pb_1.Message {
         pb_1.Message.setField(this, 2, value);
     }
     get process() {
-        return pb_1.Message.getWrapperField(this, SchedulingContextBatchProcess, 3) as SchedulingContextBatchProcess | undefined | null;
+        return pb_1.Message.getWrapperField(this, SchedulingContextBatchProcess, 3) as SchedulingContextBatchProcess | undefined;
     }
-    set process(value: SchedulingContextBatchProcess | undefined | null) {
+    set process(value: SchedulingContextBatchProcess | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_process() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<SchedulingContextBatchAsObject>): SchedulingContextBatch {
+    static fromObject(data: SchedulingContextBatchAsObjectPartial): SchedulingContextBatch {
         const message = new SchedulingContextBatch({});
         if (data.limit != null) {
             message.limit = data.limit;
@@ -285,7 +291,7 @@ export class SchedulingContextBatch extends pb_1.Message {
         if (this.deadline != 0)
             writer.writeUint64(2, this.deadline);
         if (this.has_process)
-            writer.writeMessage(3, this.process, () => this.process.serialize(writer));
+            writer.writeMessage(3, this.process, () => this.process!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -321,6 +327,11 @@ export type SchedulingContextBatchAsObject = {
     deadline: number;
     process?: SchedulingContextBatchProcessAsObject;
 };
+export type SchedulingContextBatchAsObjectPartial = {
+    limit?: number;
+    deadline?: number;
+    process?: SchedulingContextBatchProcessAsObjectPartial;
+};
 export class SchedulingContextBatchProcess extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -340,7 +351,7 @@ export class SchedulingContextBatchProcess extends pb_1.Message {
     set id(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<SchedulingContextBatchProcessAsObject>): SchedulingContextBatchProcess {
+    static fromObject(data: SchedulingContextBatchProcessAsObjectPartial): SchedulingContextBatchProcess {
         const message = new SchedulingContextBatchProcess({});
         if (data.id != null) {
             message.id = data.id;
@@ -386,6 +397,9 @@ export class SchedulingContextBatchProcess extends pb_1.Message {
 export type SchedulingContextBatchProcessAsObject = {
     id: string;
 };
+export type SchedulingContextBatchProcessAsObjectPartial = {
+    id?: string;
+};
 export class Target extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -430,15 +444,15 @@ export class Target extends pb_1.Message {
         pb_1.Message.setField(this, 3, value);
     }
     get context() {
-        return pb_1.Message.getWrapperField(this, SchedulingContext, 4) as SchedulingContext | undefined | null;
+        return pb_1.Message.getWrapperField(this, SchedulingContext, 4) as SchedulingContext | undefined;
     }
-    set context(value: SchedulingContext | undefined | null) {
+    set context(value: SchedulingContext | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_context() {
         return pb_1.Message.getField(this, 4) != null;
     }
-    static fromObject(data: RecursivePartial<TargetAsObject>): Target {
+    static fromObject(data: TargetAsObjectPartial): Target {
         const message = new Target({});
         if (data.id != null) {
             message.id = data.id;
@@ -476,7 +490,7 @@ export class Target extends pb_1.Message {
         if (this.handler.length)
             writer.writeString(3, this.handler);
         if (this.has_context)
-            writer.writeMessage(4, this.context, () => this.context.serialize(writer));
+            writer.writeMessage(4, this.context, () => this.context!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -516,6 +530,12 @@ export type TargetAsObject = {
     handler: string;
     context?: SchedulingContextAsObject;
 };
+export type TargetAsObjectPartial = {
+    id?: string;
+    cwd?: string;
+    handler?: string;
+    context?: SchedulingContextAsObjectPartial;
+};
 export class Event extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -550,15 +570,15 @@ export class Event extends pb_1.Message {
         pb_1.Message.setField(this, 2, value);
     }
     get target() {
-        return pb_1.Message.getWrapperField(this, Target, 3) as Target | undefined | null;
+        return pb_1.Message.getWrapperField(this, Target, 3) as Target | undefined;
     }
-    set target(value: Target | undefined | null) {
+    set target(value: Target | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_target() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<EventAsObject>): Event {
+    static fromObject(data: EventAsObjectPartial): Event {
         const message = new Event({});
         if (data.id != null) {
             message.id = data.id;
@@ -590,7 +610,7 @@ export class Event extends pb_1.Message {
         if (this.type != Type.HTTP)
             writer.writeEnum(2, this.type);
         if (this.has_target)
-            writer.writeMessage(3, this.target, () => this.target.serialize(writer));
+            writer.writeMessage(3, this.target, () => this.target!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -626,6 +646,11 @@ export type EventAsObject = {
     type: Type;
     target?: TargetAsObject;
 };
+export type EventAsObjectPartial = {
+    id?: string;
+    type?: Type;
+    target?: TargetAsObjectPartial;
+};
 export class Pop extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -645,7 +670,7 @@ export class Pop extends pb_1.Message {
     set id(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<PopAsObject>): Pop {
+    static fromObject(data: PopAsObjectPartial): Pop {
         const message = new Pop({});
         if (data.id != null) {
             message.id = data.id;
@@ -691,6 +716,9 @@ export class Pop extends pb_1.Message {
 export type PopAsObject = {
     id: string;
 };
+export type PopAsObjectPartial = {
+    id?: string;
+};
 export class Complete extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -710,7 +738,7 @@ export class Complete extends pb_1.Message {
     set id(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<CompleteAsObject>): Complete {
+    static fromObject(data: CompleteAsObjectPartial): Complete {
         const message = new Complete({});
         if (data.id != null) {
             message.id = data.id;
@@ -756,6 +784,9 @@ export class Complete extends pb_1.Message {
 export type CompleteAsObject = {
     id: string;
 };
+export type CompleteAsObjectPartial = {
+    id?: string;
+};
 export class CompleteResult extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {}) {
@@ -763,7 +794,7 @@ export class CompleteResult extends pb_1.Message {
         pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
         if (!Array.isArray(data) && typeof data == "object") { }
     }
-    static fromObject(data: RecursivePartial<CompleteResultAsObject>): CompleteResult {
+    static fromObject(data: CompleteResultAsObjectPartial): CompleteResult {
         const message = new CompleteResult({});
         return message;
     }
@@ -797,6 +828,7 @@ export class CompleteResult extends pb_1.Message {
     }
 }
 export type CompleteResultAsObject = {};
+export type CompleteResultAsObjectPartial = {};
 interface GrpcUnaryServiceInterface<P, R> {
     (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;
     (message: P, metadata: grpc_1.Metadata, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/no_namespace/nested.ts
+++ b/test/no_namespace/nested.ts
@@ -50,9 +50,9 @@ export class SchedulingContext extends pb_1.Message {
         pb_1.Message.setField(this, 3, value);
     }
     get batch() {
-        return pb_1.Message.getWrapperField(this, SchedulingContextBatch, 4) as SchedulingContextBatch;
+        return pb_1.Message.getWrapperField(this, SchedulingContextBatch, 4) as SchedulingContextBatch | undefined | null;
     }
-    set batch(value: SchedulingContextBatch) {
+    set batch(value: SchedulingContextBatch | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_batch() {
@@ -245,9 +245,9 @@ export class SchedulingContextBatch extends pb_1.Message {
         pb_1.Message.setField(this, 2, value);
     }
     get process() {
-        return pb_1.Message.getWrapperField(this, SchedulingContextBatchProcess, 3) as SchedulingContextBatchProcess;
+        return pb_1.Message.getWrapperField(this, SchedulingContextBatchProcess, 3) as SchedulingContextBatchProcess | undefined | null;
     }
-    set process(value: SchedulingContextBatchProcess) {
+    set process(value: SchedulingContextBatchProcess | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_process() {
@@ -430,9 +430,9 @@ export class Target extends pb_1.Message {
         pb_1.Message.setField(this, 3, value);
     }
     get context() {
-        return pb_1.Message.getWrapperField(this, SchedulingContext, 4) as SchedulingContext;
+        return pb_1.Message.getWrapperField(this, SchedulingContext, 4) as SchedulingContext | undefined | null;
     }
-    set context(value: SchedulingContext) {
+    set context(value: SchedulingContext | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_context() {
@@ -550,9 +550,9 @@ export class Event extends pb_1.Message {
         pb_1.Message.setField(this, 2, value);
     }
     get target() {
-        return pb_1.Message.getWrapperField(this, Target, 3) as Target;
+        return pb_1.Message.getWrapperField(this, Target, 3) as Target | undefined | null;
     }
-    set target(value: Target) {
+    set target(value: Target | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_target() {

--- a/test/no_namespace/no_namespace.ts
+++ b/test/no_namespace/no_namespace.ts
@@ -31,27 +31,27 @@ export class NoNamespace extends pb_1.Message {
         }
     }
     get label() {
-        return pb_1.Message.getWrapperField(this, dependency_1.eventTarget, 1) as dependency_1.eventTarget;
+        return pb_1.Message.getWrapperField(this, dependency_1.eventTarget, 1) as dependency_1.eventTarget | undefined | null;
     }
-    set label(value: dependency_1.eventTarget) {
+    set label(value: dependency_1.eventTarget | undefined | null) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_label() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get other_fields() {
-        return pb_1.Message.getWrapperField(this, dependency_2.MessageFields, 2) as dependency_2.MessageFields;
+        return pb_1.Message.getWrapperField(this, dependency_2.MessageFields, 2) as dependency_2.MessageFields | undefined | null;
     }
-    set other_fields(value: dependency_2.MessageFields) {
+    set other_fields(value: dependency_2.MessageFields | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_other_fields() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get batch_fields() {
-        return pb_1.Message.getWrapperField(this, dependency_1.eventSchedulingContextBatch, 3) as dependency_1.eventSchedulingContextBatch;
+        return pb_1.Message.getWrapperField(this, dependency_1.eventSchedulingContextBatch, 3) as dependency_1.eventSchedulingContextBatch | undefined | null;
     }
-    set batch_fields(value: dependency_1.eventSchedulingContextBatch) {
+    set batch_fields(value: dependency_1.eventSchedulingContextBatch | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_batch_fields() {

--- a/test/no_namespace/no_namespace.ts
+++ b/test/no_namespace/no_namespace.ts
@@ -55,9 +55,9 @@ export class NoNamespace extends pb_1.Message {
         return pb_1.Message.getField(this, 3) != null;
     }
     static fromObject(data: {
-        label?: ReturnType<typeof dependency_1.eventTarget.prototype.toObject>;
-        other_fields?: ReturnType<typeof dependency_2.MessageFields.prototype.toObject>;
-        batch_fields?: ReturnType<typeof dependency_1.eventSchedulingContextBatch.prototype.toObject>;
+        label?: Parameters<typeof dependency_1.eventTarget.fromObject>[0];
+        other_fields?: Parameters<typeof dependency_2.MessageFields.fromObject>[0];
+        batch_fields?: Parameters<typeof dependency_1.eventSchedulingContextBatch.fromObject>[0];
     }): NoNamespace {
         const message = new NoNamespace({});
         if (data.label != null) {
@@ -73,9 +73,9 @@ export class NoNamespace extends pb_1.Message {
     }
     toObject() {
         const data: {
-            label?: ReturnType<typeof dependency_1.eventTarget.prototype.toObject>;
-            other_fields?: ReturnType<typeof dependency_2.MessageFields.prototype.toObject>;
-            batch_fields?: ReturnType<typeof dependency_1.eventSchedulingContextBatch.prototype.toObject>;
+            label?: Parameters<typeof dependency_1.eventTarget.fromObject>[0];
+            other_fields?: Parameters<typeof dependency_2.MessageFields.fromObject>[0];
+            batch_fields?: Parameters<typeof dependency_1.eventSchedulingContextBatch.fromObject>[0];
         } = {};
         if (this.label != null) {
             data.label = this.label.toObject();

--- a/test/no_namespace/no_namespace.ts
+++ b/test/no_namespace/no_namespace.ts
@@ -6,6 +6,9 @@
 import * as dependency_1 from "./nested";
 import * as dependency_2 from "./double_nested";
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class NoNamespace extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -54,11 +57,7 @@ export class NoNamespace extends pb_1.Message {
     get has_batch_fields() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        label?: Parameters<typeof dependency_1.eventTarget.fromObject>[0];
-        other_fields?: Parameters<typeof dependency_2.MessageFields.fromObject>[0];
-        batch_fields?: Parameters<typeof dependency_1.eventSchedulingContextBatch.fromObject>[0];
-    }): NoNamespace {
+    static fromObject(data: RecursivePartial<NoNamespaceAsObject>): NoNamespace {
         const message = new NoNamespace({});
         if (data.label != null) {
             message.label = dependency_1.eventTarget.fromObject(data.label);
@@ -72,11 +71,7 @@ export class NoNamespace extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            label?: Parameters<typeof dependency_1.eventTarget.fromObject>[0];
-            other_fields?: Parameters<typeof dependency_2.MessageFields.fromObject>[0];
-            batch_fields?: Parameters<typeof dependency_1.eventSchedulingContextBatch.fromObject>[0];
-        } = {};
+        const data: NoNamespaceAsObject = {};
         if (this.label != null) {
             data.label = this.label.toObject();
         }
@@ -128,3 +123,8 @@ export class NoNamespace extends pb_1.Message {
         return NoNamespace.deserialize(bytes);
     }
 }
+export type NoNamespaceAsObject = {
+    label?: dependency_1.eventTargetAsObject;
+    other_fields?: dependency_2.MessageFieldsAsObject;
+    batch_fields?: dependency_1.eventSchedulingContextBatchAsObject;
+};

--- a/test/no_namespace/no_namespace.ts
+++ b/test/no_namespace/no_namespace.ts
@@ -6,9 +6,6 @@
 import * as dependency_1 from "./nested";
 import * as dependency_2 from "./double_nested";
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class NoNamespace extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -31,33 +28,33 @@ export class NoNamespace extends pb_1.Message {
         }
     }
     get label() {
-        return pb_1.Message.getWrapperField(this, dependency_1.eventTarget, 1) as dependency_1.eventTarget | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.eventTarget, 1) as dependency_1.eventTarget | undefined;
     }
-    set label(value: dependency_1.eventTarget | undefined | null) {
+    set label(value: dependency_1.eventTarget | undefined) {
         pb_1.Message.setWrapperField(this, 1, value);
     }
     get has_label() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get other_fields() {
-        return pb_1.Message.getWrapperField(this, dependency_2.MessageFields, 2) as dependency_2.MessageFields | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_2.MessageFields, 2) as dependency_2.MessageFields | undefined;
     }
-    set other_fields(value: dependency_2.MessageFields | undefined | null) {
+    set other_fields(value: dependency_2.MessageFields | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_other_fields() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get batch_fields() {
-        return pb_1.Message.getWrapperField(this, dependency_1.eventSchedulingContextBatch, 3) as dependency_1.eventSchedulingContextBatch | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.eventSchedulingContextBatch, 3) as dependency_1.eventSchedulingContextBatch | undefined;
     }
-    set batch_fields(value: dependency_1.eventSchedulingContextBatch | undefined | null) {
+    set batch_fields(value: dependency_1.eventSchedulingContextBatch | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_batch_fields() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<NoNamespaceAsObject>): NoNamespace {
+    static fromObject(data: NoNamespaceAsObjectPartial): NoNamespace {
         const message = new NoNamespace({});
         if (data.label != null) {
             message.label = dependency_1.eventTarget.fromObject(data.label);
@@ -88,11 +85,11 @@ export class NoNamespace extends pb_1.Message {
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
         if (this.has_label)
-            writer.writeMessage(1, this.label, () => this.label.serialize(writer));
+            writer.writeMessage(1, this.label, () => this.label!.serialize(writer));
         if (this.has_other_fields)
-            writer.writeMessage(2, this.other_fields, () => this.other_fields.serialize(writer));
+            writer.writeMessage(2, this.other_fields, () => this.other_fields!.serialize(writer));
         if (this.has_batch_fields)
-            writer.writeMessage(3, this.batch_fields, () => this.batch_fields.serialize(writer));
+            writer.writeMessage(3, this.batch_fields, () => this.batch_fields!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -127,4 +124,9 @@ export type NoNamespaceAsObject = {
     label?: dependency_1.eventTargetAsObject;
     other_fields?: dependency_2.MessageFieldsAsObject;
     batch_fields?: dependency_1.eventSchedulingContextBatchAsObject;
+};
+export type NoNamespaceAsObjectPartial = {
+    label?: dependency_1.eventTargetAsObjectPartial;
+    other_fields?: dependency_2.MessageFieldsAsObjectPartial;
+    batch_fields?: dependency_1.eventSchedulingContextBatchAsObjectPartial;
 };

--- a/test/oneof.ts
+++ b/test/oneof.ts
@@ -115,23 +115,16 @@ export class OneOfWithoutAnyOtherFields extends pb_1.Message {
     }
     toObject() {
         const data: {
-            nickname?: string;
-            realname?: string;
-            age?: string;
-            date_of_birth?: string;
-        } = {};
-        if (this.nickname != null) {
-            data.nickname = this.nickname;
-        }
-        if (this.realname != null) {
-            data.realname = this.realname;
-        }
-        if (this.age != null) {
-            data.age = this.age;
-        }
-        if (this.date_of_birth != null) {
-            data.date_of_birth = this.date_of_birth;
-        }
+            nickname: string;
+            realname: string;
+            age: string;
+            date_of_birth: string;
+        } = {
+            nickname: this.nickname,
+            realname: this.realname,
+            age: this.age,
+            date_of_birth: this.date_of_birth
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -257,19 +250,14 @@ export class OneOf extends pb_1.Message {
     }
     toObject() {
         const data: {
-            nickname?: string;
-            date_of_birth?: string;
-            age?: string;
-        } = {};
-        if (this.nickname != null) {
-            data.nickname = this.nickname;
-        }
-        if (this.date_of_birth != null) {
-            data.date_of_birth = this.date_of_birth;
-        }
-        if (this.age != null) {
-            data.age = this.age;
-        }
+            nickname: string;
+            date_of_birth: string;
+            age: string;
+        } = {
+            nickname: this.nickname,
+            date_of_birth: this.date_of_birth,
+            age: this.age
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/oneof.ts
+++ b/test/oneof.ts
@@ -4,9 +4,6 @@
  * source: test/_/oneof.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class OneOfWithoutAnyOtherFields extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2], [4, 3]];
     constructor(data?: any[] | ({} & (({
@@ -95,7 +92,7 @@ export class OneOfWithoutAnyOtherFields extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [4, 3])];
     }
-    static fromObject(data: RecursivePartial<OneOfWithoutAnyOtherFields.AsObject>): OneOfWithoutAnyOtherFields {
+    static fromObject(data: OneOfWithoutAnyOtherFields.AsObjectPartial): OneOfWithoutAnyOtherFields {
         const message = new OneOfWithoutAnyOtherFields({});
         if (data.nickname != null) {
             message.nickname = data.nickname;
@@ -172,6 +169,12 @@ export namespace OneOfWithoutAnyOtherFields {
         age: string;
         date_of_birth: string;
     };
+    export type AsObjectPartial = {
+        nickname?: string;
+        realname?: string;
+        age?: string;
+        date_of_birth?: string;
+    };
 }
 export class OneOf extends pb_1.Message {
     #one_of_decls: number[][] = [[3, 4]];
@@ -232,7 +235,7 @@ export class OneOf extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [3, 4])];
     }
-    static fromObject(data: RecursivePartial<OneOf.AsObject>): OneOf {
+    static fromObject(data: OneOf.AsObjectPartial): OneOf {
         const message = new OneOf({});
         if (data.nickname != null) {
             message.nickname = data.nickname;
@@ -298,5 +301,10 @@ export namespace OneOf {
         nickname: string;
         date_of_birth: string;
         age: string;
+    };
+    export type AsObjectPartial = {
+        nickname?: string;
+        date_of_birth?: string;
+        age?: string;
     };
 }

--- a/test/oneof.ts
+++ b/test/oneof.ts
@@ -4,6 +4,9 @@
  * source: test/_/oneof.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class OneOfWithoutAnyOtherFields extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2], [4, 3]];
     constructor(data?: any[] | ({} & (({
@@ -92,12 +95,7 @@ export class OneOfWithoutAnyOtherFields extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [4, 3])];
     }
-    static fromObject(data: {
-        nickname?: string;
-        realname?: string;
-        age?: string;
-        date_of_birth?: string;
-    }): OneOfWithoutAnyOtherFields {
+    static fromObject(data: RecursivePartial<OneOfWithoutAnyOtherFields.AsObject>): OneOfWithoutAnyOtherFields {
         const message = new OneOfWithoutAnyOtherFields({});
         if (data.nickname != null) {
             message.nickname = data.nickname;
@@ -114,12 +112,7 @@ export class OneOfWithoutAnyOtherFields extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            nickname: string;
-            realname: string;
-            age: string;
-            date_of_birth: string;
-        } = {
+        const data: OneOfWithoutAnyOtherFields.AsObject = {
             nickname: this.nickname,
             realname: this.realname,
             age: this.age,
@@ -171,6 +164,14 @@ export class OneOfWithoutAnyOtherFields extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): OneOfWithoutAnyOtherFields {
         return OneOfWithoutAnyOtherFields.deserialize(bytes);
     }
+}
+export namespace OneOfWithoutAnyOtherFields {
+    export type AsObject = {
+        nickname: string;
+        realname: string;
+        age: string;
+        date_of_birth: string;
+    };
 }
 export class OneOf extends pb_1.Message {
     #one_of_decls: number[][] = [[3, 4]];
@@ -231,11 +232,7 @@ export class OneOf extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [3, 4])];
     }
-    static fromObject(data: {
-        nickname?: string;
-        date_of_birth?: string;
-        age?: string;
-    }): OneOf {
+    static fromObject(data: RecursivePartial<OneOf.AsObject>): OneOf {
         const message = new OneOf({});
         if (data.nickname != null) {
             message.nickname = data.nickname;
@@ -249,11 +246,7 @@ export class OneOf extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            nickname: string;
-            date_of_birth: string;
-            age: string;
-        } = {
+        const data: OneOf.AsObject = {
             nickname: this.nickname,
             date_of_birth: this.date_of_birth,
             age: this.age
@@ -299,4 +292,11 @@ export class OneOf extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): OneOf {
         return OneOf.deserialize(bytes);
     }
+}
+export namespace OneOf {
+    export type AsObject = {
+        nickname: string;
+        date_of_birth: string;
+        age: string;
+    };
 }

--- a/test/optional/optional_proto2.ts
+++ b/test/optional/optional_proto2.ts
@@ -4,6 +4,9 @@
  * source: test/_/optional/optional_proto2.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class NotOptional extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -34,10 +37,7 @@ export class NotOptional extends pb_1.Message {
     get has_should_be_optional() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        should_be_required?: string[];
-        should_be_optional?: string;
-    }): NotOptional {
+    static fromObject(data: RecursivePartial<NotOptional.AsObject>): NotOptional {
         const message = new NotOptional({
             should_be_required: data.should_be_required
         });
@@ -47,10 +47,7 @@ export class NotOptional extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            should_be_required: string[];
-            should_be_optional: string;
-        } = {
+        const data: NotOptional.AsObject = {
             should_be_required: this.should_be_required,
             should_be_optional: this.should_be_optional
         };
@@ -90,4 +87,10 @@ export class NotOptional extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): NotOptional {
         return NotOptional.deserialize(bytes);
     }
+}
+export namespace NotOptional {
+    export type AsObject = {
+        should_be_required: string[];
+        should_be_optional: string;
+    };
 }

--- a/test/optional/optional_proto2.ts
+++ b/test/optional/optional_proto2.ts
@@ -35,7 +35,7 @@ export class NotOptional extends pb_1.Message {
         return pb_1.Message.getField(this, 2) != null;
     }
     static fromObject(data: {
-        should_be_required: string[];
+        should_be_required?: string[];
         should_be_optional?: string;
     }): NotOptional {
         const message = new NotOptional({
@@ -49,13 +49,11 @@ export class NotOptional extends pb_1.Message {
     toObject() {
         const data: {
             should_be_required: string[];
-            should_be_optional?: string;
+            should_be_optional: string;
         } = {
-            should_be_required: this.should_be_required
+            should_be_required: this.should_be_required,
+            should_be_optional: this.should_be_optional
         };
-        if (this.should_be_optional != null) {
-            data.should_be_optional = this.should_be_optional;
-        }
         return data;
     }
     serialize(): Uint8Array;

--- a/test/optional/optional_proto2.ts
+++ b/test/optional/optional_proto2.ts
@@ -4,9 +4,6 @@
  * source: test/_/optional/optional_proto2.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class NotOptional extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -37,7 +34,7 @@ export class NotOptional extends pb_1.Message {
     get has_should_be_optional() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<NotOptional.AsObject>): NotOptional {
+    static fromObject(data: NotOptional.AsObjectPartial): NotOptional {
         const message = new NotOptional({
             should_be_required: data.should_be_required
         });
@@ -59,7 +56,7 @@ export class NotOptional extends pb_1.Message {
         const writer = w || new pb_1.BinaryWriter();
         if (this.should_be_required.length)
             writer.writeRepeatedString(1, this.should_be_required);
-        if (this.has_should_be_optional && this.should_be_optional.length)
+        if (this.has_should_be_optional && this.should_be_optional!.length)
             writer.writeString(2, this.should_be_optional);
         if (!w)
             return writer.getResultBuffer();
@@ -92,5 +89,9 @@ export namespace NotOptional {
     export type AsObject = {
         should_be_required: string[];
         should_be_optional: string;
+    };
+    export type AsObjectPartial = {
+        should_be_required: string[];
+        should_be_optional?: string;
     };
 }

--- a/test/optional/optional_proto3.ts
+++ b/test/optional/optional_proto3.ts
@@ -4,9 +4,6 @@
  * source: test/_/optional/optional_proto3.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class Optional extends pb_1.Message {
     #one_of_decls: number[][] = [[2]];
     constructor(data?: any[] | ({
@@ -49,7 +46,7 @@ export class Optional extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [2])];
     }
-    static fromObject(data: RecursivePartial<Optional.AsObject>): Optional {
+    static fromObject(data: Optional.AsObjectPartial): Optional {
         const message = new Optional({});
         if (data.should_not_be_required != null) {
             message.should_not_be_required = data.should_not_be_required;
@@ -105,5 +102,9 @@ export namespace Optional {
     export type AsObject = {
         should_not_be_required: string[];
         proto3_optional: string;
+    };
+    export type AsObjectPartial = {
+        should_not_be_required?: string[];
+        proto3_optional?: string;
     };
 }

--- a/test/optional/optional_proto3.ts
+++ b/test/optional/optional_proto3.ts
@@ -61,15 +61,12 @@ export class Optional extends pb_1.Message {
     }
     toObject() {
         const data: {
-            should_not_be_required?: string[];
-            proto3_optional?: string;
-        } = {};
-        if (this.should_not_be_required != null) {
-            data.should_not_be_required = this.should_not_be_required;
-        }
-        if (this.proto3_optional != null) {
-            data.proto3_optional = this.proto3_optional;
-        }
+            should_not_be_required: string[];
+            proto3_optional: string;
+        } = {
+            should_not_be_required: this.should_not_be_required,
+            proto3_optional: this.proto3_optional
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/optional/optional_proto3.ts
+++ b/test/optional/optional_proto3.ts
@@ -4,6 +4,9 @@
  * source: test/_/optional/optional_proto3.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class Optional extends pb_1.Message {
     #one_of_decls: number[][] = [[2]];
     constructor(data?: any[] | ({
@@ -46,10 +49,7 @@ export class Optional extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [2])];
     }
-    static fromObject(data: {
-        should_not_be_required?: string[];
-        proto3_optional?: string;
-    }): Optional {
+    static fromObject(data: RecursivePartial<Optional.AsObject>): Optional {
         const message = new Optional({});
         if (data.should_not_be_required != null) {
             message.should_not_be_required = data.should_not_be_required;
@@ -60,10 +60,7 @@ export class Optional extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            should_not_be_required: string[];
-            proto3_optional: string;
-        } = {
+        const data: Optional.AsObject = {
             should_not_be_required: this.should_not_be_required,
             proto3_optional: this.proto3_optional
         };
@@ -103,4 +100,10 @@ export class Optional extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Optional {
         return Optional.deserialize(bytes);
     }
+}
+export namespace Optional {
+    export type AsObject = {
+        should_not_be_required: string[];
+        proto3_optional: string;
+    };
 }

--- a/test/packagedirective.ts
+++ b/test/packagedirective.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace pkg.mycompany {
+    type RecursivePartial<T> = {
+        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+    };
     export class Message extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -24,9 +27,7 @@ export namespace pkg.mycompany {
         set field(value: string[]) {
             pb_1.Message.setField(this, 1, value);
         }
-        static fromObject(data: {
-            field?: string[];
-        }): Message {
+        static fromObject(data: RecursivePartial<Message.AsObject>): Message {
             const message = new Message({});
             if (data.field != null) {
                 message.field = data.field;
@@ -34,9 +35,7 @@ export namespace pkg.mycompany {
             return message;
         }
         toObject() {
-            const data: {
-                field: string[];
-            } = {
+            const data: Message.AsObject = {
                 field: this.field
             };
             return data;
@@ -70,5 +69,10 @@ export namespace pkg.mycompany {
         static deserializeBinary(bytes: Uint8Array): Message {
             return Message.deserialize(bytes);
         }
+    }
+    export namespace Message {
+        export type AsObject = {
+            field: string[];
+        };
     }
 }

--- a/test/packagedirective.ts
+++ b/test/packagedirective.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 export namespace pkg.mycompany {
-    type RecursivePartial<T> = {
-        [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-    };
     export class Message extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -27,7 +24,7 @@ export namespace pkg.mycompany {
         set field(value: string[]) {
             pb_1.Message.setField(this, 1, value);
         }
-        static fromObject(data: RecursivePartial<Message.AsObject>): Message {
+        static fromObject(data: Message.AsObjectPartial): Message {
             const message = new Message({});
             if (data.field != null) {
                 message.field = data.field;
@@ -73,6 +70,9 @@ export namespace pkg.mycompany {
     export namespace Message {
         export type AsObject = {
             field: string[];
+        };
+        export type AsObjectPartial = {
+            field?: string[];
         };
     }
 }

--- a/test/packagedirective.ts
+++ b/test/packagedirective.ts
@@ -35,11 +35,10 @@ export namespace pkg.mycompany {
         }
         toObject() {
             const data: {
-                field?: string[];
-            } = {};
-            if (this.field != null) {
-                data.field = this.field;
-            }
+                field: string[];
+            } = {
+                field: this.field
+            };
             return data;
         }
         serialize(): Uint8Array;

--- a/test/presence/BUILD.bazel
+++ b/test/presence/BUILD.bazel
@@ -16,12 +16,8 @@ diff_and_update(
 ts_project(
     name = "presence",
     srcs = glob(["*.ts"]),
-    tsconfig = {
-        "compilerOptions": {
-            "target": "ES2020",
-            "module": "CommonJS"
-        },
-    },
+    tsconfig = {}, # no special options
+    extends = "//test:tsconfig.json",
     deps = [
         "@npm//@types/jasmine",
         "@npm//@types/node",

--- a/test/presence/presence.spec.ts
+++ b/test/presence/presence.spec.ts
@@ -18,18 +18,18 @@ describe("defaults", () => {
         expect(typeof presence["has_opt_oneof"]).toBe("boolean")
         expect(typeof presence["has_opt_string"]).toBe("boolean")
 
-        expect(typeof presence["has_repeated"]).toBe("undefined")
-        expect(typeof presence["has_map"]).toBe("undefined")
+        expect(typeof (presence as any)["has_repeated"]).toBe("undefined")
+        expect(typeof (presence as any)["has_map"]).toBe("undefined")
     });
 
     it("should have has_ fields (v3)", () => {
         const presence = new PresenceMessageV3();
 
-        expect(typeof presence["has_enum"]).toBe("undefined")
-        expect(typeof presence["has_int32"]).toBe("undefined")
+        expect(typeof (presence as any)["has_enum"]).toBe("undefined")
+        expect(typeof (presence as any)["has_int32"]).toBe("undefined")
         expect(typeof presence["has_message"]).toBe("boolean")
         expect(typeof presence["has_oneof"]).toBe("boolean")
-        expect(typeof presence["has_string"]).toBe("undefined")
+        expect(typeof (presence as any)["has_string"]).toBe("undefined")
 
         expect(typeof presence["has_opt_enum"]).toBe("boolean")
         expect(typeof presence["has_opt_int32"]).toBe("boolean")
@@ -37,8 +37,8 @@ describe("defaults", () => {
         expect(typeof presence["has_opt_oneof"]).toBe("boolean")
         expect(typeof presence["has_opt_string"]).toBe("boolean")
 
-        expect(typeof presence["has_repeated"]).toBe("undefined")
-        expect(typeof presence["has_map"]).toBe("undefined")
+        expect(typeof (presence as any)["has_repeated"]).toBe("undefined")
+        expect(typeof (presence as any)["has_map"]).toBe("undefined")
     });
 
     it("should have presence", () => {
@@ -53,7 +53,7 @@ describe("defaults", () => {
     it("should make presence field false on assignment of undefined", () => {
         const presence = new PresenceMessageV3();
         presence.opt_int32 = 10;
-        presence.opt_int32 = undefined;
+        presence.opt_int32 = undefined!;
 
         expect(presence.opt_int32).toBe(0);
         expect(presence.has_opt_int32).toBeFalse();

--- a/test/presence/presence_common.ts
+++ b/test/presence/presence_common.ts
@@ -4,6 +4,9 @@
  * source: test/_/presence/presence_common.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export enum PresenceCommonEnum {
     ZERO = 0,
     ONE = 1,
@@ -28,9 +31,7 @@ export class PresenceCommonMessage extends pb_1.Message {
     set message(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        message?: string;
-    }): PresenceCommonMessage {
+    static fromObject(data: RecursivePartial<PresenceCommonMessage.AsObject>): PresenceCommonMessage {
         const message = new PresenceCommonMessage({});
         if (data.message != null) {
             message.message = data.message;
@@ -38,9 +39,7 @@ export class PresenceCommonMessage extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            message: string;
-        } = {
+        const data: PresenceCommonMessage.AsObject = {
             message: this.message
         };
         return data;
@@ -74,6 +73,11 @@ export class PresenceCommonMessage extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): PresenceCommonMessage {
         return PresenceCommonMessage.deserialize(bytes);
     }
+}
+export namespace PresenceCommonMessage {
+    export type AsObject = {
+        message: string;
+    };
 }
 export class PresenceCommonMessageOneOf extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2]];
@@ -123,10 +127,7 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2])];
     }
-    static fromObject(data: {
-        int32?: number;
-        message?: Parameters<typeof PresenceCommonMessage.fromObject>[0];
-    }): PresenceCommonMessageOneOf {
+    static fromObject(data: RecursivePartial<PresenceCommonMessageOneOf.AsObject>): PresenceCommonMessageOneOf {
         const message = new PresenceCommonMessageOneOf({});
         if (data.int32 != null) {
             message.int32 = data.int32;
@@ -137,10 +138,7 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            int32: number;
-            message?: Parameters<typeof PresenceCommonMessage.fromObject>[0];
-        } = {
+        const data: PresenceCommonMessageOneOf.AsObject = {
             int32: this.int32
         };
         if (this.message != null) {
@@ -182,4 +180,10 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): PresenceCommonMessageOneOf {
         return PresenceCommonMessageOneOf.deserialize(bytes);
     }
+}
+export namespace PresenceCommonMessageOneOf {
+    export type AsObject = {
+        int32: number;
+        message?: PresenceCommonMessage.AsObject;
+    };
 }

--- a/test/presence/presence_common.ts
+++ b/test/presence/presence_common.ts
@@ -4,9 +4,6 @@
  * source: test/_/presence/presence_common.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export enum PresenceCommonEnum {
     ZERO = 0,
     ONE = 1,
@@ -31,7 +28,7 @@ export class PresenceCommonMessage extends pb_1.Message {
     set message(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<PresenceCommonMessage.AsObject>): PresenceCommonMessage {
+    static fromObject(data: PresenceCommonMessage.AsObjectPartial): PresenceCommonMessage {
         const message = new PresenceCommonMessage({});
         if (data.message != null) {
             message.message = data.message;
@@ -78,6 +75,9 @@ export namespace PresenceCommonMessage {
     export type AsObject = {
         message: string;
     };
+    export type AsObjectPartial = {
+        message?: string;
+    };
 }
 export class PresenceCommonMessageOneOf extends pb_1.Message {
     #one_of_decls: number[][] = [[1, 2]];
@@ -109,9 +109,9 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, PresenceCommonMessage, 2) as PresenceCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, PresenceCommonMessage, 2) as PresenceCommonMessage | undefined;
     }
-    set message(value: PresenceCommonMessage | undefined | null) {
+    set message(value: PresenceCommonMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_message() {
@@ -127,7 +127,7 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [1, 2])];
     }
-    static fromObject(data: RecursivePartial<PresenceCommonMessageOneOf.AsObject>): PresenceCommonMessageOneOf {
+    static fromObject(data: PresenceCommonMessageOneOf.AsObjectPartial): PresenceCommonMessageOneOf {
         const message = new PresenceCommonMessageOneOf({});
         if (data.int32 != null) {
             message.int32 = data.int32;
@@ -153,7 +153,7 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
         if (this.has_int32)
             writer.writeInt32(1, this.int32);
         if (this.has_message)
-            writer.writeMessage(2, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(2, this.message, () => this.message!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -185,5 +185,9 @@ export namespace PresenceCommonMessageOneOf {
     export type AsObject = {
         int32: number;
         message?: PresenceCommonMessage.AsObject;
+    };
+    export type AsObjectPartial = {
+        int32?: number;
+        message?: PresenceCommonMessage.AsObjectPartial;
     };
 }

--- a/test/presence/presence_common.ts
+++ b/test/presence/presence_common.ts
@@ -39,11 +39,10 @@ export class PresenceCommonMessage extends pb_1.Message {
     }
     toObject() {
         const data: {
-            message?: string;
-        } = {};
-        if (this.message != null) {
-            data.message = this.message;
-        }
+            message: string;
+        } = {
+            message: this.message
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -126,7 +125,7 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
     }
     static fromObject(data: {
         int32?: number;
-        message?: ReturnType<typeof PresenceCommonMessage.prototype.toObject>;
+        message?: Parameters<typeof PresenceCommonMessage.fromObject>[0];
     }): PresenceCommonMessageOneOf {
         const message = new PresenceCommonMessageOneOf({});
         if (data.int32 != null) {
@@ -139,12 +138,11 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
     }
     toObject() {
         const data: {
-            int32?: number;
-            message?: ReturnType<typeof PresenceCommonMessage.prototype.toObject>;
-        } = {};
-        if (this.int32 != null) {
-            data.int32 = this.int32;
-        }
+            int32: number;
+            message?: Parameters<typeof PresenceCommonMessage.fromObject>[0];
+        } = {
+            int32: this.int32
+        };
         if (this.message != null) {
             data.message = this.message.toObject();
         }

--- a/test/presence/presence_common.ts
+++ b/test/presence/presence_common.ts
@@ -109,9 +109,9 @@ export class PresenceCommonMessageOneOf extends pb_1.Message {
         return pb_1.Message.getField(this, 1) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, PresenceCommonMessage, 2) as PresenceCommonMessage;
+        return pb_1.Message.getWrapperField(this, PresenceCommonMessage, 2) as PresenceCommonMessage | undefined | null;
     }
-    set message(value: PresenceCommonMessage) {
+    set message(value: PresenceCommonMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 2, this.#one_of_decls[0], value);
     }
     get has_message() {

--- a/test/presence/presence_proto2.ts
+++ b/test/presence/presence_proto2.ts
@@ -156,14 +156,14 @@ export class PresenceMessageV2 extends pb_1.Message {
         int32?: number;
         enum?: dependency_1.PresenceCommonEnum;
         string?: string;
-        message?: ReturnType<typeof dependency_1.PresenceCommonMessage.prototype.toObject>;
-        oneof?: ReturnType<typeof dependency_1.PresenceCommonMessageOneOf.prototype.toObject>;
+        message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
+        oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
         opt_int32?: number;
         opt_enum?: dependency_1.PresenceCommonEnum;
         opt_string?: string;
-        opt_message?: ReturnType<typeof dependency_1.PresenceCommonMessage.prototype.toObject>;
-        opt_oneof?: ReturnType<typeof dependency_1.PresenceCommonMessageOneOf.prototype.toObject>;
-        repeated: number[];
+        opt_message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
+        opt_oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
+        repeated?: number[];
         map?: {
             [key: string]: string;
         };
@@ -199,19 +199,23 @@ export class PresenceMessageV2 extends pb_1.Message {
             int32?: number;
             enum?: dependency_1.PresenceCommonEnum;
             string?: string;
-            message?: ReturnType<typeof dependency_1.PresenceCommonMessage.prototype.toObject>;
-            oneof?: ReturnType<typeof dependency_1.PresenceCommonMessageOneOf.prototype.toObject>;
-            opt_int32?: number;
-            opt_enum?: dependency_1.PresenceCommonEnum;
-            opt_string?: string;
-            opt_message?: ReturnType<typeof dependency_1.PresenceCommonMessage.prototype.toObject>;
-            opt_oneof?: ReturnType<typeof dependency_1.PresenceCommonMessageOneOf.prototype.toObject>;
+            message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
+            oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
+            opt_int32: number;
+            opt_enum: dependency_1.PresenceCommonEnum;
+            opt_string: string;
+            opt_message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
+            opt_oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
             repeated: number[];
-            map?: {
+            map: {
                 [key: string]: string;
             };
         } = {
-            repeated: this.repeated
+            opt_int32: this.opt_int32,
+            opt_enum: this.opt_enum,
+            opt_string: this.opt_string,
+            repeated: this.repeated,
+            map: Object.fromEntries(this.map)
         };
         if (this.int32 != null) {
             data.int32 = this.int32;
@@ -228,23 +232,11 @@ export class PresenceMessageV2 extends pb_1.Message {
         if (this.oneof != null) {
             data.oneof = this.oneof.toObject();
         }
-        if (this.opt_int32 != null) {
-            data.opt_int32 = this.opt_int32;
-        }
-        if (this.opt_enum != null) {
-            data.opt_enum = this.opt_enum;
-        }
-        if (this.opt_string != null) {
-            data.opt_string = this.opt_string;
-        }
         if (this.opt_message != null) {
             data.opt_message = this.opt_message.toObject();
         }
         if (this.opt_oneof != null) {
             data.opt_oneof = this.opt_oneof.toObject();
-        }
-        if (this.map != null) {
-            data.map = Object.fromEntries(this.map);
         }
         return data;
     }

--- a/test/presence/presence_proto2.ts
+++ b/test/presence/presence_proto2.ts
@@ -243,7 +243,7 @@ export class PresenceMessageV2 extends pb_1.Message {
         if (this.opt_oneof != null) {
             data.opt_oneof = this.opt_oneof.toObject();
         }
-        if (this.map.size > 0) {
+        if (this.map != null) {
             data.map = Object.fromEntries(this.map);
         }
         return data;

--- a/test/presence/presence_proto2.ts
+++ b/test/presence/presence_proto2.ts
@@ -54,45 +54,45 @@ export class PresenceMessageV2 extends pb_1.Message {
             this.map = new Map();
     }
     get int32() {
-        return pb_1.Message.getField(this, 1) as number;
+        return pb_1.Message.getField(this, 1) as number | undefined | null;
     }
-    set int32(value: number) {
+    set int32(value: number | undefined | null) {
         pb_1.Message.setField(this, 1, value);
     }
     get has_int32() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get enum() {
-        return pb_1.Message.getField(this, 2) as dependency_1.PresenceCommonEnum;
+        return pb_1.Message.getField(this, 2) as dependency_1.PresenceCommonEnum | undefined | null;
     }
-    set enum(value: dependency_1.PresenceCommonEnum) {
+    set enum(value: dependency_1.PresenceCommonEnum | undefined | null) {
         pb_1.Message.setField(this, 2, value);
     }
     get has_enum() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get string() {
-        return pb_1.Message.getField(this, 3) as string;
+        return pb_1.Message.getField(this, 3) as string | undefined | null;
     }
-    set string(value: string) {
+    set string(value: string | undefined | null) {
         pb_1.Message.setField(this, 3, value);
     }
     get has_string() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 4) as dependency_1.PresenceCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 4) as dependency_1.PresenceCommonMessage | undefined | null;
     }
-    set message(value: dependency_1.PresenceCommonMessage) {
+    set message(value: dependency_1.PresenceCommonMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_message() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get oneof() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 5) as dependency_1.PresenceCommonMessageOneOf;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 5) as dependency_1.PresenceCommonMessageOneOf | undefined | null;
     }
-    set oneof(value: dependency_1.PresenceCommonMessageOneOf) {
+    set oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined | null) {
         pb_1.Message.setWrapperField(this, 5, value);
     }
     get has_oneof() {
@@ -126,18 +126,18 @@ export class PresenceMessageV2 extends pb_1.Message {
         return pb_1.Message.getField(this, 8) != null;
     }
     get opt_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 9) as dependency_1.PresenceCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 9) as dependency_1.PresenceCommonMessage | undefined | null;
     }
-    set opt_message(value: dependency_1.PresenceCommonMessage) {
+    set opt_message(value: dependency_1.PresenceCommonMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 9, value);
     }
     get has_opt_message() {
         return pb_1.Message.getField(this, 9) != null;
     }
     get opt_oneof() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 10) as dependency_1.PresenceCommonMessageOneOf;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 10) as dependency_1.PresenceCommonMessageOneOf | undefined | null;
     }
-    set opt_oneof(value: dependency_1.PresenceCommonMessageOneOf) {
+    set opt_oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined | null) {
         pb_1.Message.setWrapperField(this, 10, value);
     }
     get has_opt_oneof() {

--- a/test/presence/presence_proto2.ts
+++ b/test/presence/presence_proto2.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./presence_common";
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class PresenceMessageV2 extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -54,45 +51,45 @@ export class PresenceMessageV2 extends pb_1.Message {
             this.map = new Map();
     }
     get int32() {
-        return pb_1.Message.getField(this, 1) as number | undefined | null;
+        return pb_1.Message.getField(this, 1) as number | undefined;
     }
-    set int32(value: number | undefined | null) {
+    set int32(value: number | undefined) {
         pb_1.Message.setField(this, 1, value);
     }
     get has_int32() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get enum() {
-        return pb_1.Message.getField(this, 2) as dependency_1.PresenceCommonEnum | undefined | null;
+        return pb_1.Message.getField(this, 2) as dependency_1.PresenceCommonEnum | undefined;
     }
-    set enum(value: dependency_1.PresenceCommonEnum | undefined | null) {
+    set enum(value: dependency_1.PresenceCommonEnum | undefined) {
         pb_1.Message.setField(this, 2, value);
     }
     get has_enum() {
         return pb_1.Message.getField(this, 2) != null;
     }
     get string() {
-        return pb_1.Message.getField(this, 3) as string | undefined | null;
+        return pb_1.Message.getField(this, 3) as string | undefined;
     }
-    set string(value: string | undefined | null) {
+    set string(value: string | undefined) {
         pb_1.Message.setField(this, 3, value);
     }
     get has_string() {
         return pb_1.Message.getField(this, 3) != null;
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 4) as dependency_1.PresenceCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 4) as dependency_1.PresenceCommonMessage | undefined;
     }
-    set message(value: dependency_1.PresenceCommonMessage | undefined | null) {
+    set message(value: dependency_1.PresenceCommonMessage | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_message() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get oneof() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 5) as dependency_1.PresenceCommonMessageOneOf | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 5) as dependency_1.PresenceCommonMessageOneOf | undefined;
     }
-    set oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined | null) {
+    set oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined) {
         pb_1.Message.setWrapperField(this, 5, value);
     }
     get has_oneof() {
@@ -126,18 +123,18 @@ export class PresenceMessageV2 extends pb_1.Message {
         return pb_1.Message.getField(this, 8) != null;
     }
     get opt_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 9) as dependency_1.PresenceCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 9) as dependency_1.PresenceCommonMessage | undefined;
     }
-    set opt_message(value: dependency_1.PresenceCommonMessage | undefined | null) {
+    set opt_message(value: dependency_1.PresenceCommonMessage | undefined) {
         pb_1.Message.setWrapperField(this, 9, value);
     }
     get has_opt_message() {
         return pb_1.Message.getField(this, 9) != null;
     }
     get opt_oneof() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 10) as dependency_1.PresenceCommonMessageOneOf | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 10) as dependency_1.PresenceCommonMessageOneOf | undefined;
     }
-    set opt_oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined | null) {
+    set opt_oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined) {
         pb_1.Message.setWrapperField(this, 10, value);
     }
     get has_opt_oneof() {
@@ -155,7 +152,7 @@ export class PresenceMessageV2 extends pb_1.Message {
     set map(value: Map<string, string>) {
         pb_1.Message.setField(this, 12, value as any);
     }
-    static fromObject(data: RecursivePartial<PresenceMessageV2.AsObject>): PresenceMessageV2 {
+    static fromObject(data: PresenceMessageV2.AsObjectPartial): PresenceMessageV2 {
         const message = new PresenceMessageV2({
             int32: data.int32,
             enum: data.enum,
@@ -221,22 +218,22 @@ export class PresenceMessageV2 extends pb_1.Message {
             writer.writeInt32(1, this.int32);
         if (this.has_enum)
             writer.writeEnum(2, this.enum);
-        if (this.has_string && this.string.length)
+        if (this.has_string && this.string!.length)
             writer.writeString(3, this.string);
         if (this.has_message)
-            writer.writeMessage(4, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(4, this.message, () => this.message!.serialize(writer));
         if (this.has_oneof)
-            writer.writeMessage(5, this.oneof, () => this.oneof.serialize(writer));
+            writer.writeMessage(5, this.oneof, () => this.oneof!.serialize(writer));
         if (this.has_opt_int32)
             writer.writeInt32(6, this.opt_int32);
         if (this.has_opt_enum)
             writer.writeEnum(7, this.opt_enum);
-        if (this.has_opt_string && this.opt_string.length)
+        if (this.has_opt_string && this.opt_string!.length)
             writer.writeString(8, this.opt_string);
         if (this.has_opt_message)
-            writer.writeMessage(9, this.opt_message, () => this.opt_message.serialize(writer));
+            writer.writeMessage(9, this.opt_message, () => this.opt_message!.serialize(writer));
         if (this.has_opt_oneof)
-            writer.writeMessage(10, this.opt_oneof, () => this.opt_oneof.serialize(writer));
+            writer.writeMessage(10, this.opt_oneof, () => this.opt_oneof!.serialize(writer));
         if (this.repeated.length)
             writer.writeRepeatedInt32(11, this.repeated);
         for (const [key, value] of this.map) {
@@ -314,6 +311,22 @@ export namespace PresenceMessageV2 {
         opt_string: string;
         opt_message?: dependency_1.PresenceCommonMessage.AsObject;
         opt_oneof?: dependency_1.PresenceCommonMessageOneOf.AsObject;
+        repeated: number[];
+        map: {
+            [key: string]: string;
+        };
+    };
+    export type AsObjectPartial = {
+        int32: number;
+        enum: dependency_1.PresenceCommonEnum;
+        string: string;
+        message: dependency_1.PresenceCommonMessage.AsObjectPartial;
+        oneof: dependency_1.PresenceCommonMessageOneOf.AsObjectPartial;
+        opt_int32?: number;
+        opt_enum?: dependency_1.PresenceCommonEnum;
+        opt_string?: string;
+        opt_message?: dependency_1.PresenceCommonMessage.AsObjectPartial;
+        opt_oneof?: dependency_1.PresenceCommonMessageOneOf.AsObjectPartial;
         repeated: number[];
         map: {
             [key: string]: string;

--- a/test/presence/presence_proto2.ts
+++ b/test/presence/presence_proto2.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./presence_common";
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class PresenceMessageV2 extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -152,22 +155,7 @@ export class PresenceMessageV2 extends pb_1.Message {
     set map(value: Map<string, string>) {
         pb_1.Message.setField(this, 12, value as any);
     }
-    static fromObject(data: {
-        int32?: number;
-        enum?: dependency_1.PresenceCommonEnum;
-        string?: string;
-        message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
-        oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
-        opt_int32?: number;
-        opt_enum?: dependency_1.PresenceCommonEnum;
-        opt_string?: string;
-        opt_message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
-        opt_oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
-        repeated?: number[];
-        map?: {
-            [key: string]: string;
-        };
-    }): PresenceMessageV2 {
+    static fromObject(data: RecursivePartial<PresenceMessageV2.AsObject>): PresenceMessageV2 {
         const message = new PresenceMessageV2({
             int32: data.int32,
             enum: data.enum,
@@ -195,22 +183,7 @@ export class PresenceMessageV2 extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            int32?: number;
-            enum?: dependency_1.PresenceCommonEnum;
-            string?: string;
-            message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
-            oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
-            opt_int32: number;
-            opt_enum: dependency_1.PresenceCommonEnum;
-            opt_string: string;
-            opt_message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
-            opt_oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
-            repeated: number[];
-            map: {
-                [key: string]: string;
-            };
-        } = {
+        const data: PresenceMessageV2.AsObject = {
             opt_int32: this.opt_int32,
             opt_enum: this.opt_enum,
             opt_string: this.opt_string,
@@ -328,4 +301,22 @@ export class PresenceMessageV2 extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): PresenceMessageV2 {
         return PresenceMessageV2.deserialize(bytes);
     }
+}
+export namespace PresenceMessageV2 {
+    export type AsObject = {
+        int32?: number;
+        enum?: dependency_1.PresenceCommonEnum;
+        string?: string;
+        message?: dependency_1.PresenceCommonMessage.AsObject;
+        oneof?: dependency_1.PresenceCommonMessageOneOf.AsObject;
+        opt_int32: number;
+        opt_enum: dependency_1.PresenceCommonEnum;
+        opt_string: string;
+        opt_message?: dependency_1.PresenceCommonMessage.AsObject;
+        opt_oneof?: dependency_1.PresenceCommonMessageOneOf.AsObject;
+        repeated: number[];
+        map: {
+            [key: string]: string;
+        };
+    };
 }

--- a/test/presence/presence_proto3.ts
+++ b/test/presence/presence_proto3.ts
@@ -91,18 +91,18 @@ export class PresenceMessageV3 extends pb_1.Message {
         pb_1.Message.setField(this, 3, value);
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 4) as dependency_1.PresenceCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 4) as dependency_1.PresenceCommonMessage | undefined | null;
     }
-    set message(value: dependency_1.PresenceCommonMessage) {
+    set message(value: dependency_1.PresenceCommonMessage | undefined | null) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_message() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get oneof() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 5) as dependency_1.PresenceCommonMessageOneOf;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 5) as dependency_1.PresenceCommonMessageOneOf | undefined | null;
     }
-    set oneof(value: dependency_1.PresenceCommonMessageOneOf) {
+    set oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined | null) {
         pb_1.Message.setWrapperField(this, 5, value);
     }
     get has_oneof() {
@@ -136,18 +136,18 @@ export class PresenceMessageV3 extends pb_1.Message {
         return pb_1.Message.getField(this, 8) != null;
     }
     get opt_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 9) as dependency_1.PresenceCommonMessage;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 9) as dependency_1.PresenceCommonMessage | undefined | null;
     }
-    set opt_message(value: dependency_1.PresenceCommonMessage) {
+    set opt_message(value: dependency_1.PresenceCommonMessage | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 9, this.#one_of_decls[3], value);
     }
     get has_opt_message() {
         return pb_1.Message.getField(this, 9) != null;
     }
     get opt_oneof() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 10) as dependency_1.PresenceCommonMessageOneOf;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 10) as dependency_1.PresenceCommonMessageOneOf | undefined | null;
     }
-    set opt_oneof(value: dependency_1.PresenceCommonMessageOneOf) {
+    set opt_oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined | null) {
         pb_1.Message.setOneofWrapperField(this, 10, this.#one_of_decls[4], value);
     }
     get has_opt_oneof() {

--- a/test/presence/presence_proto3.ts
+++ b/test/presence/presence_proto3.ts
@@ -312,7 +312,7 @@ export class PresenceMessageV3 extends pb_1.Message {
         if (this.repeated != null) {
             data.repeated = this.repeated;
         }
-        if (this.map.size > 0) {
+        if (this.map != null) {
             data.map = Object.fromEntries(this.map);
         }
         return data;

--- a/test/presence/presence_proto3.ts
+++ b/test/presence/presence_proto3.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./presence_common";
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class PresenceMessageV3 extends pb_1.Message {
     #one_of_decls: number[][] = [[6], [7], [8], [9], [10]];
     constructor(data?: any[] | ({
@@ -207,22 +210,7 @@ export class PresenceMessageV3 extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [10])];
     }
-    static fromObject(data: {
-        int32?: number;
-        enum?: dependency_1.PresenceCommonEnum;
-        string?: string;
-        message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
-        oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
-        opt_int32?: number;
-        opt_enum?: dependency_1.PresenceCommonEnum;
-        opt_string?: string;
-        opt_message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
-        opt_oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
-        repeated?: number[];
-        map?: {
-            [key: string]: string;
-        };
-    }): PresenceMessageV3 {
+    static fromObject(data: RecursivePartial<PresenceMessageV3.AsObject>): PresenceMessageV3 {
         const message = new PresenceMessageV3({});
         if (data.int32 != null) {
             message.int32 = data.int32;
@@ -263,22 +251,7 @@ export class PresenceMessageV3 extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            int32: number;
-            enum: dependency_1.PresenceCommonEnum;
-            string: string;
-            message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
-            oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
-            opt_int32: number;
-            opt_enum: dependency_1.PresenceCommonEnum;
-            opt_string: string;
-            opt_message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
-            opt_oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
-            repeated: number[];
-            map: {
-                [key: string]: string;
-            };
-        } = {
+        const data: PresenceMessageV3.AsObject = {
             int32: this.int32,
             enum: this.enum,
             string: this.string,
@@ -390,4 +363,22 @@ export class PresenceMessageV3 extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): PresenceMessageV3 {
         return PresenceMessageV3.deserialize(bytes);
     }
+}
+export namespace PresenceMessageV3 {
+    export type AsObject = {
+        int32: number;
+        enum: dependency_1.PresenceCommonEnum;
+        string: string;
+        message?: dependency_1.PresenceCommonMessage.AsObject;
+        oneof?: dependency_1.PresenceCommonMessageOneOf.AsObject;
+        opt_int32: number;
+        opt_enum: dependency_1.PresenceCommonEnum;
+        opt_string: string;
+        opt_message?: dependency_1.PresenceCommonMessage.AsObject;
+        opt_oneof?: dependency_1.PresenceCommonMessageOneOf.AsObject;
+        repeated: number[];
+        map: {
+            [key: string]: string;
+        };
+    };
 }

--- a/test/presence/presence_proto3.ts
+++ b/test/presence/presence_proto3.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as dependency_1 from "./presence_common";
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class PresenceMessageV3 extends pb_1.Message {
     #one_of_decls: number[][] = [[6], [7], [8], [9], [10]];
     constructor(data?: any[] | ({
@@ -91,18 +88,18 @@ export class PresenceMessageV3 extends pb_1.Message {
         pb_1.Message.setField(this, 3, value);
     }
     get message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 4) as dependency_1.PresenceCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 4) as dependency_1.PresenceCommonMessage | undefined;
     }
-    set message(value: dependency_1.PresenceCommonMessage | undefined | null) {
+    set message(value: dependency_1.PresenceCommonMessage | undefined) {
         pb_1.Message.setWrapperField(this, 4, value);
     }
     get has_message() {
         return pb_1.Message.getField(this, 4) != null;
     }
     get oneof() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 5) as dependency_1.PresenceCommonMessageOneOf | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 5) as dependency_1.PresenceCommonMessageOneOf | undefined;
     }
-    set oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined | null) {
+    set oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined) {
         pb_1.Message.setWrapperField(this, 5, value);
     }
     get has_oneof() {
@@ -136,18 +133,18 @@ export class PresenceMessageV3 extends pb_1.Message {
         return pb_1.Message.getField(this, 8) != null;
     }
     get opt_message() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 9) as dependency_1.PresenceCommonMessage | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessage, 9) as dependency_1.PresenceCommonMessage | undefined;
     }
-    set opt_message(value: dependency_1.PresenceCommonMessage | undefined | null) {
+    set opt_message(value: dependency_1.PresenceCommonMessage | undefined) {
         pb_1.Message.setOneofWrapperField(this, 9, this.#one_of_decls[3], value);
     }
     get has_opt_message() {
         return pb_1.Message.getField(this, 9) != null;
     }
     get opt_oneof() {
-        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 10) as dependency_1.PresenceCommonMessageOneOf | undefined | null;
+        return pb_1.Message.getWrapperField(this, dependency_1.PresenceCommonMessageOneOf, 10) as dependency_1.PresenceCommonMessageOneOf | undefined;
     }
-    set opt_oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined | null) {
+    set opt_oneof(value: dependency_1.PresenceCommonMessageOneOf | undefined) {
         pb_1.Message.setOneofWrapperField(this, 10, this.#one_of_decls[4], value);
     }
     get has_opt_oneof() {
@@ -210,7 +207,7 @@ export class PresenceMessageV3 extends pb_1.Message {
         };
         return cases[pb_1.Message.computeOneofCase(this, [10])];
     }
-    static fromObject(data: RecursivePartial<PresenceMessageV3.AsObject>): PresenceMessageV3 {
+    static fromObject(data: PresenceMessageV3.AsObjectPartial): PresenceMessageV3 {
         const message = new PresenceMessageV3({});
         if (data.int32 != null) {
             message.int32 = data.int32;
@@ -286,9 +283,9 @@ export class PresenceMessageV3 extends pb_1.Message {
         if (this.string.length)
             writer.writeString(3, this.string);
         if (this.has_message)
-            writer.writeMessage(4, this.message, () => this.message.serialize(writer));
+            writer.writeMessage(4, this.message, () => this.message!.serialize(writer));
         if (this.has_oneof)
-            writer.writeMessage(5, this.oneof, () => this.oneof.serialize(writer));
+            writer.writeMessage(5, this.oneof, () => this.oneof!.serialize(writer));
         if (this.has_opt_int32)
             writer.writeInt32(6, this.opt_int32);
         if (this.has_opt_enum)
@@ -296,9 +293,9 @@ export class PresenceMessageV3 extends pb_1.Message {
         if (this.has_opt_string)
             writer.writeString(8, this.opt_string);
         if (this.has_opt_message)
-            writer.writeMessage(9, this.opt_message, () => this.opt_message.serialize(writer));
+            writer.writeMessage(9, this.opt_message, () => this.opt_message!.serialize(writer));
         if (this.has_opt_oneof)
-            writer.writeMessage(10, this.opt_oneof, () => this.opt_oneof.serialize(writer));
+            writer.writeMessage(10, this.opt_oneof, () => this.opt_oneof!.serialize(writer));
         if (this.repeated.length)
             writer.writePackedInt32(11, this.repeated);
         for (const [key, value] of this.map) {
@@ -378,6 +375,22 @@ export namespace PresenceMessageV3 {
         opt_oneof?: dependency_1.PresenceCommonMessageOneOf.AsObject;
         repeated: number[];
         map: {
+            [key: string]: string;
+        };
+    };
+    export type AsObjectPartial = {
+        int32?: number;
+        enum?: dependency_1.PresenceCommonEnum;
+        string?: string;
+        message?: dependency_1.PresenceCommonMessage.AsObjectPartial;
+        oneof?: dependency_1.PresenceCommonMessageOneOf.AsObjectPartial;
+        opt_int32?: number;
+        opt_enum?: dependency_1.PresenceCommonEnum;
+        opt_string?: string;
+        opt_message?: dependency_1.PresenceCommonMessage.AsObjectPartial;
+        opt_oneof?: dependency_1.PresenceCommonMessageOneOf.AsObjectPartial;
+        repeated?: number[];
+        map?: {
             [key: string]: string;
         };
     };

--- a/test/presence/presence_proto3.ts
+++ b/test/presence/presence_proto3.ts
@@ -211,13 +211,13 @@ export class PresenceMessageV3 extends pb_1.Message {
         int32?: number;
         enum?: dependency_1.PresenceCommonEnum;
         string?: string;
-        message?: ReturnType<typeof dependency_1.PresenceCommonMessage.prototype.toObject>;
-        oneof?: ReturnType<typeof dependency_1.PresenceCommonMessageOneOf.prototype.toObject>;
+        message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
+        oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
         opt_int32?: number;
         opt_enum?: dependency_1.PresenceCommonEnum;
         opt_string?: string;
-        opt_message?: ReturnType<typeof dependency_1.PresenceCommonMessage.prototype.toObject>;
-        opt_oneof?: ReturnType<typeof dependency_1.PresenceCommonMessageOneOf.prototype.toObject>;
+        opt_message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
+        opt_oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
         repeated?: number[];
         map?: {
             [key: string]: string;
@@ -264,56 +264,41 @@ export class PresenceMessageV3 extends pb_1.Message {
     }
     toObject() {
         const data: {
-            int32?: number;
-            enum?: dependency_1.PresenceCommonEnum;
-            string?: string;
-            message?: ReturnType<typeof dependency_1.PresenceCommonMessage.prototype.toObject>;
-            oneof?: ReturnType<typeof dependency_1.PresenceCommonMessageOneOf.prototype.toObject>;
-            opt_int32?: number;
-            opt_enum?: dependency_1.PresenceCommonEnum;
-            opt_string?: string;
-            opt_message?: ReturnType<typeof dependency_1.PresenceCommonMessage.prototype.toObject>;
-            opt_oneof?: ReturnType<typeof dependency_1.PresenceCommonMessageOneOf.prototype.toObject>;
-            repeated?: number[];
-            map?: {
+            int32: number;
+            enum: dependency_1.PresenceCommonEnum;
+            string: string;
+            message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
+            oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
+            opt_int32: number;
+            opt_enum: dependency_1.PresenceCommonEnum;
+            opt_string: string;
+            opt_message?: Parameters<typeof dependency_1.PresenceCommonMessage.fromObject>[0];
+            opt_oneof?: Parameters<typeof dependency_1.PresenceCommonMessageOneOf.fromObject>[0];
+            repeated: number[];
+            map: {
                 [key: string]: string;
             };
-        } = {};
-        if (this.int32 != null) {
-            data.int32 = this.int32;
-        }
-        if (this.enum != null) {
-            data.enum = this.enum;
-        }
-        if (this.string != null) {
-            data.string = this.string;
-        }
+        } = {
+            int32: this.int32,
+            enum: this.enum,
+            string: this.string,
+            opt_int32: this.opt_int32,
+            opt_enum: this.opt_enum,
+            opt_string: this.opt_string,
+            repeated: this.repeated,
+            map: Object.fromEntries(this.map)
+        };
         if (this.message != null) {
             data.message = this.message.toObject();
         }
         if (this.oneof != null) {
             data.oneof = this.oneof.toObject();
         }
-        if (this.opt_int32 != null) {
-            data.opt_int32 = this.opt_int32;
-        }
-        if (this.opt_enum != null) {
-            data.opt_enum = this.opt_enum;
-        }
-        if (this.opt_string != null) {
-            data.opt_string = this.opt_string;
-        }
         if (this.opt_message != null) {
             data.opt_message = this.opt_message.toObject();
         }
         if (this.opt_oneof != null) {
             data.opt_oneof = this.opt_oneof.toObject();
-        }
-        if (this.repeated != null) {
-            data.repeated = this.repeated;
-        }
-        if (this.map != null) {
-            data.map = Object.fromEntries(this.map);
         }
         return data;
     }

--- a/test/repeated.ts
+++ b/test/repeated.ts
@@ -34,11 +34,10 @@ export class Repeated extends pb_1.Message {
     }
     toObject() {
         const data: {
-            indx?: number[];
-        } = {};
-        if (this.indx != null) {
-            data.indx = this.indx;
-        }
+            indx: number[];
+        } = {
+            indx: this.indx
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/repeated.ts
+++ b/test/repeated.ts
@@ -4,6 +4,9 @@
  * source: test/_/repeated.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class Repeated extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -23,9 +26,7 @@ export class Repeated extends pb_1.Message {
     set indx(value: number[]) {
         pb_1.Message.setField(this, 4, value);
     }
-    static fromObject(data: {
-        indx?: number[];
-    }): Repeated {
+    static fromObject(data: RecursivePartial<Repeated.AsObject>): Repeated {
         const message = new Repeated({});
         if (data.indx != null) {
             message.indx = data.indx;
@@ -33,9 +34,7 @@ export class Repeated extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            indx: number[];
-        } = {
+        const data: Repeated.AsObject = {
             indx: this.indx
         };
         return data;
@@ -69,4 +68,9 @@ export class Repeated extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Repeated {
         return Repeated.deserialize(bytes);
     }
+}
+export namespace Repeated {
+    export type AsObject = {
+        indx: number[];
+    };
 }

--- a/test/repeated.ts
+++ b/test/repeated.ts
@@ -4,9 +4,6 @@
  * source: test/_/repeated.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class Repeated extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -26,7 +23,7 @@ export class Repeated extends pb_1.Message {
     set indx(value: number[]) {
         pb_1.Message.setField(this, 4, value);
     }
-    static fromObject(data: RecursivePartial<Repeated.AsObject>): Repeated {
+    static fromObject(data: Repeated.AsObjectPartial): Repeated {
         const message = new Repeated({});
         if (data.indx != null) {
             message.indx = data.indx;
@@ -72,5 +69,8 @@ export class Repeated extends pb_1.Message {
 export namespace Repeated {
     export type AsObject = {
         indx: number[];
+    };
+    export type AsObjectPartial = {
+        indx?: number[];
     };
 }

--- a/test/required.ts
+++ b/test/required.ts
@@ -4,9 +4,6 @@
  * source: test/_/required.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class NoOptionalValues extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -21,24 +18,24 @@ export class NoOptionalValues extends pb_1.Message {
         }
     }
     get test() {
-        return pb_1.Message.getField(this, 1) as string | undefined | null;
+        return pb_1.Message.getField(this, 1) as string | undefined;
     }
-    set test(value: string | undefined | null) {
+    set test(value: string | undefined) {
         pb_1.Message.setField(this, 1, value);
     }
     get has_test() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get test2() {
-        return pb_1.Message.getField(this, 2) as string | undefined | null;
+        return pb_1.Message.getField(this, 2) as string | undefined;
     }
-    set test2(value: string | undefined | null) {
+    set test2(value: string | undefined) {
         pb_1.Message.setField(this, 2, value);
     }
     get has_test2() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<NoOptionalValues.AsObject>): NoOptionalValues {
+    static fromObject(data: NoOptionalValues.AsObjectPartial): NoOptionalValues {
         const message = new NoOptionalValues({
             test: data.test,
             test2: data.test2
@@ -59,9 +56,9 @@ export class NoOptionalValues extends pb_1.Message {
     serialize(w: pb_1.BinaryWriter): void;
     serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
         const writer = w || new pb_1.BinaryWriter();
-        if (this.has_test && this.test.length)
+        if (this.has_test && this.test!.length)
             writer.writeString(1, this.test);
-        if (this.has_test2 && this.test2.length)
+        if (this.has_test2 && this.test2!.length)
             writer.writeString(2, this.test2);
         if (!w)
             return writer.getResultBuffer();
@@ -94,5 +91,9 @@ export namespace NoOptionalValues {
     export type AsObject = {
         test?: string;
         test2?: string;
+    };
+    export type AsObjectPartial = {
+        test: string;
+        test2: string;
     };
 }

--- a/test/required.ts
+++ b/test/required.ts
@@ -21,18 +21,18 @@ export class NoOptionalValues extends pb_1.Message {
         }
     }
     get test() {
-        return pb_1.Message.getField(this, 1) as string;
+        return pb_1.Message.getField(this, 1) as string | undefined | null;
     }
-    set test(value: string) {
+    set test(value: string | undefined | null) {
         pb_1.Message.setField(this, 1, value);
     }
     get has_test() {
         return pb_1.Message.getField(this, 1) != null;
     }
     get test2() {
-        return pb_1.Message.getField(this, 2) as string;
+        return pb_1.Message.getField(this, 2) as string | undefined | null;
     }
-    set test2(value: string) {
+    set test2(value: string | undefined | null) {
         pb_1.Message.setField(this, 2, value);
     }
     get has_test2() {

--- a/test/required.ts
+++ b/test/required.ts
@@ -4,6 +4,9 @@
  * source: test/_/required.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class NoOptionalValues extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -35,10 +38,7 @@ export class NoOptionalValues extends pb_1.Message {
     get has_test2() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        test?: string;
-        test2?: string;
-    }): NoOptionalValues {
+    static fromObject(data: RecursivePartial<NoOptionalValues.AsObject>): NoOptionalValues {
         const message = new NoOptionalValues({
             test: data.test,
             test2: data.test2
@@ -46,10 +46,7 @@ export class NoOptionalValues extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            test?: string;
-            test2?: string;
-        } = {};
+        const data: NoOptionalValues.AsObject = {};
         if (this.test != null) {
             data.test = this.test;
         }
@@ -92,4 +89,10 @@ export class NoOptionalValues extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): NoOptionalValues {
         return NoOptionalValues.deserialize(bytes);
     }
+}
+export namespace NoOptionalValues {
+    export type AsObject = {
+        test?: string;
+        test2?: string;
+    };
 }

--- a/test/rpcs.ts
+++ b/test/rpcs.ts
@@ -754,15 +754,15 @@ export class StorageClient extends grpc_1.makeGenericClientConstructor(Unimpleme
         super(address, credentials, options);
     }
     query: GrpcStreamServiceInterface<Query, Query> = (message: Query, metadata?: grpc_1.Metadata | grpc_1.CallOptions, options?: grpc_1.CallOptions): grpc_1.ClientReadableStream<Query> => {
-        return super.query(message, metadata, options);
+        return super["query"](message, metadata, options);
     };
     get: GrpcUnaryServiceInterface<Query, _Object> = (message: Query, metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<_Object>, options?: grpc_1.CallOptions | grpc_1.requestCallback<_Object>, callback?: grpc_1.requestCallback<_Object>): grpc_1.ClientUnaryCall => {
-        return super.get(message, metadata, options, callback);
+        return super["get"](message, metadata, options, callback);
     };
     put: GrpWritableServiceInterface<Put, _Object> = (metadata: grpc_1.Metadata | grpc_1.CallOptions | grpc_1.requestCallback<_Object>, options?: grpc_1.CallOptions | grpc_1.requestCallback<_Object>, callback?: grpc_1.requestCallback<_Object>): grpc_1.ClientWritableStream<Put> => {
-        return super.put(metadata, options, callback);
+        return super["put"](metadata, options, callback);
     };
     chunk: GrpcChunkServiceInterface<Chunk.Query, Chunk> = (metadata?: grpc_1.Metadata | grpc_1.CallOptions, options?: grpc_1.CallOptions): grpc_1.ClientDuplexStream<Chunk.Query, Chunk> => {
-        return super.chunk(metadata, options);
+        return super["chunk"](metadata, options);
     };
 }

--- a/test/rpcs.ts
+++ b/test/rpcs.ts
@@ -182,9 +182,9 @@ export class Chunk extends pb_1.Message {
         pb_1.Message.setField(this, 1, value);
     }
     get range() {
-        return pb_1.Message.getWrapperField(this, Chunk.Range, 2) as Chunk.Range;
+        return pb_1.Message.getWrapperField(this, Chunk.Range, 2) as Chunk.Range | undefined | null;
     }
-    set range(value: Chunk.Range) {
+    set range(value: Chunk.Range | undefined | null) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_range() {
@@ -360,9 +360,9 @@ export namespace Chunk {
             pb_1.Message.setField(this, 1, value);
         }
         get range() {
-            return pb_1.Message.getWrapperField(this, Chunk.Range, 2) as Chunk.Range;
+            return pb_1.Message.getWrapperField(this, Chunk.Range, 2) as Chunk.Range | undefined | null;
         }
-        set range(value: Chunk.Range) {
+        set range(value: Chunk.Range | undefined | null) {
             pb_1.Message.setWrapperField(this, 2, value);
         }
         get has_range() {
@@ -587,9 +587,9 @@ export class Put extends pb_1.Message {
         pb_1.Message.setField(this, 1, value);
     }
     get chunk() {
-        return pb_1.Message.getWrapperField(this, Chunk, 3) as Chunk;
+        return pb_1.Message.getWrapperField(this, Chunk, 3) as Chunk | undefined | null;
     }
-    set chunk(value: Chunk) {
+    set chunk(value: Chunk | undefined | null) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_chunk() {

--- a/test/rpcs.ts
+++ b/test/rpcs.ts
@@ -5,9 +5,6 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class None extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {}) {
@@ -15,7 +12,7 @@ export class None extends pb_1.Message {
         pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
         if (!Array.isArray(data) && typeof data == "object") { }
     }
-    static fromObject(data: RecursivePartial<None.AsObject>): None {
+    static fromObject(data: None.AsObjectPartial): None {
         const message = new None({});
         return message;
     }
@@ -50,6 +47,7 @@ export class None extends pb_1.Message {
 }
 export namespace None {
     export type AsObject = {};
+    export type AsObjectPartial = {};
 }
 export class _Object extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -90,7 +88,7 @@ export class _Object extends pb_1.Message {
     set mimeType(value: string) {
         pb_1.Message.setField(this, 4, value);
     }
-    static fromObject(data: RecursivePartial<_Object.AsObject>): _Object {
+    static fromObject(data: _Object.AsObjectPartial): _Object {
         const message = new _Object({});
         if (data.id != null) {
             message.id = data.id;
@@ -157,6 +155,11 @@ export namespace _Object {
         size: number;
         mimeType: string;
     };
+    export type AsObjectPartial = {
+        id?: string;
+        size?: number;
+        mimeType?: string;
+    };
 }
 export class Chunk extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -182,15 +185,15 @@ export class Chunk extends pb_1.Message {
         pb_1.Message.setField(this, 1, value);
     }
     get range() {
-        return pb_1.Message.getWrapperField(this, Chunk.Range, 2) as Chunk.Range | undefined | null;
+        return pb_1.Message.getWrapperField(this, Chunk.Range, 2) as Chunk.Range | undefined;
     }
-    set range(value: Chunk.Range | undefined | null) {
+    set range(value: Chunk.Range | undefined) {
         pb_1.Message.setWrapperField(this, 2, value);
     }
     get has_range() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: RecursivePartial<Chunk.AsObject>): Chunk {
+    static fromObject(data: Chunk.AsObjectPartial): Chunk {
         const message = new Chunk({});
         if (data.data != null) {
             message.data = data.data;
@@ -216,7 +219,7 @@ export class Chunk extends pb_1.Message {
         if (this.data.length)
             writer.writeBytes(1, this.data);
         if (this.has_range)
-            writer.writeMessage(2, this.range, () => this.range.serialize(writer));
+            writer.writeMessage(2, this.range, () => this.range!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -249,6 +252,10 @@ export namespace Chunk {
         data: Uint8Array;
         range?: Chunk.Range.AsObject;
     };
+    export type AsObjectPartial = {
+        data?: Uint8Array;
+        range?: Chunk.Range.AsObjectPartial;
+    };
     export class Range extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -278,7 +285,7 @@ export namespace Chunk {
         set end(value: number) {
             pb_1.Message.setField(this, 2, value);
         }
-        static fromObject(data: RecursivePartial<Range.AsObject>): Range {
+        static fromObject(data: Range.AsObjectPartial): Range {
             const message = new Range({});
             if (data.start != null) {
                 message.start = data.start;
@@ -335,6 +342,10 @@ export namespace Chunk {
             start: number;
             end: number;
         };
+        export type AsObjectPartial = {
+            start?: number;
+            end?: number;
+        };
     }
     export class Query extends pb_1.Message {
         #one_of_decls: number[][] = [];
@@ -360,15 +371,15 @@ export namespace Chunk {
             pb_1.Message.setField(this, 1, value);
         }
         get range() {
-            return pb_1.Message.getWrapperField(this, Chunk.Range, 2) as Chunk.Range | undefined | null;
+            return pb_1.Message.getWrapperField(this, Chunk.Range, 2) as Chunk.Range | undefined;
         }
-        set range(value: Chunk.Range | undefined | null) {
+        set range(value: Chunk.Range | undefined) {
             pb_1.Message.setWrapperField(this, 2, value);
         }
         get has_range() {
             return pb_1.Message.getField(this, 2) != null;
         }
-        static fromObject(data: RecursivePartial<Query.AsObject>): Query {
+        static fromObject(data: Query.AsObjectPartial): Query {
             const message = new Query({});
             if (data.id != null) {
                 message.id = data.id;
@@ -394,7 +405,7 @@ export namespace Chunk {
             if (this.id.length)
                 writer.writeString(1, this.id);
             if (this.has_range)
-                writer.writeMessage(2, this.range, () => this.range.serialize(writer));
+                writer.writeMessage(2, this.range, () => this.range!.serialize(writer));
             if (!w)
                 return writer.getResultBuffer();
         }
@@ -427,6 +438,10 @@ export namespace Chunk {
             id: string;
             range?: Chunk.Range.AsObject;
         };
+        export type AsObjectPartial = {
+            id?: string;
+            range?: Chunk.Range.AsObjectPartial;
+        };
     }
 }
 export class Query extends pb_1.Message {
@@ -448,7 +463,7 @@ export class Query extends pb_1.Message {
     set id(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<Query.AsObject>): Query {
+    static fromObject(data: Query.AsObjectPartial): Query {
         const message = new Query({});
         if (data.id != null) {
             message.id = data.id;
@@ -495,6 +510,9 @@ export namespace Query {
     export type AsObject = {
         id: string;
     };
+    export type AsObjectPartial = {
+        id?: string;
+    };
     export class Result extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -514,7 +532,7 @@ export namespace Query {
         set objects(value: _Object[]) {
             pb_1.Message.setRepeatedWrapperField(this, 1, value);
         }
-        static fromObject(data: RecursivePartial<Result.AsObject>): Result {
+        static fromObject(data: Result.AsObjectPartial): Result {
             const message = new Result({});
             if (data.objects != null) {
                 message.objects = data.objects.map(item => _Object.fromObject(item));
@@ -532,7 +550,7 @@ export namespace Query {
         serialize(w?: pb_1.BinaryWriter): Uint8Array | void {
             const writer = w || new pb_1.BinaryWriter();
             if (this.objects.length)
-                writer.writeRepeatedMessage(1, this.objects, (item: _Object) => item.serialize(writer));
+                writer.writeRepeatedMessage(1, this.objects, (item: _Object) => item!.serialize(writer));
             if (!w)
                 return writer.getResultBuffer();
         }
@@ -561,6 +579,9 @@ export namespace Query {
         export type AsObject = {
             objects: _Object.AsObject[];
         };
+        export type AsObjectPartial = {
+            objects?: _Object.AsObjectPartial[];
+        };
     }
 }
 export class Put extends pb_1.Message {
@@ -587,15 +608,15 @@ export class Put extends pb_1.Message {
         pb_1.Message.setField(this, 1, value);
     }
     get chunk() {
-        return pb_1.Message.getWrapperField(this, Chunk, 3) as Chunk | undefined | null;
+        return pb_1.Message.getWrapperField(this, Chunk, 3) as Chunk | undefined;
     }
-    set chunk(value: Chunk | undefined | null) {
+    set chunk(value: Chunk | undefined) {
         pb_1.Message.setWrapperField(this, 3, value);
     }
     get has_chunk() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: RecursivePartial<Put.AsObject>): Put {
+    static fromObject(data: Put.AsObjectPartial): Put {
         const message = new Put({});
         if (data.id != null) {
             message.id = data.id;
@@ -621,7 +642,7 @@ export class Put extends pb_1.Message {
         if (this.id.length)
             writer.writeString(1, this.id);
         if (this.has_chunk)
-            writer.writeMessage(3, this.chunk, () => this.chunk.serialize(writer));
+            writer.writeMessage(3, this.chunk, () => this.chunk!.serialize(writer));
         if (!w)
             return writer.getResultBuffer();
     }
@@ -653,6 +674,10 @@ export namespace Put {
     export type AsObject = {
         id: string;
         chunk?: Chunk.AsObject;
+    };
+    export type AsObjectPartial = {
+        id?: string;
+        chunk?: Chunk.AsObjectPartial;
     };
 }
 interface GrpcUnaryServiceInterface<P, R> {

--- a/test/rpcs.ts
+++ b/test/rpcs.ts
@@ -5,6 +5,9 @@
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
 import * as grpc_1 from "@grpc/grpc-js";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class None extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {}) {
@@ -12,12 +15,12 @@ export class None extends pb_1.Message {
         pb_1.Message.initialize(this, Array.isArray(data) ? data : [], 0, -1, [], this.#one_of_decls);
         if (!Array.isArray(data) && typeof data == "object") { }
     }
-    static fromObject(data: {}): None {
+    static fromObject(data: RecursivePartial<None.AsObject>): None {
         const message = new None({});
         return message;
     }
     toObject() {
-        const data: {} = {};
+        const data: None.AsObject = {};
         return data;
     }
     serialize(): Uint8Array;
@@ -44,6 +47,9 @@ export class None extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): None {
         return None.deserialize(bytes);
     }
+}
+export namespace None {
+    export type AsObject = {};
 }
 export class _Object extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -84,11 +90,7 @@ export class _Object extends pb_1.Message {
     set mimeType(value: string) {
         pb_1.Message.setField(this, 4, value);
     }
-    static fromObject(data: {
-        id?: string;
-        size?: number;
-        mimeType?: string;
-    }): _Object {
+    static fromObject(data: RecursivePartial<_Object.AsObject>): _Object {
         const message = new _Object({});
         if (data.id != null) {
             message.id = data.id;
@@ -102,11 +104,7 @@ export class _Object extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: string;
-            size: number;
-            mimeType: string;
-        } = {
+        const data: _Object.AsObject = {
             id: this.id,
             size: this.size,
             mimeType: this.mimeType
@@ -153,6 +151,13 @@ export class _Object extends pb_1.Message {
         return _Object.deserialize(bytes);
     }
 }
+export namespace _Object {
+    export type AsObject = {
+        id: string;
+        size: number;
+        mimeType: string;
+    };
+}
 export class Chunk extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -185,10 +190,7 @@ export class Chunk extends pb_1.Message {
     get has_range() {
         return pb_1.Message.getField(this, 2) != null;
     }
-    static fromObject(data: {
-        data?: Uint8Array;
-        range?: Parameters<typeof Chunk.Range.fromObject>[0];
-    }): Chunk {
+    static fromObject(data: RecursivePartial<Chunk.AsObject>): Chunk {
         const message = new Chunk({});
         if (data.data != null) {
             message.data = data.data;
@@ -199,10 +201,7 @@ export class Chunk extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            data: Uint8Array;
-            range?: Parameters<typeof Chunk.Range.fromObject>[0];
-        } = {
+        const data: Chunk.AsObject = {
             data: this.data
         };
         if (this.range != null) {
@@ -246,6 +245,10 @@ export class Chunk extends pb_1.Message {
     }
 }
 export namespace Chunk {
+    export type AsObject = {
+        data: Uint8Array;
+        range?: Chunk.Range.AsObject;
+    };
     export class Range extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -275,10 +278,7 @@ export namespace Chunk {
         set end(value: number) {
             pb_1.Message.setField(this, 2, value);
         }
-        static fromObject(data: {
-            start?: number;
-            end?: number;
-        }): Range {
+        static fromObject(data: RecursivePartial<Range.AsObject>): Range {
             const message = new Range({});
             if (data.start != null) {
                 message.start = data.start;
@@ -289,10 +289,7 @@ export namespace Chunk {
             return message;
         }
         toObject() {
-            const data: {
-                start: number;
-                end: number;
-            } = {
+            const data: Range.AsObject = {
                 start: this.start,
                 end: this.end
             };
@@ -333,6 +330,12 @@ export namespace Chunk {
             return Range.deserialize(bytes);
         }
     }
+    export namespace Range {
+        export type AsObject = {
+            start: number;
+            end: number;
+        };
+    }
     export class Query extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -365,10 +368,7 @@ export namespace Chunk {
         get has_range() {
             return pb_1.Message.getField(this, 2) != null;
         }
-        static fromObject(data: {
-            id?: string;
-            range?: Parameters<typeof Chunk.Range.fromObject>[0];
-        }): Query {
+        static fromObject(data: RecursivePartial<Query.AsObject>): Query {
             const message = new Query({});
             if (data.id != null) {
                 message.id = data.id;
@@ -379,10 +379,7 @@ export namespace Chunk {
             return message;
         }
         toObject() {
-            const data: {
-                id: string;
-                range?: Parameters<typeof Chunk.Range.fromObject>[0];
-            } = {
+            const data: Query.AsObject = {
                 id: this.id
             };
             if (this.range != null) {
@@ -425,6 +422,12 @@ export namespace Chunk {
             return Query.deserialize(bytes);
         }
     }
+    export namespace Query {
+        export type AsObject = {
+            id: string;
+            range?: Chunk.Range.AsObject;
+        };
+    }
 }
 export class Query extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -445,9 +448,7 @@ export class Query extends pb_1.Message {
     set id(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        id?: string;
-    }): Query {
+    static fromObject(data: RecursivePartial<Query.AsObject>): Query {
         const message = new Query({});
         if (data.id != null) {
             message.id = data.id;
@@ -455,9 +456,7 @@ export class Query extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: string;
-        } = {
+        const data: Query.AsObject = {
             id: this.id
         };
         return data;
@@ -493,6 +492,9 @@ export class Query extends pb_1.Message {
     }
 }
 export namespace Query {
+    export type AsObject = {
+        id: string;
+    };
     export class Result extends pb_1.Message {
         #one_of_decls: number[][] = [];
         constructor(data?: any[] | {
@@ -512,9 +514,7 @@ export namespace Query {
         set objects(value: _Object[]) {
             pb_1.Message.setRepeatedWrapperField(this, 1, value);
         }
-        static fromObject(data: {
-            objects?: Parameters<typeof _Object.fromObject>[0][];
-        }): Result {
+        static fromObject(data: RecursivePartial<Result.AsObject>): Result {
             const message = new Result({});
             if (data.objects != null) {
                 message.objects = data.objects.map(item => _Object.fromObject(item));
@@ -522,9 +522,7 @@ export namespace Query {
             return message;
         }
         toObject() {
-            const data: {
-                objects: Parameters<typeof _Object.fromObject>[0][];
-            } = {
+            const data: Result.AsObject = {
                 objects: this.objects.map((item: _Object) => item.toObject())
             };
             return data;
@@ -559,6 +557,11 @@ export namespace Query {
             return Result.deserialize(bytes);
         }
     }
+    export namespace Result {
+        export type AsObject = {
+            objects: _Object.AsObject[];
+        };
+    }
 }
 export class Put extends pb_1.Message {
     #one_of_decls: number[][] = [];
@@ -592,10 +595,7 @@ export class Put extends pb_1.Message {
     get has_chunk() {
         return pb_1.Message.getField(this, 3) != null;
     }
-    static fromObject(data: {
-        id?: string;
-        chunk?: Parameters<typeof Chunk.fromObject>[0];
-    }): Put {
+    static fromObject(data: RecursivePartial<Put.AsObject>): Put {
         const message = new Put({});
         if (data.id != null) {
             message.id = data.id;
@@ -606,10 +606,7 @@ export class Put extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            id: string;
-            chunk?: Parameters<typeof Chunk.fromObject>[0];
-        } = {
+        const data: Put.AsObject = {
             id: this.id
         };
         if (this.chunk != null) {
@@ -651,6 +648,12 @@ export class Put extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Put {
         return Put.deserialize(bytes);
     }
+}
+export namespace Put {
+    export type AsObject = {
+        id: string;
+        chunk?: Chunk.AsObject;
+    };
 }
 interface GrpcUnaryServiceInterface<P, R> {
     (message: P, metadata: grpc_1.Metadata, options: grpc_1.CallOptions, callback: grpc_1.requestCallback<R>): grpc_1.ClientUnaryCall;

--- a/test/rpcs.ts
+++ b/test/rpcs.ts
@@ -103,19 +103,14 @@ export class _Object extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: string;
-            size?: number;
-            mimeType?: string;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
-        if (this.size != null) {
-            data.size = this.size;
-        }
-        if (this.mimeType != null) {
-            data.mimeType = this.mimeType;
-        }
+            id: string;
+            size: number;
+            mimeType: string;
+        } = {
+            id: this.id,
+            size: this.size,
+            mimeType: this.mimeType
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -192,7 +187,7 @@ export class Chunk extends pb_1.Message {
     }
     static fromObject(data: {
         data?: Uint8Array;
-        range?: ReturnType<typeof Chunk.Range.prototype.toObject>;
+        range?: Parameters<typeof Chunk.Range.fromObject>[0];
     }): Chunk {
         const message = new Chunk({});
         if (data.data != null) {
@@ -205,12 +200,11 @@ export class Chunk extends pb_1.Message {
     }
     toObject() {
         const data: {
-            data?: Uint8Array;
-            range?: ReturnType<typeof Chunk.Range.prototype.toObject>;
-        } = {};
-        if (this.data != null) {
-            data.data = this.data;
-        }
+            data: Uint8Array;
+            range?: Parameters<typeof Chunk.Range.fromObject>[0];
+        } = {
+            data: this.data
+        };
         if (this.range != null) {
             data.range = this.range.toObject();
         }
@@ -296,15 +290,12 @@ export namespace Chunk {
         }
         toObject() {
             const data: {
-                start?: number;
-                end?: number;
-            } = {};
-            if (this.start != null) {
-                data.start = this.start;
-            }
-            if (this.end != null) {
-                data.end = this.end;
-            }
+                start: number;
+                end: number;
+            } = {
+                start: this.start,
+                end: this.end
+            };
             return data;
         }
         serialize(): Uint8Array;
@@ -376,7 +367,7 @@ export namespace Chunk {
         }
         static fromObject(data: {
             id?: string;
-            range?: ReturnType<typeof Chunk.Range.prototype.toObject>;
+            range?: Parameters<typeof Chunk.Range.fromObject>[0];
         }): Query {
             const message = new Query({});
             if (data.id != null) {
@@ -389,12 +380,11 @@ export namespace Chunk {
         }
         toObject() {
             const data: {
-                id?: string;
-                range?: ReturnType<typeof Chunk.Range.prototype.toObject>;
-            } = {};
-            if (this.id != null) {
-                data.id = this.id;
-            }
+                id: string;
+                range?: Parameters<typeof Chunk.Range.fromObject>[0];
+            } = {
+                id: this.id
+            };
             if (this.range != null) {
                 data.range = this.range.toObject();
             }
@@ -466,11 +456,10 @@ export class Query extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: string;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
+            id: string;
+        } = {
+            id: this.id
+        };
         return data;
     }
     serialize(): Uint8Array;
@@ -524,7 +513,7 @@ export namespace Query {
             pb_1.Message.setRepeatedWrapperField(this, 1, value);
         }
         static fromObject(data: {
-            objects?: ReturnType<typeof _Object.prototype.toObject>[];
+            objects?: Parameters<typeof _Object.fromObject>[0][];
         }): Result {
             const message = new Result({});
             if (data.objects != null) {
@@ -534,11 +523,10 @@ export namespace Query {
         }
         toObject() {
             const data: {
-                objects?: ReturnType<typeof _Object.prototype.toObject>[];
-            } = {};
-            if (this.objects != null) {
-                data.objects = this.objects.map((item: _Object) => item.toObject());
-            }
+                objects: Parameters<typeof _Object.fromObject>[0][];
+            } = {
+                objects: this.objects.map((item: _Object) => item.toObject())
+            };
             return data;
         }
         serialize(): Uint8Array;
@@ -606,7 +594,7 @@ export class Put extends pb_1.Message {
     }
     static fromObject(data: {
         id?: string;
-        chunk?: ReturnType<typeof Chunk.prototype.toObject>;
+        chunk?: Parameters<typeof Chunk.fromObject>[0];
     }): Put {
         const message = new Put({});
         if (data.id != null) {
@@ -619,12 +607,11 @@ export class Put extends pb_1.Message {
     }
     toObject() {
         const data: {
-            id?: string;
-            chunk?: ReturnType<typeof Chunk.prototype.toObject>;
-        } = {};
-        if (this.id != null) {
-            data.id = this.id;
-        }
+            id: string;
+            chunk?: Parameters<typeof Chunk.fromObject>[0];
+        } = {
+            id: this.id
+        };
         if (this.chunk != null) {
             data.chunk = this.chunk.toObject();
         }

--- a/test/serialization.ts
+++ b/test/serialization.ts
@@ -4,9 +4,6 @@
  * source: test/_/serialization.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
-type RecursivePartial<T> = {
-    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
-};
 export class Serialization extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -26,7 +23,7 @@ export class Serialization extends pb_1.Message {
     set test(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: RecursivePartial<Serialization.AsObject>): Serialization {
+    static fromObject(data: Serialization.AsObjectPartial): Serialization {
         const message = new Serialization({});
         if (data.test != null) {
             message.test = data.test;
@@ -72,5 +69,8 @@ export class Serialization extends pb_1.Message {
 export namespace Serialization {
     export type AsObject = {
         test: string;
+    };
+    export type AsObjectPartial = {
+        test?: string;
     };
 }

--- a/test/serialization.ts
+++ b/test/serialization.ts
@@ -4,6 +4,9 @@
  * source: test/_/serialization.proto
  * git: https://github.com/thesayyn/protoc-gen-ts */
 import * as pb_1 from "google-protobuf";
+type RecursivePartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? RecursivePartial<U>[] : T[P] extends Uint8Array ? T[P] : T[P] extends object ? RecursivePartial<T[P]> : T[P];
+};
 export class Serialization extends pb_1.Message {
     #one_of_decls: number[][] = [];
     constructor(data?: any[] | {
@@ -23,9 +26,7 @@ export class Serialization extends pb_1.Message {
     set test(value: string) {
         pb_1.Message.setField(this, 1, value);
     }
-    static fromObject(data: {
-        test?: string;
-    }): Serialization {
+    static fromObject(data: RecursivePartial<Serialization.AsObject>): Serialization {
         const message = new Serialization({});
         if (data.test != null) {
             message.test = data.test;
@@ -33,9 +34,7 @@ export class Serialization extends pb_1.Message {
         return message;
     }
     toObject() {
-        const data: {
-            test: string;
-        } = {
+        const data: Serialization.AsObject = {
             test: this.test
         };
         return data;
@@ -69,4 +68,9 @@ export class Serialization extends pb_1.Message {
     static deserializeBinary(bytes: Uint8Array): Serialization {
         return Serialization.deserialize(bytes);
     }
+}
+export namespace Serialization {
+    export type AsObject = {
+        test: string;
+    };
 }

--- a/test/serialization.ts
+++ b/test/serialization.ts
@@ -34,11 +34,10 @@ export class Serialization extends pb_1.Message {
     }
     toObject() {
         const data: {
-            test?: string;
-        } = {};
-        if (this.test != null) {
-            data.test = this.test;
-        }
+            test: string;
+        } = {
+            test: this.test
+        };
         return data;
     }
     serialize(): Uint8Array;

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,5 +3,8 @@
     "target": "ES2020",
     "module": "CommonJS",
     "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true
   }
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,5 +2,6 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
+    "strict": true,
   }
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+  }
+}


### PR DESCRIPTION
Reated to #154 
Tsconfig options `noFallthroughCasesInSwitch`, `noImplicitReturns` and `noPropertyAccessFromIndexSignature` are enabled in all tests.

Options `noFallthroughCasesInSwitch` and `noImplicitReturns` required no changes.

Option `noPropertyAccessFromIndexSignature` required to change method access in RPC from property access to element access.