### PR TITLE
Include wasm files in package

### DIFF
--- a/.github/workflows/publish_at_head.yaml
+++ b/.github/workflows/publish_at_head.yaml
@@ -17,11 +17,12 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
+          default: true
       - uses: jetli/wasm-pack-action@v0.4.0
       - uses: Swatinem/rust-cache@v2
       - name: install and run cargo-patch
-        run: cargo install cargo-patch && cargo-patch
+        run: cargo install cargo-patch --locked && cargo-patch
       - name: compile
         run: ./infra/compile.sh
       - name: publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,12 +27,13 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.79.0
+          default: true
       - uses: jetli/wasm-pack-action@v0.4.0
       - uses: Swatinem/rust-cache@v2
       - name: Install and run cargo-patch
         run: |
-          cargo install cargo-patch
+          cargo install cargo-patch --locked
           cargo-patch
       - name: compile
         run: ./infra/compile.sh

--- a/js/plugin/package.json
+++ b/js/plugin/package.json
@@ -18,5 +18,9 @@
     },
     "bin": {
         "protoc-gen-ts": "main.js"
-    }
+    },
+    "files":[
+        "main.js",
+        "dist"
+    ]
 }


### PR DESCRIPTION
Follow-up from https://github.com/thesayyn/protoc-gen-ts/issues/255#issuecomment-3148606407
- adds the `files` field in package.json, explicitly listing the files that must be included in the package. This fixes the binary distributed with the package.
- to support a new release of this package, the GH Actions workflow must be changed to lock the rust version to 1.79. This is due to `cargo-patch` failing to install on the latest version of rust, likely due to the `time` issue introduced by rust 1.80. 

This is more of a temporary fix to allow people to try out the rust version of `protoc-gen-ts`. A future PR will ideally review the dependencies and remove/update them as needed.