### PR TITLE
feat: make input arrays readonly

### DIFF
--- a/src/descriptor.ts
+++ b/src/descriptor.ts
@@ -592,6 +592,7 @@ function createMessageSignature(
             field.wrapRepeatedType(
               field.getType(fieldDescriptor, rootDescriptor),
               fieldDescriptor,
+              true
             ),
           ),
           fieldDescriptor.options?.deprecated,
@@ -672,7 +673,7 @@ function createPrimitiveMessageSignature(
         )
           ? ts.factory.createToken(ts.SyntaxKind.QuestionToken)
           : undefined,
-        field.wrapRepeatedType(fieldType as ts.TypeNode, fieldDescriptor),
+        field.wrapRepeatedType(fieldType as ts.TypeNode, fieldDescriptor, true),
       ),
     );
   }
@@ -1116,6 +1117,7 @@ function createSetter(
   const type = field.wrapRepeatedType(
     field.getType(fieldDescriptor, rootDescriptor),
     fieldDescriptor,
+    true
   );
   const valueParameter = ts.factory.createIdentifier("value");
 

--- a/src/field.ts
+++ b/src/field.ts
@@ -5,10 +5,22 @@ import * as ts from "typescript";
 /**
  * @param {*} type
  * @param {descriptor.FieldDescriptorProto} fieldDescriptor
+ * @param {boolean=} makeReadonly
  */
-export function wrapRepeatedType(type: any, fieldDescriptor: descriptor.FieldDescriptorProto) {
+export function wrapRepeatedType(
+  type: any,
+  fieldDescriptor: descriptor.FieldDescriptorProto,
+  makeReadonly = false
+) {
   if (isRepeated(fieldDescriptor) && !isMap(fieldDescriptor)) {
     type = ts.factory.createArrayTypeNode(type);
+
+    if (makeReadonly) {
+      type = ts.factory.createTypeOperatorNode(
+        ts.SyntaxKind.ReadonlyKeyword,
+        type,
+      );
+    }
   }
 
   return type;


### PR DESCRIPTION
Arrays should be `readonly` when used as parameters to allow `readonly` arrays to be passed.

There is another `wrapArray`-call here: https://github.com/jeengbe/protoc-gen-ts/blob/je-readonly-arrays/src/descriptor.ts#L553-L558, which I was not sure about how it's used.