### PR TITLE
chore: allow ts 5 as a peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "google-protobuf": "^3.13.0",
-    "typescript": "4.x.x || 5.x.x"
+    "typescript": ">= 4.9.x"
   },
   "devDependencies": {
     "@bazel/bazelisk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "protoc-gen-ts",
   "description": "Compile protocol buffers descriptors to Typescript.",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "license": "MIT",
   "author": {
     "email": "thesayyn@gmail.com",
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "google-protobuf": "^3.13.0",
-    "typescript": "4.x.x"
+    "typescript": "4.x.x || 5.x.x"
   },
   "devDependencies": {
     "@bazel/bazelisk": "^1.9.0",


### PR DESCRIPTION
Part of #203, #225

Using the plugin with Typescript 5.x.x was previously blocked by an `if` block that required that the TS major version be >= 4 and that the minor version be >=9 (the only 5.x.x Typescript versions have minor versions that are between 0 and 2). See [#204](https://github.com/thesayyn/protoc-gen-ts/pull/204). That fixed a portion of the issue, but the plugin is still not usable with Typescript 5.x.x due to a peer dependency restriction limiting it to use with Typescript 4.x.x. 

This adds TS 5.x.x as a potential peerdep.
