### PR TITLE
feat: ts_proto_library: improve rules_js compatibility

### DIFF
--- a/index.bzl
+++ b/index.bzl
@@ -74,6 +74,7 @@ def _ts_proto_library(ctx):
             outputs = outputs,
             arguments = [args],
             progress_message = "Generating Protocol Buffers for Typescript %s" % ctx.label,
+            env = {"BAZEL_BINDIR": ctx.bin_dir.path},
         )
 
     return [


### PR DESCRIPTION
rules_js's `js_binary` targets need `BAZEL_BINDIR` env variable when running as bazel's actions.
With this change, `ts_proto_library` can be used with rules_js, if users provide rules_js version of `protoc-gen-ts` under `//protoc-gen-ts/bin` like this:

```
load("@npm//:protoc-gen-ts/package_json.bzl", "bin")

bin.protoc_gen_ts_binary(
    name = "protoc-gen-ts",
    visibility = ["//visibility:public"],
)
```

This PR does not migrate anything to rules_js. However, this small change makes protoc-gen-ts practically usable with rules_js, while being totally harmless to rules_nodejs users.
ref #176
