### PR TITLE
add type alias to toObject method to prevent from inferred type too long error when compiling

### DIFF
--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -499,7 +499,7 @@ function createToObject(
     undefined,
     undefined,
     [],
-    undefined,
+    createPrimitiveMessageSignature(rootDescriptor, messageDescriptor),
     ts.factory.createBlock(statements, true),
   );
 }


### PR DESCRIPTION
fixes #231 